### PR TITLE
Sync preparation time with calendar detail tiles

### DIFF
--- a/lib/domain/use-cases/stream_preparations_use_case.dart
+++ b/lib/domain/use-cases/stream_preparations_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/repositories/preparation_repository.dart';
+
+@Injectable()
+class StreamPreparationsUseCase {
+  final PreparationRepository _preparationRepository;
+
+  StreamPreparationsUseCase(this._preparationRepository);
+
+  Stream<Map<String, PreparationEntity>> call() {
+    return _preparationRepository.preparationStream;
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,6 +143,10 @@
     "@travelTime": {
         "description": "Label for the travel time text field"
     },
+    "preparationTime": "Preparation Time",
+    "@preparationTime": {
+        "description": "Label for preparation time"
+    },
     "hours": "hours",
     "@hours": {
         "description": "Unit of time"

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -35,6 +35,7 @@
     "appointmentNameHint": "예) 영화 보기",
     "appointmentPlace": "약속 장소",
     "travelTime": "이동시간",
+    "preparationTime": "준비시간",
     "hours": "시간",
     "minutes": "분",
     "selectTime": "시간을 선택해 주세요",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -314,6 +314,12 @@ abstract class AppLocalizations {
   /// **'Travel Time'**
   String get travelTime;
 
+  /// Label for preparation time
+  ///
+  /// In en, this message translates to:
+  /// **'Preparation Time'**
+  String get preparationTime;
+
   /// Unit of time
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -125,6 +125,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get travelTime => 'Travel Time';
 
   @override
+  String get preparationTime => 'Preparation Time';
+
+  @override
   String get hours => 'hours';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -120,6 +120,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get travelTime => '이동시간';
 
   @override
+  String get preparationTime => '준비시간';
+
+  @override
   String get hours => '시간';
 
   @override

--- a/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
@@ -1,11 +1,17 @@
+import 'dart:async';
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/use-cases/delete_schedule_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_preparation_by_schedule_id_use_case.dart';
 import 'package:on_time_front/domain/use-cases/get_schedules_by_date_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_preparation_by_schedule_id_use_case.dart';
 import 'package:on_time_front/domain/use-cases/load_schedules_for_month_use_case.dart';
+import 'package:on_time_front/domain/use-cases/stream_preparations_use_case.dart';
 
 part 'monthly_schedules_event.dart';
 part 'monthly_schedules_state.dart';
@@ -17,15 +23,40 @@ class MonthlySchedulesBloc
     this._loadSchedulesForMonthUseCase,
     this._getSchedulesByDateUseCase,
     this._deleteScheduleUseCase,
+    this._loadPreparationByScheduleIdUseCase,
+    this._getPreparationByScheduleIdUseCase,
+    this._streamPreparationsUseCase,
   ) : super(MonthlySchedulesState()) {
     on<MonthlySchedulesSubscriptionRequested>(_onSubscriptionRequested);
     on<MonthlySchedulesMonthAdded>(_onMonthAdded);
     on<MonthlySchedulesScheduleDeleted>(_onScheduleDeleted);
+    on<MonthlySchedulesVisibleDateChanged>(_onVisibleDateChanged);
+    on<MonthlySchedulesPreparationsPrefetchRequested>(
+      _onPreparationsPrefetchRequested,
+    );
+    on<MonthlySchedulesPreparationsStreamChanged>(
+      _onPreparationsStreamChanged,
+    );
+
+    _preparationSubscription = _streamPreparationsUseCase().listen(
+      (preparations) {
+        add(
+          MonthlySchedulesPreparationsStreamChanged(
+            preparations: preparations,
+          ),
+        );
+      },
+    );
   }
 
   final LoadSchedulesForMonthUseCase _loadSchedulesForMonthUseCase;
   final GetSchedulesByDateUseCase _getSchedulesByDateUseCase;
   final DeleteScheduleUseCase _deleteScheduleUseCase;
+  final LoadPreparationByScheduleIdUseCase _loadPreparationByScheduleIdUseCase;
+  final GetPreparationByScheduleIdUseCase _getPreparationByScheduleIdUseCase;
+  final StreamPreparationsUseCase _streamPreparationsUseCase;
+
+  StreamSubscription<Map<String, PreparationEntity>>? _preparationSubscription;
 
   Future<void> _onSubscriptionRequested(
     MonthlySchedulesSubscriptionRequested event,
@@ -37,27 +68,17 @@ class MonthlySchedulesBloc
 
     await emit.forEach(
       _getSchedulesByDateUseCase(event.startDate, event.endDate),
-      onData: (schedules) => state.copyWith(
-        status: () => MonthlySchedulesStatus.success,
-        schedules: () => schedules.fold<Map<DateTime, List<ScheduleEntity>>>(
-          {},
-          (previousValue, element) {
-            final scheduleTime = DateTime(
-              element.scheduleTime.year,
-              element.scheduleTime.month,
-              element.scheduleTime.day,
-            );
-            if (previousValue.containsKey(scheduleTime)) {
-              previousValue[scheduleTime]!.add(element);
-            } else {
-              previousValue[scheduleTime] = [element];
-            }
-            return previousValue;
-          },
-        ),
-        startDate: () => event.startDate,
-        endDate: () => event.endDate,
-      ),
+      onData: (schedules) {
+        final groupedSchedules = _groupSchedulesByDate(schedules);
+        final nextState = state.copyWith(
+          status: () => MonthlySchedulesStatus.success,
+          schedules: () => groupedSchedules,
+          startDate: () => event.startDate,
+          endDate: () => event.endDate,
+        );
+        _requestVisibleDatePreparationPrefetch(nextState);
+        return nextState;
+      },
       onError: (error, stackTrace) => state.copyWith(
         status: () => MonthlySchedulesStatus.error,
       ),
@@ -106,27 +127,15 @@ class MonthlySchedulesBloc
     await emit.forEach(
       _getSchedulesByDateUseCase(startDate, endDate),
       onData: (schedules) {
-        return state.copyWith(
+        final groupedSchedules = _groupSchedulesByDate(schedules);
+        final nextState = state.copyWith(
           status: () => MonthlySchedulesStatus.success,
-          schedules: () => schedules.fold<Map<DateTime, List<ScheduleEntity>>>(
-            {},
-            (previousValue, element) {
-              final scheduleTime = DateTime(
-                element.scheduleTime.year,
-                element.scheduleTime.month,
-                element.scheduleTime.day,
-              );
-              if (previousValue.containsKey(scheduleTime)) {
-                previousValue[scheduleTime]!.add(element);
-              } else {
-                previousValue[scheduleTime] = [element];
-              }
-              return previousValue;
-            },
-          ),
+          schedules: () => groupedSchedules,
           startDate: () => startDate,
           endDate: () => endDate,
         );
+        _requestVisibleDatePreparationPrefetch(nextState);
+        return nextState;
       },
       onError: (error, stackTrace) {
         return state.copyWith(
@@ -141,8 +150,12 @@ class MonthlySchedulesBloc
     Emitter<MonthlySchedulesState> emit,
   ) async {
     try {
+      final updatedPreparationMap =
+          Map<String, Duration>.from(state.preparationDurationByScheduleId)
+            ..remove(event.schedule.id);
       emit(state.copyWith(
         lastDeletedSchedule: () => event.schedule,
+        preparationDurationByScheduleId: () => updatedPreparationMap,
       ));
       await _deleteScheduleUseCase(event.schedule);
     } catch (e) {
@@ -150,5 +163,161 @@ class MonthlySchedulesBloc
         status: () => MonthlySchedulesStatus.error,
       ));
     }
+  }
+
+  void _onVisibleDateChanged(
+    MonthlySchedulesVisibleDateChanged event,
+    Emitter<MonthlySchedulesState> emit,
+  ) {
+    final normalizedDate =
+        DateTime(event.date.year, event.date.month, event.date.day);
+    final nextState = state.copyWith(visibleDate: () => normalizedDate);
+    emit(nextState);
+    _requestVisibleDatePreparationPrefetch(nextState);
+  }
+
+  Future<void> _onPreparationsPrefetchRequested(
+    MonthlySchedulesPreparationsPrefetchRequested event,
+    Emitter<MonthlySchedulesState> emit,
+  ) async {
+    final missingIds = event.scheduleIds
+        .where((id) => !state.preparationDurationByScheduleId.containsKey(id))
+        .toSet();
+    if (missingIds.isEmpty) {
+      return;
+    }
+
+    final fetchedDurations = <String, Duration>{};
+    var hasUpdates = false;
+
+    for (final scheduleId in missingIds) {
+      try {
+        await _loadPreparationByScheduleIdUseCase(scheduleId);
+        if (state.preparationDurationByScheduleId.containsKey(scheduleId)) {
+          // Stream update already has fresher data.
+          continue;
+        }
+        final preparation =
+            await _getPreparationByScheduleIdUseCase(scheduleId);
+        fetchedDurations[scheduleId] = preparation.totalDuration;
+        hasUpdates = true;
+      } catch (_) {
+        // Keep fallback UI when loading fails.
+      }
+    }
+
+    if (hasUpdates) {
+      final updatedMap = Map<String, Duration>.from(
+        state.preparationDurationByScheduleId,
+      )..addAll(fetchedDurations);
+      emit(
+        state.copyWith(
+          preparationDurationByScheduleId: () => updatedMap,
+        ),
+      );
+    }
+  }
+
+  void _onPreparationsStreamChanged(
+    MonthlySchedulesPreparationsStreamChanged event,
+    Emitter<MonthlySchedulesState> emit,
+  ) {
+    final cachedScheduleIds = _getCachedScheduleIds(state.schedules);
+    if (cachedScheduleIds.isEmpty) {
+      return;
+    }
+
+    final nextDurations = Map<String, Duration>.from(
+      state.preparationDurationByScheduleId,
+    );
+    var hasChange = false;
+
+    for (final entry in event.preparations.entries) {
+      if (!cachedScheduleIds.contains(entry.key)) {
+        continue;
+      }
+
+      final nextDuration = entry.value.totalDuration;
+      if (nextDurations[entry.key] != nextDuration) {
+        nextDurations[entry.key] = nextDuration;
+        hasChange = true;
+      }
+    }
+
+    if (!hasChange) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        preparationDurationByScheduleId: () => nextDurations,
+      ),
+    );
+  }
+
+  void _requestVisibleDatePreparationPrefetch(
+      MonthlySchedulesState sourceState) {
+    final visibleDate = sourceState.visibleDate;
+    if (visibleDate == null) {
+      return;
+    }
+    final scheduleIds = _getScheduleIdsForDate(
+      sourceState.schedules,
+      visibleDate,
+    );
+    if (scheduleIds.isEmpty) {
+      return;
+    }
+    add(MonthlySchedulesPreparationsPrefetchRequested(
+        scheduleIds: scheduleIds));
+  }
+
+  Map<DateTime, List<ScheduleEntity>> _groupSchedulesByDate(
+    List<ScheduleEntity> schedules,
+  ) {
+    return schedules.fold<Map<DateTime, List<ScheduleEntity>>>(
+      {},
+      (previousValue, element) {
+        final scheduleTime = DateTime(
+          element.scheduleTime.year,
+          element.scheduleTime.month,
+          element.scheduleTime.day,
+        );
+        if (previousValue.containsKey(scheduleTime)) {
+          previousValue[scheduleTime]!.add(element);
+        } else {
+          previousValue[scheduleTime] = [element];
+        }
+        return previousValue;
+      },
+    );
+  }
+
+  List<String> _getScheduleIdsForDate(
+    Map<DateTime, List<ScheduleEntity>> schedules,
+    DateTime date,
+  ) {
+    final normalizedDate = DateTime(date.year, date.month, date.day);
+    return schedules[normalizedDate]
+            ?.map((schedule) => schedule.id)
+            .toList(growable: false) ??
+        const <String>[];
+  }
+
+  Set<String> _getCachedScheduleIds(
+      Map<DateTime, List<ScheduleEntity>> schedules) {
+    final ids = <String>{};
+    for (final scheduleList in schedules.values) {
+      for (final schedule in scheduleList) {
+        ids.add(schedule.id);
+      }
+    }
+    return ids;
+  }
+
+  @override
+  Future<void> close() async {
+    await _preparationSubscription?.cancel();
+    return super.close();
   }
 }

--- a/lib/presentation/calendar/bloc/monthly_schedules_event.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_event.dart
@@ -40,3 +40,36 @@ final class MonthlySchedulesScheduleDeleted extends MonthlySchedulesEvent {
   @override
   List<Object> get props => [schedule];
 }
+
+final class MonthlySchedulesVisibleDateChanged extends MonthlySchedulesEvent {
+  final DateTime date;
+
+  const MonthlySchedulesVisibleDateChanged({required this.date});
+
+  @override
+  List<Object> get props => [date.year, date.month, date.day];
+}
+
+final class MonthlySchedulesPreparationsPrefetchRequested
+    extends MonthlySchedulesEvent {
+  final List<String> scheduleIds;
+
+  const MonthlySchedulesPreparationsPrefetchRequested({
+    required this.scheduleIds,
+  });
+
+  @override
+  List<Object> get props => [scheduleIds];
+}
+
+final class MonthlySchedulesPreparationsStreamChanged
+    extends MonthlySchedulesEvent {
+  final Map<String, PreparationEntity> preparations;
+
+  const MonthlySchedulesPreparationsStreamChanged({
+    required this.preparations,
+  });
+
+  @override
+  List<Object> get props => [preparations];
+}

--- a/lib/presentation/calendar/bloc/monthly_schedules_state.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_state.dart
@@ -6,35 +6,52 @@ final class MonthlySchedulesState extends Equatable {
   const MonthlySchedulesState(
       {this.status = MonthlySchedulesStatus.initial,
       this.schedules = const {},
+      this.preparationDurationByScheduleId = const {},
       this.lastDeletedSchedule,
       this.startDate,
-      this.endDate});
+      this.endDate,
+      this.visibleDate});
 
   final MonthlySchedulesStatus status;
   final Map<DateTime, List<ScheduleEntity>> schedules;
+  final Map<String, Duration> preparationDurationByScheduleId;
   final ScheduleEntity? lastDeletedSchedule;
   final DateTime? startDate;
   final DateTime? endDate;
+  final DateTime? visibleDate;
 
   MonthlySchedulesState copyWith({
     MonthlySchedulesStatus Function()? status,
     Map<DateTime, List<ScheduleEntity>> Function()? schedules,
+    Map<String, Duration> Function()? preparationDurationByScheduleId,
     ScheduleEntity? Function()? lastDeletedSchedule,
     DateTime? Function()? startDate,
     DateTime? Function()? endDate,
+    DateTime? Function()? visibleDate,
   }) {
     return MonthlySchedulesState(
       status: status != null ? status() : this.status,
       schedules: schedules != null ? schedules() : this.schedules,
+      preparationDurationByScheduleId: preparationDurationByScheduleId != null
+          ? preparationDurationByScheduleId()
+          : this.preparationDurationByScheduleId,
       lastDeletedSchedule: lastDeletedSchedule != null
           ? lastDeletedSchedule()
           : this.lastDeletedSchedule,
       startDate: startDate != null ? startDate() : this.startDate,
       endDate: endDate != null ? endDate() : this.endDate,
+      visibleDate: visibleDate != null ? visibleDate() : this.visibleDate,
     );
   }
 
   @override
-  List<Object?> get props =>
-      [status, schedules, lastDeletedSchedule, startDate, endDate];
+  List<Object?> get props => [
+        status,
+        schedules,
+        preparationDurationByScheduleId,
+        lastDeletedSchedule,
+        startDate,
+        endDate,
+        visibleDate,
+      ];
 }

--- a/lib/presentation/calendar/component/schedule_detail.dart
+++ b/lib/presentation/calendar/component/schedule_detail.dart
@@ -47,9 +47,14 @@ class _VerticalDivider extends StatelessWidget {
 
 class ScheduleDetail extends StatefulWidget {
   ScheduleDetail(
-      {super.key, required this.schedule, this.onDeleted, this.onEdit});
+      {super.key,
+      required this.schedule,
+      this.preparationTime,
+      this.onDeleted,
+      this.onEdit});
 
   final ScheduleEntity schedule;
+  final Duration? preparationTime;
   final VoidCallback? onEdit;
   final VoidCallback? onDeleted;
 
@@ -130,6 +135,7 @@ class _ScheduleDetailState extends State<ScheduleDetail> {
                 child: _ScheduleDetailsColumn(
                   schedule: widget.schedule,
                   placeName: widget.schedule.place.placeName,
+                  preparationTime: widget.preparationTime,
                 ),
               ),
             ],
@@ -173,10 +179,13 @@ class _ScheduleTimeColumn extends StatelessWidget {
 
 class _ScheduleDetailsColumn extends StatelessWidget {
   const _ScheduleDetailsColumn(
-      {required this.schedule, required this.placeName});
+      {required this.schedule,
+      required this.placeName,
+      required this.preparationTime});
 
   final ScheduleEntity schedule;
   final String placeName;
+  final Duration? preparationTime;
 
   @override
   Widget build(BuildContext context) {
@@ -235,6 +244,12 @@ class _ScheduleDetailsColumn extends StatelessWidget {
                   _ScheduleInfoTile(
                     label: AppLocalizations.of(context)!.travelTime,
                     value: formatDuration(context, schedule.moveTime),
+                  ),
+                  _ScheduleInfoTile(
+                    label: AppLocalizations.of(context)!.preparationTime,
+                    value: preparationTime == null
+                        ? '-'
+                        : formatDuration(context, preparationTime!),
                   ),
                   _ScheduleInfoTile(
                     label: AppLocalizations.of(context)!.spareTime,

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -91,6 +91,11 @@ class _CalendarScreenState extends State<CalendarScreen> {
               0,
             ),
           ),
+        )
+        ..add(
+          MonthlySchedulesVisibleDateChanged(
+            date: _selectedDate,
+          ),
         ),
       child: Scaffold(
         backgroundColor: colorScheme.surfaceContainerLow,
@@ -146,6 +151,11 @@ class _CalendarScreenState extends State<CalendarScreen> {
                             _selectedDate =
                                 _clampDay(selectedDay, _firstDay, _lastDay);
                           });
+                          context.read<MonthlySchedulesBloc>().add(
+                                MonthlySchedulesVisibleDateChanged(
+                                  date: _selectedDate,
+                                ),
+                              );
                         },
                         onPageChanged: (focusedDay) {
                           final clampedFocusedDay =
@@ -154,6 +164,12 @@ class _CalendarScreenState extends State<CalendarScreen> {
                           setState(() {
                             _selectedDate = clampedFocusedDay;
                           });
+
+                          context.read<MonthlySchedulesBloc>().add(
+                                MonthlySchedulesVisibleDateChanged(
+                                  date: _selectedDate,
+                                ),
+                              );
 
                           context.read<MonthlySchedulesBloc>().add(
                                 MonthlySchedulesMonthAdded(
@@ -312,6 +328,9 @@ class _CalendarScreenState extends State<CalendarScreen> {
 
                                 return ScheduleDetail(
                                   schedule: schedule,
+                                  preparationTime:
+                                      state.preparationDurationByScheduleId[
+                                          schedule.id],
                                   onEdit: () {
                                     showModalBottomSheet(
                                       context: context,

--- a/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
+++ b/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
@@ -1,0 +1,312 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/use-cases/delete_schedule_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_schedules_by_date_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_schedules_for_month_use_case.dart';
+import 'package:on_time_front/domain/use-cases/stream_preparations_use_case.dart';
+import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
+
+class StubLoadSchedulesForMonthUseCase implements LoadSchedulesForMonthUseCase {
+  StubLoadSchedulesForMonthUseCase(this.handler);
+  final Future<void> Function(DateTime date) handler;
+
+  @override
+  Future<void> call(DateTime date) => handler(date);
+}
+
+class StubGetSchedulesByDateUseCase implements GetSchedulesByDateUseCase {
+  StubGetSchedulesByDateUseCase(this.handler);
+  final Stream<List<ScheduleEntity>> Function(DateTime, DateTime) handler;
+
+  @override
+  Stream<List<ScheduleEntity>> call(DateTime startDate, DateTime endDate) {
+    return handler(startDate, endDate);
+  }
+}
+
+class StubDeleteScheduleUseCase implements DeleteScheduleUseCase {
+  StubDeleteScheduleUseCase(this.handler);
+  final Future<void> Function(ScheduleEntity schedule) handler;
+
+  @override
+  Future<void> call(ScheduleEntity schedule) => handler(schedule);
+}
+
+class StubLoadPreparationByScheduleIdUseCase
+    implements LoadPreparationByScheduleIdUseCase {
+  StubLoadPreparationByScheduleIdUseCase(this.handler);
+  final Future<void> Function(String scheduleId) handler;
+
+  @override
+  Future<void> call(String scheduleId) => handler(scheduleId);
+}
+
+class StubGetPreparationByScheduleIdUseCase
+    implements GetPreparationByScheduleIdUseCase {
+  StubGetPreparationByScheduleIdUseCase(this.handler);
+  final Future<PreparationEntity> Function(String scheduleId) handler;
+
+  @override
+  Future<PreparationEntity> call(String scheduleId) => handler(scheduleId);
+}
+
+class StubStreamPreparationsUseCase implements StreamPreparationsUseCase {
+  StubStreamPreparationsUseCase(this.handler);
+  final Stream<Map<String, PreparationEntity>> Function() handler;
+
+  @override
+  Stream<Map<String, PreparationEntity>> call() => handler();
+}
+
+void main() {
+  final selectedDate = DateTime(2026, 3, 20);
+  final scheduleA = ScheduleEntity(
+    id: 'schedule-a',
+    place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+    scheduleName: 'Meeting',
+    scheduleTime: DateTime(2026, 3, 20, 9, 0),
+    moveTime: const Duration(minutes: 20),
+    isChanged: false,
+    isStarted: false,
+    scheduleSpareTime: const Duration(minutes: 10),
+    scheduleNote: '',
+  );
+  final scheduleB = ScheduleEntity(
+    id: 'schedule-b',
+    place: PlaceEntity(id: 'place-2', placeName: 'Cafe'),
+    scheduleName: 'Coffee',
+    scheduleTime: DateTime(2026, 3, 20, 11, 0),
+    moveTime: const Duration(minutes: 15),
+    isChanged: false,
+    isStarted: false,
+    scheduleSpareTime: const Duration(minutes: 5),
+    scheduleNote: '',
+  );
+
+  late StubLoadSchedulesForMonthUseCase loadSchedulesForMonthUseCase;
+  late StubGetSchedulesByDateUseCase getSchedulesByDateUseCase;
+  late StubDeleteScheduleUseCase deleteScheduleUseCase;
+  late StubLoadPreparationByScheduleIdUseCase
+      loadPreparationByScheduleIdUseCase;
+  late StubGetPreparationByScheduleIdUseCase getPreparationByScheduleIdUseCase;
+  late StubStreamPreparationsUseCase streamPreparationsUseCase;
+
+  late Map<String, int> loadCallsByScheduleId;
+  late Stream<Map<String, PreparationEntity>> preparationsStream;
+
+  MonthlySchedulesBloc buildBloc() {
+    return MonthlySchedulesBloc(
+      loadSchedulesForMonthUseCase,
+      getSchedulesByDateUseCase,
+      deleteScheduleUseCase,
+      loadPreparationByScheduleIdUseCase,
+      getPreparationByScheduleIdUseCase,
+      streamPreparationsUseCase,
+    );
+  }
+
+  setUp(() {
+    loadCallsByScheduleId = {};
+
+    loadSchedulesForMonthUseCase = StubLoadSchedulesForMonthUseCase(
+      (_) async {},
+    );
+    getSchedulesByDateUseCase = StubGetSchedulesByDateUseCase(
+      (_, __) => Stream<List<ScheduleEntity>>.fromIterable([
+        [scheduleA, scheduleB],
+      ]),
+    );
+    deleteScheduleUseCase = StubDeleteScheduleUseCase((_) async {});
+    preparationsStream = const Stream.empty();
+    streamPreparationsUseCase = StubStreamPreparationsUseCase(
+      () => preparationsStream,
+    );
+    loadPreparationByScheduleIdUseCase = StubLoadPreparationByScheduleIdUseCase(
+      (scheduleId) async {
+        loadCallsByScheduleId[scheduleId] =
+            (loadCallsByScheduleId[scheduleId] ?? 0) + 1;
+      },
+    );
+    getPreparationByScheduleIdUseCase = StubGetPreparationByScheduleIdUseCase(
+      (scheduleId) async {
+        if (scheduleId == scheduleA.id) {
+          return const PreparationEntity(
+            preparationStepList: [
+              PreparationStepEntity(
+                id: 'prep-a',
+                preparationName: 'Shower',
+                preparationTime: Duration(minutes: 20),
+              ),
+            ],
+          );
+        }
+        return const PreparationEntity(
+          preparationStepList: [
+            PreparationStepEntity(
+              id: 'prep-b',
+              preparationName: 'Dress',
+              preparationTime: Duration(minutes: 15),
+            ),
+          ],
+        );
+      },
+    );
+  });
+
+  test('visible date + schedules prefetches preparations for visible schedules',
+      () async {
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+
+    final loadedState = await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId.containsKey(scheduleA.id) &&
+          state.preparationDurationByScheduleId.containsKey(scheduleB.id),
+    );
+
+    expect(
+      loadedState.preparationDurationByScheduleId[scheduleA.id],
+      const Duration(minutes: 20),
+    );
+    expect(
+      loadedState.preparationDurationByScheduleId[scheduleB.id],
+      const Duration(minutes: 15),
+    );
+  });
+
+  test('cached schedule preparations are not fetched again', () async {
+    getSchedulesByDateUseCase = StubGetSchedulesByDateUseCase(
+      (_, __) => Stream<List<ScheduleEntity>>.fromIterable([
+        [scheduleA, scheduleB],
+        [scheduleA, scheduleB],
+      ]),
+    );
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+
+    await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId.length == 2 &&
+          state.preparationDurationByScheduleId.containsKey(scheduleA.id) &&
+          state.preparationDurationByScheduleId.containsKey(scheduleB.id),
+    );
+
+    final beforeA = loadCallsByScheduleId[scheduleA.id] ?? 0;
+    final beforeB = loadCallsByScheduleId[scheduleB.id] ?? 0;
+
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(loadCallsByScheduleId[scheduleA.id], beforeA);
+    expect(loadCallsByScheduleId[scheduleB.id], beforeB);
+  });
+
+  test('stream update changes preparation time for cached schedule', () async {
+    final controller = StreamController<Map<String, PreparationEntity>>();
+    addTearDown(controller.close);
+    preparationsStream = controller.stream;
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+    await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId.containsKey(scheduleA.id) &&
+          state.preparationDurationByScheduleId.containsKey(scheduleB.id),
+    );
+
+    controller.add({
+      scheduleA.id: const PreparationEntity(
+        preparationStepList: [
+          PreparationStepEntity(
+            id: 'prep-a-new',
+            preparationName: 'Shower',
+            preparationTime: Duration(minutes: 45),
+          ),
+        ],
+      ),
+    });
+
+    final updatedState = await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId[scheduleA.id] ==
+          const Duration(minutes: 45),
+    );
+    expect(
+      updatedState.preparationDurationByScheduleId[scheduleB.id],
+      const Duration(minutes: 15),
+    );
+  });
+
+  test('stream update ignores schedules not cached in monthly state', () async {
+    final controller = StreamController<Map<String, PreparationEntity>>();
+    addTearDown(controller.close);
+    preparationsStream = controller.stream;
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+    final loadedState = await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId.containsKey(scheduleA.id) &&
+          state.preparationDurationByScheduleId.containsKey(scheduleB.id),
+    );
+
+    controller.add({
+      'not-cached': const PreparationEntity(
+        preparationStepList: [
+          PreparationStepEntity(
+            id: 'prep-x',
+            preparationName: 'Other',
+            preparationTime: Duration(minutes: 99),
+          ),
+        ],
+      ),
+    });
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(bloc.state.preparationDurationByScheduleId,
+        loadedState.preparationDurationByScheduleId);
+  });
+
+  test('deleting a schedule removes its cached preparation duration', () async {
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+    await bloc.stream.firstWhere(
+      (state) =>
+          state.preparationDurationByScheduleId.containsKey(scheduleA.id) &&
+          state.preparationDurationByScheduleId.containsKey(scheduleB.id),
+    );
+
+    bloc.add(MonthlySchedulesScheduleDeleted(schedule: scheduleA));
+
+    final deletedState = await bloc.stream.firstWhere(
+      (state) =>
+          !state.preparationDurationByScheduleId.containsKey(scheduleA.id),
+    );
+    expect(
+      deletedState.preparationDurationByScheduleId[scheduleB.id],
+      const Duration(minutes: 15),
+    );
+  });
+}

--- a/test/presentation/calendar/component/schedule_detail_test.dart
+++ b/test/presentation/calendar/component/schedule_detail_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/calendar/component/schedule_detail.dart';
+
+class _FakeSvgAssetBundle extends CachingAssetBundle {
+  static const _svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>';
+
+  @override
+  Future<ByteData> load(String key) async {
+    final bytes = Uint8List.fromList(utf8.encode(_svg));
+    return ByteData.view(bytes.buffer);
+  }
+}
+
+void main() {
+  final schedule = ScheduleEntity(
+    id: 'schedule-1',
+    place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+    scheduleName: 'Design Review',
+    scheduleTime: DateTime(2026, 3, 20, 9, 0),
+    moveTime: const Duration(minutes: 30),
+    isChanged: false,
+    isStarted: false,
+    scheduleSpareTime: const Duration(minutes: 10),
+    scheduleNote: '',
+  );
+
+  Future<void> pumpScheduleDetail(
+    WidgetTester tester, {
+    Duration? preparationTime,
+  }) async {
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: _FakeSvgAssetBundle(),
+        child: MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ScheduleDetail(
+              schedule: schedule,
+              preparationTime: preparationTime,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('expanded tile shows travel, preparation, spare in order',
+      (tester) async {
+    await pumpScheduleDetail(tester,
+        preparationTime: const Duration(minutes: 20));
+
+    await tester.tap(find.text('Design Review'));
+    await tester.pumpAndSettle();
+
+    final travel = find.text('Travel Time');
+    final preparation = find.text('Preparation Time');
+    final spare = find.text('Spare Time');
+
+    expect(travel, findsOneWidget);
+    expect(preparation, findsOneWidget);
+    expect(spare, findsOneWidget);
+    expect(find.text('20 minutes'), findsOneWidget);
+
+    final travelY = tester.getTopLeft(travel).dy;
+    final preparationY = tester.getTopLeft(preparation).dy;
+    final spareY = tester.getTopLeft(spare).dy;
+    expect(travelY, lessThan(preparationY));
+    expect(preparationY, lessThan(spareY));
+  });
+
+  testWidgets('preparation fallback is shown as dash when unavailable',
+      (tester) async {
+    await pumpScheduleDetail(tester);
+
+    await tester.tap(find.text('Design Review'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Preparation Time'), findsOneWidget);
+    expect(find.text('-'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Summary
- add per-schedule preparation durations to the monthly schedules state and update bloc/events so visible dates prefetch data and react to live stream updates
- show a new preparation row between travel and spare time in the expanded schedule detail and add the associated localization strings
- wire calendar screen to dispatch visible-date changes so prefetching and live updates keep the UI fresh without reloads

Testing
- Not run (not requested)