### PR TITLE
fix: adjust layout of StepProgress in onboarding screen

### DIFF
--- a/lib/presentation/onboarding/screens/onboarding_screen.dart
+++ b/lib/presentation/onboarding/screens/onboarding_screen.dart
@@ -206,9 +206,14 @@ class _AppBar extends StatelessWidget {
             icon: _previousIcon,
           ),
         ),
-        StepProgress(
-          currentStep: tabController.index,
-          totalSteps: tabController.length,
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: StepProgress(
+              currentStep: tabController.index,
+              totalSteps: tabController.length,
+            ),
+          ),
         ),
         SizedBox(
           width: iconButtonSize,


### PR DESCRIPTION
## Describe your changes
- Wrapped StepProgress in an Expanded widget with padding to improve layout and responsiveness.
- Ensured proper spacing and alignment within the onboarding screen's app bar.

## Issue ticket number and link
Closes #316 

## Screenshots (if appropriate):
<img width="439" height="831" alt="image" src="https://github.com/user-attachments/assets/5b3124b9-a22d-468e-979f-4a370a35f4d4" />
