### PR TITLE
feat: add function in alarm screen for keep preparing after timeout a…

### DIFF
--- a/lib/presentation/alarm/bloc/alarm_timer/alarm_timer_event.dart
+++ b/lib/presentation/alarm/bloc/alarm_timer/alarm_timer_event.dart
@@ -60,3 +60,7 @@ class AlarmTimerStepsUpdated extends AlarmTimerEvent {
   @override
   List<Object?> get props => [preparationSteps];
 }
+
+class AlarmTimerPreparationsTimeOvered extends AlarmTimerEvent {
+  const AlarmTimerPreparationsTimeOvered();
+}

--- a/lib/presentation/alarm/bloc/alarm_timer/alarm_timer_state.dart
+++ b/lib/presentation/alarm/bloc/alarm_timer/alarm_timer_state.dart
@@ -208,6 +208,7 @@ class AlarmTimerPreparationCompletion extends AlarmTimerState {
     required super.isLate,
   });
 
+// 준비 완료 상태
   @override
   AlarmTimerPreparationCompletion copyWith({
     List<PreparationStepEntity>? preparationSteps,
@@ -222,6 +223,51 @@ class AlarmTimerPreparationCompletion extends AlarmTimerState {
     bool? isLate,
   }) {
     return AlarmTimerPreparationCompletion(
+      preparationSteps: preparationSteps ?? this.preparationSteps,
+      currentStepIndex: currentStepIndex ?? this.currentStepIndex,
+      stepElapsedTimes: stepElapsedTimes ?? this.stepElapsedTimes,
+      preparationStepStates:
+          preparationStepStates ?? this.preparationStepStates,
+      preparationRemainingTime:
+          preparationRemainingTime ?? this.preparationRemainingTime,
+      totalRemainingTime: totalRemainingTime ?? this.totalRemainingTime,
+      totalPreparationTime: totalPreparationTime ?? this.totalPreparationTime,
+      progress: progress ?? this.progress,
+      beforeOutTime: beforeOutTime ?? this.beforeOutTime,
+      isLate: isLate ?? this.isLate,
+    );
+  }
+}
+
+// 준비 시간 만료 상태
+class AlarmTimerPreparationsTimeOver extends AlarmTimerState {
+  const AlarmTimerPreparationsTimeOver({
+    required super.preparationSteps,
+    required super.currentStepIndex,
+    required super.stepElapsedTimes,
+    required super.preparationStepStates,
+    required super.preparationRemainingTime,
+    required super.totalRemainingTime,
+    required super.totalPreparationTime,
+    required super.progress,
+    required super.beforeOutTime,
+    required super.isLate,
+  });
+
+  @override
+  AlarmTimerPreparationsTimeOver copyWith({
+    List<PreparationStepEntity>? preparationSteps,
+    int? currentStepIndex,
+    List<int>? stepElapsedTimes,
+    List<PreparationStateEnum>? preparationStepStates,
+    int? preparationRemainingTime,
+    int? totalRemainingTime,
+    int? totalPreparationTime,
+    double? progress,
+    int? beforeOutTime,
+    bool? isLate,
+  }) {
+    return AlarmTimerPreparationsTimeOver(
       preparationSteps: preparationSteps ?? this.preparationSteps,
       currentStepIndex: currentStepIndex ?? this.currentStepIndex,
       stepElapsedTimes: stepElapsedTimes ?? this.stepElapsedTimes,


### PR DESCRIPTION
- 준비 시간 초과 시 로직 구현 
1. 할당된 준비 시간이 모두 지나면 모달 컴포넌트 표시 
2. 모달 컴포넌트에서 '준비 종료' 선택 시 early_late_screen으로 넘어감
3. 모달 컴포넌트에서 '계속 준비하기' 선택 시 해당 페이지에 남음. 
4. beforeOutTime (나가기 전까지 남은 시간) 기반 타이머 로직은 수정이 필요함. 기존 타이머와 변수 분리 필요. 
