### PR TITLE
Add theme-driven alarm preparation UI tweaks

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -1,27 +1,421 @@
-# Folder Structure
-- app\
-  expo routes
-- components
-- hooks
-- test
-- data
-  - data-sources\
-    Local data source\
-    Remote data source
-  - models\
-    watermelon database models
-  - schemas
-    database schemas
-  - repositories\
-    Implementations of repository interfaces from the domain layer
-- domain
-  - entities
-  - repositories\
-    Interfaces of repositories
-    repositories should return entities
-  - use-cases
-- di\
-  container\
-  hook
+# OnTime Flutter Project Architecture
 
-  
+This document provides a comprehensive overview of the OnTime Flutter project's architecture, folder structure, and design patterns.
+
+## 🏗️ Architecture Overview
+
+OnTime follows **Clean Architecture** principles with a clear separation of concerns across three main layers:
+
+- **Presentation Layer**: UI components, state management (BLoC/Cubit), and navigation
+- **Domain Layer**: Business logic, entities, use cases, and repository interfaces
+- **Data Layer**: Repository implementations, data sources (local/remote), and data models
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    PRESENTATION LAYER                       │
+├─────────────────────────────────────────────────────────────┤
+│  • Screens & Components                                     │
+│  • BLoC/Cubit (State Management)                           │
+│  • Navigation (GoRouter)                                   │
+│  • Theme & Localization                                    │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     DOMAIN LAYER                            │
+├─────────────────────────────────────────────────────────────┤
+│  • Entities (Business Objects)                             │
+│  • Use Cases (Business Logic)                              │
+│  • Repository Interfaces                                   │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      DATA LAYER                             │
+├─────────────────────────────────────────────────────────────┤
+│  • Repository Implementations                              │
+│  • Data Sources (Remote API, Local Database, Local Storage)│
+│  • Data Models (JSON Serialization)                        │
+│  • Database Tables & DAOs                                  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 📁 Project Structure
+
+```
+lib/
+├── 📱 presentation/          # UI Layer (Screens, Widgets, State Management)
+│   ├── alarm/               # Alarm and timer functionality
+│   ├── app/                 # Main app setup and global BLoC
+│   ├── calendar/            # Calendar views and components
+│   ├── early_late/          # Early/late arrival screens
+│   ├── home/                # Home screen and dashboard
+│   ├── login/               # Authentication screens
+│   ├── my_page/             # User profile and settings
+│   ├── notification_allow/  # Notification permission
+│   ├── onboarding/          # User onboarding flow
+│   ├── schedule_create/     # Schedule creation and editing
+│   └── shared/              # Shared UI components and utilities
+│       ├── components/      # Reusable widgets
+│       ├── router/          # Navigation configuration
+│       ├── theme/           # App theming
+│       └── utils/           # UI utilities
+│
+├── 🏢 domain/               # Business Logic Layer
+│   ├── entities/            # Business objects (User, Schedule, etc.)
+│   ├── repositories/        # Repository interfaces
+│   └── use-cases/           # Business logic operations
+│
+├── 💾 data/                 # Data Access Layer
+│   ├── daos/                # Database Access Objects (Drift)
+│   ├── data_sources/        # Data source interfaces/implementations
+│   ├── models/              # API request/response models
+│   ├── repositories/        # Repository implementations
+│   └── tables/              # Database table definitions
+│
+├── 🔧 core/                 # Core Infrastructure
+│   ├── constants/           # App constants and environment variables
+│   ├── database/            # Database configuration (Drift)
+│   ├── di/                  # Dependency injection setup (Injectable)
+│   ├── dio/                 # HTTP client configuration
+│   ├── services/            # Core services (navigation, notifications)
+│   └── utils/               # Core utilities and converters
+│
+├── 🌍 l10n/                 # Localization files
+├── firebase_options.dart    # Firebase configuration
+└── main.dart               # Application entry point
+```
+
+## 🛠️ Technology Stack
+
+### Core Framework & Language
+
+- **Flutter**: Cross-platform mobile framework
+- **Dart**: Programming language
+
+### State Management
+
+- **BLoC/Cubit**: Business Logic Component pattern for state management
+- **Riverpod**: Additional state management for specific use cases
+- **Equatable**: Value equality for state objects
+
+### Dependency Injection
+
+- **Injectable**: Code generation for dependency injection
+- **GetIt**: Service locator pattern
+
+### Database & Persistence
+
+- **Drift**: Type-safe SQL database library
+- **SharedPreferences**: Simple key-value storage
+- **FlutterSecureStorage**: Secure token storage
+
+### Networking
+
+- **Dio**: HTTP client with interceptors
+- **JSON Annotation**: JSON serialization code generation
+
+### Navigation
+
+- **GoRouter**: Declarative routing solution
+
+### UI Components
+
+- **Material Design**: Google's design system
+- **Flutter SVG**: SVG asset support
+- **TableCalendar**: Calendar widget
+
+### Authentication
+
+- **Google Sign-In**: Google OAuth integration
+- **Kakao SDK**: Kakao social login
+- **Firebase Auth**: Authentication backend
+
+### Notifications
+
+- **Firebase Messaging**: Push notifications
+- **Flutter Local Notifications**: Local notifications
+
+### Development Tools
+
+- **Freezed**: Code generation for immutable classes
+- **Build Runner**: Code generation runner
+- **Widgetbook**: Component development environment
+
+## 📋 Architecture Patterns
+
+### 1. Clean Architecture Layers
+
+#### **Presentation Layer**
+
+- **Screens**: Full-screen widgets representing app pages
+- **Components**: Reusable UI widgets
+- **BLoC/Cubit**: State management following BLoC pattern
+- **Navigation**: Declarative routing with GoRouter
+
+#### **Domain Layer**
+
+- **Entities**: Core business objects using Freezed for immutability
+- **Use Cases**: Single-responsibility business logic operations
+- **Repository Interfaces**: Contracts for data access
+
+#### **Data Layer**
+
+- **Repository Implementations**: Concrete implementations of domain interfaces
+- **Data Sources**: Abstraction over remote APIs and local storage
+- **Models**: Data transfer objects with JSON serialization
+
+### 2. Dependency Injection
+
+```dart
+// Injectable annotation for automatic registration
+@Injectable()
+class UserRepository implements UserRepositoryInterface {
+  // Implementation
+}
+
+// GetIt service locator configuration
+final getIt = GetIt.instance;
+
+@InjectableInit()
+void configureDependencies() => getIt.init();
+```
+
+### 3. State Management with BLoC
+
+```dart
+// BLoC for handling user authentication state
+@Injectable()
+class AppBloc extends Bloc<AppEvent, AppState> {
+  AppBloc(this._streamUserUseCase, this._signOutUseCase)
+      : super(AppState(user: const UserEntity.empty())) {
+    on<AppUserSubscriptionRequested>(_onUserSubscriptionRequested);
+    on<AppSignOutPressed>(_onSignOutPressed);
+  }
+}
+```
+
+### 4. Data Models with JSON Serialization
+
+```dart
+@JsonSerializable()
+class GetUserResponseModel {
+  final int userId;
+  final String email;
+  final String name;
+
+  // Conversion to domain entity
+  UserEntity toEntity() {
+    return UserEntity(
+      id: userId.toString(),
+      email: email,
+      name: name,
+    );
+  }
+}
+```
+
+### 5. Database Layer with Drift
+
+```dart
+@DriftDatabase(tables: [Users, Schedules, Places], daos: [UserDao, ScheduleDao])
+class AppDatabase extends _$AppDatabase {
+  @override
+  int get schemaVersion => 3;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator m) async => await m.createAll(),
+  );
+}
+```
+
+## 🔄 Data Flow
+
+### 1. User Interaction Flow
+
+```
+User Input → Widget → BLoC Event → Use Case → Repository → Data Source → API/DB
+                ↓
+Widget ← BLoC State ← Use Case ← Repository ← Data Source ← Response
+```
+
+### 2. Authentication Flow
+
+```
+Login Screen → AppBloc → SignInUseCase → UserRepository → AuthDataSource → API
+      ↓
+Navigation ← AppBloc ← UserEntity ← UserRepository ← AuthDataSource ← Token
+```
+
+### 3. Schedule Management Flow
+
+```
+Schedule Form → ScheduleBloc → CreateScheduleUseCase → ScheduleRepository
+                     ↓
+Database ← ScheduleDao ← ScheduleRepository ← ScheduleEntity
+```
+
+## 🎯 Key Features Architecture
+
+### 1. **Authentication System**
+
+- **Google OAuth** and **Kakao Login** integration
+- **JWT token** management with secure storage
+- **Stream-based** user state management
+- **Automatic token refresh** via interceptors
+
+### 2. **Schedule Management**
+
+- **CRUD operations** for schedules
+- **Calendar integration** with multiple view modes
+- **Preparation time calculation** and management
+- **Real-time synchronization** between local and remote data
+- **Automatic timer system** for schedule start notifications
+
+📖 **Detailed Documentation**: For comprehensive information about the automatic timer system, see [Schedule Timer System](./Schedule-Timer-System.md)
+
+### 3. **Notification System**
+
+- **Firebase push notifications** for schedule reminders
+- **Local notifications** for preparation alerts
+- **Permission handling** for notification access
+
+### 4. **Offline Support**
+
+- **Local database** with Drift for offline data access
+- **Synchronization strategy** for online/offline data consistency
+- **Caching mechanisms** for improved performance
+
+### 5. **Error Handling System**
+
+- **Result pattern** for explicit, type-safe error handling
+- **Structured failure hierarchy** across all layers (Core, Domain, Data)
+- **Automatic logging** to Firebase Crashlytics in production
+- **Environment-aware messaging**: detailed errors in debug, user-friendly messages in production
+- **Layer-appropriate failures**: Domain failures contain no infrastructure details
+
+📖 **Detailed Documentation**: For comprehensive information about the error handling system, see [Error Handling System](./Error-Handling-Result-System.md)
+
+### 6. **Local Storage for Timed Preparation**
+
+- `PreparationWithTimeLocalDataSource` persists `PreparationWithTimeEntity` per schedule using SharedPreferences.
+- Intended for lightweight, per-schedule timer state (elapsed time, completion) that should survive app restarts.
+- Repository reads canonical preparation from remote/DB; BLoC can merge it with locally persisted timing state when needed.
+
+## 🧪 Testing Strategy
+
+### Structure
+
+```
+test/
+├── config/              # Test configuration
+├── data/               # Data layer tests
+└── helpers/            # Test utilities
+```
+
+### Testing Approach
+
+- **Unit Tests**: Use cases, repositories, and business logic
+- **Widget Tests**: UI components and screen interactions
+- **Integration Tests**: End-to-end user flows
+- **Mocking**: Using Mockito for external dependencies
+
+## 📦 Build & Deployment
+
+### Development Environment
+
+- **Flutter SDK**: ^3.5.4
+- **Dart SDK**: Latest stable
+- **Build Tools**: build_runner for code generation
+
+### Code Generation Commands
+
+```bash
+# Generate all code (models, dependency injection, etc.)
+dart run build_runner build
+
+# Watch for changes and regenerate
+dart run build_runner watch
+```
+
+### Platform Support
+
+- **Android**: Native Android build
+- **iOS**: Native iOS build
+- **Web**: Progressive Web App support
+
+## 🔧 Development Guidelines
+
+### 1. **Code Organization**
+
+- Follow **Clean Architecture** principles
+- Separate concerns across layers
+- Use **feature-based** folder structure in presentation layer
+
+### 2. **State Management**
+
+- Use **BLoC pattern** for complex state management
+- Use **Cubit** for simpler state scenarios
+- Keep business logic in **use cases**, not in BLoCs
+
+### 3. **Data Handling**
+
+- Always use **entities** in the domain layer
+- Convert **models to entities** at repository boundaries
+- Implement **proper error handling** throughout the layers
+- Use **Result pattern** for all operations that can fail
+
+📖 **Detailed Documentation**: For comprehensive information about error handling, see [Error Handling System](./Error-Handling-Result-System.md)
+
+### 4. **Naming Conventions**
+
+- **Entities**: `UserEntity`, `ScheduleEntity`
+- **Use Cases**: `GetUserUseCase`, `CreateScheduleUseCase`
+- **Repositories**: `UserRepository`, `ScheduleRepository`
+- **BLoCs**: `UserBloc`, `ScheduleFormBloc`
+- **Models**: `GetUserResponseModel`, `CreateScheduleRequestModel`
+
+### 5. **Dependencies**
+
+- Register all dependencies using **@Injectable()** annotation
+- Use **interfaces** for repository contracts
+- Avoid direct dependencies between layers
+
+## 🚀 Getting Started for New Developers
+
+1. **Setup Environment**
+
+   - Install Flutter SDK
+   - Configure IDE (VS Code/Android Studio)
+   - Run `flutter pub get` to install dependencies
+
+2. **Code Generation**
+
+   - Run `dart run build_runner build`
+   - This generates dependency injection, JSON serialization, and Freezed code
+
+3. **Database Setup**
+
+   - Database migrations are handled automatically
+   - Local database files are created on first run
+
+4. **Understanding the Flow**
+
+   - Start with `main.dart` to understand app initialization
+   - Explore `presentation/app/` for global app state
+   - Check `domain/use-cases/` for business logic
+   - Review `data/repositories/` for data access patterns
+
+5. **Making Changes**
+   - Create new features following the existing layer structure
+   - Add new entities in `domain/entities/`
+   - Implement use cases in `domain/use-cases/`
+   - Create repository interfaces and implementations
+   - Build UI components in `presentation/`
+
+---
+
+_This architecture documentation is maintained alongside the codebase. Please update it when making significant architectural changes._

--- a/Error-Handling-Result-System.md
+++ b/Error-Handling-Result-System.md
@@ -1,0 +1,1242 @@
+# Result-based Error Handling System
+
+## Overview
+
+This document describes the comprehensive error handling architecture implemented across all layers of the application using the **Result pattern**. This system ensures type-safe error propagation from data sources to the UI, with automatic logging and environment-aware error messaging.
+
+## Design Principles
+
+### Core Principles
+
+1. **Explicit Error Handling**: All operations that can fail return `Result<Success, Failure>` types, making error handling mandatory and visible in type signatures
+2. **No Silent Failures**: Invalid data or broken business rules never produce incorrect but valid-looking states
+3. **Layer-Appropriate Failures**: Each layer defines failures appropriate to its abstraction level
+4. **Type Safety**: The compiler enforces error handling - you cannot ignore failures
+5. **User-Friendly Messages**: Technical details in debug mode, localized friendly messages in production
+6. **Automatic Logging**: All failures are automatically logged to Firebase Crashlytics in production
+
+### Why Result Pattern?
+
+Traditional exception-based error handling has several problems:
+
+- Exceptions can be silently ignored (no compiler enforcement)
+- Return types don't indicate possible failures
+- Easy to forget `try/catch` blocks
+- Difficult to distinguish between different error types
+
+The Result pattern solves these by making errors explicit in the type system.
+
+## Architecture Overview
+
+```mermaid
+flowchart TB
+    subgraph presentation [Presentation Layer]
+        UI[Widget/Screen]
+        BLoC[BLoC/Cubit]
+    end
+
+    subgraph domain [Domain Layer]
+        UseCase[Use Case]
+        RepoInterface[Repository Interface]
+    end
+
+    subgraph data [Data Layer]
+        RepoImpl[Repository Implementation]
+        DataSource[Data Source]
+        ExceptionMapper[Exception Mapper]
+    end
+
+    subgraph infrastructure [Infrastructure]
+        API[REST API / Dio]
+        DB[Local Database]
+        Crashlytics[Firebase Crashlytics]
+    end
+
+    UI -->|user action| BLoC
+    BLoC -->|calls| UseCase
+    UseCase -->|calls| RepoInterface
+    RepoImpl -.implements.- RepoInterface
+    RepoImpl -->|calls| DataSource
+    DataSource -->|throws| API
+    DataSource -->|throws| DB
+
+    API -->|DioException| ExceptionMapper
+    DB -->|Exception| ExceptionMapper
+    ExceptionMapper -->|Failure| RepoImpl
+
+    RepoImpl -->|"Result&lt;T, Failure&gt;"| UseCase
+    UseCase -->|"Result&lt;T, Failure&gt;"| BLoC
+    BLoC -->|State with Failure| UI
+
+    RepoImpl -->|logs| Crashlytics
+
+    style presentation fill:#e1f5ff
+    style domain fill:#fff4e1
+    style data fill:#ffe1f5
+    style infrastructure fill:#f0f0f0
+```
+
+## Layer-by-Layer Implementation
+
+### 1. Core Layer: Foundation Types
+
+The core layer provides the fundamental building blocks for error handling.
+
+#### Result Type
+
+```mermaid
+classDiagram
+    class Result~S,F~ {
+        <<sealed>>
+    }
+    class Success~S,F~ {
+        +S value
+        +successOrNull S?
+    }
+    class Err~S,F~ {
+        +F failure
+        +failureOrNull F?
+    }
+
+    Result <|-- Success
+    Result <|-- Err
+
+    class Result~S,F~ {
+        +fold(onSuccess, onFailure) T
+        +map(transform) Result
+        +flatMap(transform) Result
+        +isSuccess bool
+        +isFailure bool
+    }
+```
+
+**Location**: `lib/core/error/result.dart`
+
+**Key Methods**:
+
+- `fold<T>({onSuccess, onFailure})` - Handle both cases explicitly
+- `map<S2>(transform)` - Transform success value
+- `flatMap<S2>(transform)` - Chain operations that return Result
+- `successOrNull` / `failureOrNull` - Convenience getters
+
+#### Failure Hierarchy
+
+```mermaid
+classDiagram
+    class Failure {
+        <<abstract>>
+        +String code
+        +String message
+        +Object? cause
+        +StackTrace? stackTrace
+    }
+
+    class NetworkFailure {
+        +NetworkFailure.noConnection()
+        +NetworkFailure.timeout()
+        +NetworkFailure.serverError()
+    }
+
+    class ValidationFailure {
+        +ValidationFailure(message)
+    }
+
+    class DataIntegrityFailure {
+        +DataIntegrityFailure(message, code)
+    }
+
+    class UnexpectedFailure {
+        +UnexpectedFailure.fromException()
+    }
+
+    Failure <|-- NetworkFailure
+    Failure <|-- ValidationFailure
+    Failure <|-- DataIntegrityFailure
+    Failure <|-- UnexpectedFailure
+```
+
+**Location**: `lib/core/error/failures.dart`
+
+**Design Pattern**: Each failure type has factory constructors for common scenarios.
+
+#### Unit Type
+
+For operations that don't return a value (like `void`), we use `Unit`:
+
+```dart
+Future<Result<Unit, Failure>> deleteSchedule(...) async {
+  // ... perform deletion
+  return Success(unit); // unit is a singleton instance
+}
+```
+
+**Location**: `lib/core/error/unit.dart`
+
+### 2. Domain Layer: Business Failures
+
+Domain failures represent business rule violations without any infrastructure details.
+
+```mermaid
+classDiagram
+    class Failure {
+        <<abstract>>
+    }
+
+    class PreparationChainFailure {
+        +PreparationChainFailure.noTail()
+        +PreparationChainFailure.multipleTails()
+        +PreparationChainFailure.cycleDetected()
+        +PreparationChainFailure.broken()
+    }
+
+    class ScheduleNotFoundFailure {
+        code: SCHEDULE_NOT_FOUND
+    }
+
+    class UnauthorizedFailure {
+        code: UNAUTHORIZED
+    }
+
+    Failure <|-- PreparationChainFailure
+    Failure <|-- ScheduleNotFoundFailure
+    Failure <|-- UnauthorizedFailure
+```
+
+**Location**: `lib/domain/errors/domain_failures.dart`
+
+**Example Codes**:
+
+- `PREP_NO_TAIL` - No step has `nextPreparationId = null`
+- `PREP_MULTIPLE_TAILS` - Multiple steps have `nextPreparationId = null`
+- `PREP_CYCLE_DETECTED` - Steps form a cycle
+- `PREP_BROKEN_CHAIN` - Not all steps are connected
+
+#### Repository Interfaces
+
+Domain repositories declare failure possibilities in their signatures:
+
+```dart
+abstract interface class PreparationRepository {
+  // Streams can emit failures
+  Stream<Result<Map<String, PreparationEntity>, Failure>> get preparationStream;
+
+  // Async operations return Result
+  Future<Result<Unit, Failure>> updatePreparationByScheduleId(
+    PreparationEntity preparationEntity,
+    String scheduleId,
+  );
+
+  Future<Result<PreparationEntity, Failure>> getDefualtPreparation();
+}
+```
+
+**Key Point**: Domain layer knows nothing about HTTP status codes, Dio exceptions, or database errors.
+
+### 3. Data Layer: Exception Mapping
+
+The data layer catches infrastructure exceptions and maps them to domain-appropriate failures.
+
+```mermaid
+flowchart LR
+    subgraph DataSources
+        Remote[Remote Data Source]
+        Local[Local Data Source]
+    end
+
+    subgraph Exceptions
+        DioEx[DioException]
+        FormatEx[FormatException]
+        StateEx[StateError]
+        GenericEx[Exception]
+    end
+
+    subgraph Mapper[Exception Mapper]
+        Map[ExceptionToFailureMapper.map]
+    end
+
+    subgraph Failures
+        Network[NetworkFailure]
+        Server[ServerFailure]
+        Parse[ParseFailure]
+        Cache[CacheFailure]
+        Unexpected[UnexpectedFailure]
+    end
+
+    Remote --> DioEx
+    Remote --> FormatEx
+    Local --> StateEx
+    Local --> GenericEx
+
+    DioEx --> Map
+    FormatEx --> Map
+    StateEx --> Map
+    GenericEx --> Map
+
+    Map --> Network
+    Map --> Server
+    Map --> Parse
+    Map --> Cache
+    Map --> Unexpected
+```
+
+**Location**: `lib/data/errors/`
+
+#### Data Failures
+
+- `ServerFailure` - HTTP 400-599 responses with status code and message
+- `CacheFailure` - Local storage/database errors
+- `ParseFailure` - JSON parsing or data transformation errors
+
+#### Exception Mapping Strategy
+
+```dart
+class ExceptionToFailureMapper {
+  static Failure map(Object exception, StackTrace stackTrace) {
+    return switch (exception) {
+      DioException(type: DioExceptionType.connectionTimeout) =>
+        NetworkFailure.timeout(/* ... */),
+      DioException(type: DioExceptionType.connectionError) =>
+        NetworkFailure.noConnection(/* ... */),
+      DioException(response: final resp?) when resp.statusCode != null =>
+        ServerFailure(/* ... */),
+      FormatException() || JsonUnsupportedObjectError() =>
+        ParseFailure(/* ... */),
+      StateError() =>
+        CacheFailure(/* ... */),
+      _ =>
+        UnexpectedFailure.fromException(/* ... */),
+    };
+  }
+}
+```
+
+#### Repository Implementation Pattern
+
+```dart
+@Singleton(as: PreparationRepository)
+class PreparationRepositoryImpl implements PreparationRepository {
+  final PreparationRemoteDataSource _remoteDataSource;
+  final ErrorLoggerService _errorLogger;
+
+  @override
+  Future<Result<Unit, Failure>> updatePreparationByScheduleId(
+      PreparationEntity preparationEntity, String scheduleId) async {
+    try {
+      await _remoteDataSource.updatePreparationByScheduleId(
+          preparationEntity, scheduleId);
+      _updateStream(scheduleId, preparationEntity);
+      return Success(unit);
+    } catch (e, stackTrace) {
+      final failure = ExceptionToFailureMapper.map(e, stackTrace);
+      await _errorLogger.log(failure, hint: 'updatePreparationByScheduleId');
+      return Err(failure);
+    }
+  }
+}
+```
+
+**Key Pattern**: Catch everything, map to Failure, log, return Err.
+
+### 4. Presentation Layer: Error Display
+
+```mermaid
+sequenceDiagram
+    participant UI as Widget
+    participant BLoC as BLoC/Cubit
+    participant UseCase as Use Case
+    participant Repo as Repository
+
+    UI->>BLoC: User Action (Event)
+    BLoC->>UseCase: call()
+    UseCase->>Repo: operation()
+
+    alt Success Path
+        Repo-->>UseCase: Success(data)
+        UseCase-->>BLoC: Success(data)
+        BLoC->>BLoC: emit(state with data)
+        BLoC-->>UI: State Update
+        UI->>UI: Render Normal UI
+    else Failure Path
+        Repo-->>UseCase: Err(failure)
+        UseCase-->>BLoC: Err(failure)
+        BLoC->>BLoC: emit(state with failure)
+        BLoC-->>UI: State Update with Failure
+        UI->>UI: Show ErrorMessageBubble
+    end
+```
+
+#### State Structure
+
+BLoC states include an optional failure field:
+
+```dart
+class PreparationFormState extends Equatable {
+  final List<PreparationStepFormState> preparationStepList;
+  final PreparationFormStatus status;
+  final bool isValid;
+  final Failure? failure; // ← Error field
+
+  @override
+  List<Object?> get props => [preparationStepList, status, isValid, failure];
+}
+```
+
+#### Event Handler Pattern
+
+```dart
+void _onPreparationFormEditRequested(
+  PreparationFormEditRequested event,
+  Emitter<PreparationFormState> emit,
+) {
+  final result = PreparationFormState.fromEntity(event.preparationEntity);
+
+  result.fold(
+    onSuccess: (preparationFormState) {
+      emit(state.copyWith(
+        status: PreparationFormStatus.success,
+        preparationStepList: preparationFormState.preparationStepList,
+        failure: null, // Clear any previous failure
+      ));
+    },
+    onFailure: (failure) {
+      emit(state.copyWith(
+        status: PreparationFormStatus.error,
+        failure: failure, // Store failure in state
+        preparationStepList: const [], // Safe fallback
+      ));
+    },
+  );
+}
+```
+
+#### UI Error Display
+
+```dart
+BlocBuilder<PreparationFormBloc, PreparationFormState>(
+  builder: (context, state) {
+    return Column(
+      children: [
+        // Show error bubble if failure exists
+        if (state.failure != null)
+          ErrorMessageBubble(
+            errorMessage: Text(state.failure!.toUserMessage(context)),
+          ),
+        // ... rest of UI
+      ],
+    );
+  },
+)
+```
+
+#### User Message Conversion
+
+**Location**: `lib/presentation/shared/extensions/failure_extensions.dart`
+
+```dart
+extension FailureMessage on Failure {
+  String toUserMessage(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    // Debug mode: show technical details
+    if (kDebugMode) {
+      return '$code: $message';
+    }
+
+    // Production mode: user-friendly messages
+    return switch (this) {
+      NetworkFailure() => l10n.error, // Use localized strings
+      ValidationFailure(:final message) => message,
+      PreparationChainFailure() => l10n.error,
+      ServerFailure() => l10n.error,
+      _ => l10n.error, // Fallback
+    };
+  }
+}
+```
+
+**Pattern**: Detailed in debug, generic/localized in production.
+
+## Error Flow Examples
+
+### Example 1: Data Integrity Validation (Domain Layer)
+
+**Scenario**: Loading a preparation chain with broken links
+
+```mermaid
+sequenceDiagram
+    participant UI as PreparationEditForm
+    participant BLoC as PreparationFormBloc
+    participant State as PreparationFormState
+    participant Entity as PreparationEntity
+
+    UI->>BLoC: PreparationFormEditRequested(entity)
+    BLoC->>State: fromEntity(entity)
+
+    alt Valid Chain
+        State->>State: Validate chain structure
+        State-->>BLoC: Success(state)
+        BLoC->>BLoC: emit(state with data)
+        BLoC-->>UI: Valid state
+        UI->>UI: Render preparation list
+    else Broken Chain
+        State->>State: Detect no tail
+        State-->>BLoC: Err(PreparationChainFailure.noTail())
+        BLoC->>BLoC: emit(state with failure)
+        BLoC-->>UI: State with failure
+        UI->>UI: Show ErrorMessageBubble
+    end
+```
+
+**Key Validation Points**:
+
+1. No tail (no step with `nextPreparationId = null`)
+2. Multiple tails (more than one step with `nextPreparationId = null`)
+3. Cycle detected (step chain loops back)
+4. Broken chain (not all steps are connected)
+
+### Example 2: Network Operation (Data Layer)
+
+**Scenario**: Updating a schedule via REST API
+
+```mermaid
+sequenceDiagram
+    participant BLoC as ScheduleFormBloc
+    participant UseCase as UpdateScheduleUseCase
+    participant Repo as ScheduleRepositoryImpl
+    participant DataSource as ScheduleRemoteDataSource
+    participant API as REST API
+    participant Logger as ErrorLoggerService
+    participant Crashlytics as Firebase Crashlytics
+
+    BLoC->>UseCase: call(scheduleEntity)
+    UseCase->>Repo: updateSchedule(scheduleEntity)
+    Repo->>DataSource: updateSchedule(scheduleEntity)
+    DataSource->>API: PUT /schedules/{id}
+
+    alt Success (200 OK)
+        API-->>DataSource: Success Response
+        DataSource-->>Repo: (returns normally)
+        Repo-->>UseCase: Success(unit)
+        UseCase-->>BLoC: Success(unit)
+        BLoC->>UI: emit(success state)
+    else Network Error
+        API-->>DataSource: DioException(connectionTimeout)
+        DataSource-->>Repo: throws DioException
+        Repo->>Repo: ExceptionMapper.map()
+        Repo->>Repo: NetworkFailure.timeout()
+        Repo->>Logger: log(failure)
+        Logger->>Crashlytics: recordError() [if release mode]
+        Repo-->>UseCase: Err(NetworkFailure)
+        UseCase-->>BLoC: Err(NetworkFailure)
+        BLoC->>UI: emit(state with failure)
+    else Server Error
+        API-->>DataSource: DioException(response: 500)
+        DataSource-->>Repo: throws DioException
+        Repo->>Repo: ExceptionMapper.map()
+        Repo->>Repo: ServerFailure(statusCode: 500)
+        Repo->>Logger: log(failure)
+        Logger->>Crashlytics: recordError() [if release mode]
+        Repo-->>UseCase: Err(ServerFailure)
+        UseCase-->>BLoC: Err(ServerFailure)
+        BLoC->>UI: emit(state with failure)
+    end
+```
+
+### Example 3: Stream-based Operations
+
+**Scenario**: Real-time schedule updates
+
+```mermaid
+flowchart TB
+    Repo[Repository Stream]
+    UseCase[Use Case Stream]
+    BLoC[BLoC Subscription]
+    UI[UI State]
+
+    Repo -->|"emit Success(data1)"| UseCase
+    UseCase -->|"yield Success(data1)"| BLoC
+    BLoC -->|"emit state(data1)"| UI
+
+    Repo -->|"emit Success(data2)"| UseCase
+    UseCase -->|"yield Success(data2)"| BLoC
+    BLoC -->|"emit state(data2)"| UI
+
+    Repo -->|"emit Err(NetworkFailure)"| UseCase
+    UseCase -->|"yield Err(NetworkFailure)"| BLoC
+    BLoC -->|"emit state(failure)"| UI
+    UI -->|"show error banner"| UI
+
+    Repo -->|"emit Success(data3)"| UseCase
+    UseCase -->|"yield Success(data3)"| BLoC
+    BLoC -->|"emit state(data3, clear failure)"| UI
+```
+
+**Pattern**: Streams can emit either `Success` or `Err`. UI subscribes and updates accordingly.
+
+## Error Logging System
+
+### Architecture
+
+```mermaid
+flowchart LR
+    Repo[Repository catches exception]
+    Mapper[Maps to Failure]
+    Logger[ErrorLoggerService]
+
+    subgraph Environment
+        Debug[kDebugMode]
+        Release[kReleaseMode]
+    end
+
+    subgraph Actions
+        Print[debugPrint to console]
+        Crashlytics[Firebase Crashlytics]
+    end
+
+    Repo --> Mapper
+    Mapper --> Logger
+    Logger --> Environment
+
+    Debug --> Print
+    Release --> Crashlytics
+```
+
+**Location**:
+
+- Interface: `lib/core/services/error_logger_service.dart`
+- Implementation: `lib/core/services/crashlytics_error_logger_service.dart`
+
+### Logging Strategy
+
+**Debug Mode**:
+
+- Print all failure details to console
+- Include code, message, cause, stackTrace
+- No Crashlytics calls
+
+**Release Mode (non-web)**:
+
+- Record error to Firebase Crashlytics
+- Include custom keys: `failure_code`, `failure_hint`
+- Attach stackTrace and cause
+
+**Web Platform**:
+
+- Crashlytics not available
+- Errors logged to console only
+
+### Integration with Dependency Injection
+
+The logger is automatically injected into all repositories:
+
+```dart
+@Singleton(as: PreparationRepository)
+class PreparationRepositoryImpl implements PreparationRepository {
+  final ErrorLoggerService _errorLogger; // Injected
+
+  PreparationRepositoryImpl({
+    required ErrorLoggerService errorLoggerService,
+    // ... other dependencies
+  }) : _errorLogger = errorLoggerService;
+}
+```
+
+## Testing Error Handling
+
+### Unit Testing Result-based Code
+
+#### Testing Success Cases
+
+```dart
+test('Valid chain reconstructs correctly', () {
+  final entity = PreparationEntity(preparationStepList: [
+    stepEntity(id: 'A', name: 'A', time: Duration(minutes: 1), nextId: null),
+  ]);
+
+  final result = PreparationFormState.fromEntity(entity);
+
+  // Verify it's a success
+  expect(result.isSuccess, true);
+
+  // Extract and verify the value
+  final state = result.successOrNull!;
+  expect(state.preparationStepList.length, 1);
+  expect(state.preparationStepList[0].id, 'A');
+});
+```
+
+#### Testing Failure Cases
+
+```dart
+test('Broken chain returns PreparationChainFailure', () {
+  final entity = PreparationEntity(preparationStepList: [
+    stepEntity(id: 'A', name: 'A', time: Duration(minutes: 1), nextId: 'B'),
+    // Missing B - broken chain
+  ]);
+
+  final result = PreparationFormState.fromEntity(entity);
+
+  // Verify it's a failure
+  expect(result.isFailure, true);
+
+  // Use fold to check failure details
+  result.fold(
+    onSuccess: (_) => fail('Should not succeed with broken chain'),
+    onFailure: (failure) {
+      expect(failure, isA<PreparationChainFailure>());
+      expect(failure.code, 'PREP_NO_TAIL');
+    },
+  );
+});
+```
+
+#### Testing Multiple Failure Scenarios
+
+```dart
+group('PreparationChainFailure scenarios', () {
+  test('No tail returns PREP_NO_TAIL', () {
+    final entity = PreparationEntity(preparationStepList: [
+      stepEntity(id: 'A', nextId: 'B'),
+      stepEntity(id: 'B', nextId: 'A'), // Cycle, no tail
+    ]);
+
+    final result = PreparationFormState.fromEntity(entity);
+    expect(result.failureOrNull?.code, 'PREP_NO_TAIL');
+  });
+
+  test('Multiple tails returns PREP_MULTIPLE_TAILS', () {
+    final entity = PreparationEntity(preparationStepList: [
+      stepEntity(id: 'A', nextId: null),
+      stepEntity(id: 'B', nextId: null), // Two tails
+    ]);
+
+    final result = PreparationFormState.fromEntity(entity);
+    expect(result.failureOrNull?.code, 'PREP_MULTIPLE_TAILS');
+  });
+
+  test('Cycle detected returns PREP_CYCLE_DETECTED', () {
+    final entity = PreparationEntity(preparationStepList: [
+      stepEntity(id: 'A', nextId: 'B'),
+      stepEntity(id: 'B', nextId: 'C'),
+      stepEntity(id: 'C', nextId: 'A'), // Forms cycle
+      stepEntity(id: 'D', nextId: null), // Separate tail
+    ]);
+
+    final result = PreparationFormState.fromEntity(entity);
+    final failure = result.failureOrNull as PreparationChainFailure;
+    expect(failure.code, 'PREP_CYCLE_DETECTED');
+  });
+});
+```
+
+### Integration Testing with Mocks
+
+#### Mocking Repositories to Return Failures
+
+```dart
+class MockPreparationRepository extends Mock implements PreparationRepository {}
+
+void main() {
+  late PreparationFormBloc bloc;
+  late MockPreparationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockPreparationRepository();
+    bloc = PreparationFormBloc(/* inject mock */);
+  });
+
+  blocTest<PreparationFormBloc, PreparationFormState>(
+    'emits failure state when repository returns network error',
+    build: () {
+      // Mock repository to return failure
+      when(() => mockRepository.getPreparationByScheduleId(any()))
+          .thenAnswer((_) async => Err(NetworkFailure.noConnection()));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(LoadPreparation('schedule-123')),
+    expect: () => [
+      PreparationFormState(status: PreparationFormStatus.loading),
+      PreparationFormState(
+        status: PreparationFormStatus.error,
+        failure: isA<NetworkFailure>(),
+      ),
+    ],
+  );
+}
+```
+
+### Widget Testing with Error States
+
+```dart
+testWidgets('shows ErrorMessageBubble when failure exists', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: BlocProvider(
+        create: (_) => PreparationFormBloc(),
+        child: PreparationEditForm(),
+      ),
+    ),
+  );
+
+  // Trigger failure state
+  final bloc = tester.bloc<PreparationFormBloc>();
+  bloc.add(PreparationFormEditRequested(
+    preparationEntity: brokenChainEntity,
+  ));
+  await tester.pump();
+
+  // Verify ErrorMessageBubble is shown
+  expect(find.byType(ErrorMessageBubble), findsOneWidget);
+  expect(find.text(contains('PREP_NO_TAIL')), findsOneWidget); // Debug mode
+});
+```
+
+## Common Patterns & Best Practices
+
+### Pattern 1: Handling Result in Use Cases
+
+```dart
+// Simple pass-through
+Future<Result<Unit, Failure>> call(ScheduleEntity schedule) {
+  return _repository.updateSchedule(schedule);
+}
+
+// Transform success value
+Future<Result<int, Failure>> call(String scheduleId) async {
+  final result = await _repository.getSchedule(scheduleId);
+  return result.map((schedule) => schedule.attendeeCount);
+}
+
+// Chain multiple operations
+Future<Result<Unit, Failure>> call() async {
+  final result1 = await _prepRepo.updateDefaultPreparation(prep);
+  if (result1.isFailure) return result1;
+
+  final result2 = await _userRepo.getUser();
+  return result2;
+}
+
+// Or use flatMap for chaining
+Future<Result<Unit, Failure>> call() async {
+  return (await _prepRepo.updateDefaultPreparation(prep))
+      .flatMap((_) => _userRepo.getUser());
+}
+```
+
+### Pattern 2: Stream Operations
+
+```dart
+// Transform stream of Results
+Stream<Result<List<ScheduleEntity>, Failure>> call(
+    DateTime start, DateTime end) async* {
+  await for (final result in _repository.scheduleStream) {
+    yield result.map((schedules) =>
+        schedules.where((s) => s.isInRange(start, end)).toList());
+  }
+}
+
+// Filter and transform
+Stream<Result<ScheduleEntity?, Failure>> getUpcoming() async* {
+  await for (final result in _repository.scheduleStream) {
+    yield result.map((schedules) =>
+        schedules.firstWhereOrNull((s) => s.isUpcoming));
+  }
+}
+```
+
+### Pattern 3: BLoC emit.forEach with Result
+
+```dart
+await emit.forEach(
+  _getSchedulesByDateUseCase(startDate, endDate),
+  onData: (result) {
+    return result.fold(
+      onSuccess: (schedules) => state.copyWith(
+        status: Status.success,
+        schedules: schedules,
+        failure: null,
+      ),
+      onFailure: (failure) => state.copyWith(
+        status: Status.error,
+        failure: failure,
+      ),
+    );
+  },
+);
+```
+
+### Pattern 4: Validation in Presentation Layer
+
+```dart
+// Returns Result for operations that can fail during construction
+static Result<PreparationFormState, Failure> fromEntity(
+    PreparationEntity entity) {
+  // Validate business rules
+  if (!_isValidChain(entity)) {
+    return Err(PreparationChainFailure.broken(/* ... */));
+  }
+
+  // Transform to presentation model
+  final formSteps = _transformToFormSteps(entity);
+
+  return Success(PreparationFormState(
+    preparationStepList: formSteps,
+    status: PreparationFormStatus.success,
+  ));
+}
+```
+
+## Adding New Failures
+
+### Step-by-Step Guide
+
+#### 1. Determine the Appropriate Layer
+
+| Layer                                                 | Use When                          | Examples                                                   |
+| ----------------------------------------------------- | --------------------------------- | ---------------------------------------------------------- |
+| **Core** (`lib/core/error/failures.dart`)             | Generic, reusable across features | `NetworkFailure`, `ValidationFailure`, `UnexpectedFailure` |
+| **Domain** (`lib/domain/errors/domain_failures.dart`) | Business rule violations          | `PreparationChainFailure`, `ScheduleNotFoundFailure`       |
+| **Data** (`lib/data/errors/data_failures.dart`)       | Infrastructure-specific errors    | `ServerFailure`, `CacheFailure`, `ParseFailure`            |
+
+#### 2. Create the Failure Class
+
+```dart
+// Domain failure example
+class ScheduleOverlapFailure extends Failure {
+  const ScheduleOverlapFailure({
+    required String scheduleId,
+    required String conflictingScheduleId,
+    super.cause,
+    super.stackTrace,
+  }) : super(
+    code: 'SCHEDULE_OVERLAP',
+    message: 'Schedule $scheduleId overlaps with $conflictingScheduleId',
+  );
+}
+
+// Data failure example
+class ServerFailure extends Failure {
+  final int statusCode;
+  final String? serverMessage;
+
+  const ServerFailure({
+    required this.statusCode,
+    this.serverMessage,
+    super.cause,
+    super.stackTrace,
+  }) : super(
+    code: 'HTTP_$statusCode',
+    message: serverMessage ?? 'Server error ($statusCode)',
+  );
+}
+```
+
+#### 3. Return the Failure
+
+```dart
+// In repository
+Future<Result<Unit, Failure>> createSchedule(ScheduleEntity schedule) async {
+  try {
+    // Check business rules
+    if (_hasOverlap(schedule)) {
+      return Err(ScheduleOverlapFailure(
+        scheduleId: schedule.id,
+        conflictingScheduleId: conflictId,
+      ));
+    }
+
+    await _dataSource.createSchedule(schedule);
+    return Success(unit);
+  } catch (e, stackTrace) {
+    final failure = ExceptionToFailureMapper.map(e, stackTrace);
+    await _errorLogger.log(failure, hint: 'createSchedule');
+    return Err(failure);
+  }
+}
+```
+
+#### 4. Handle in Presentation
+
+```dart
+// In BLoC
+void _onScheduleCreated(ScheduleCreated event, Emitter<State> emit) async {
+  final result = await _createScheduleUseCase(event.schedule);
+
+  result.fold(
+    onSuccess: (_) {
+      emit(state.copyWith(
+        status: Status.success,
+        failure: null,
+      ));
+    },
+    onFailure: (failure) {
+      emit(state.copyWith(
+        status: Status.error,
+        failure: failure,
+      ));
+    },
+  );
+}
+```
+
+#### 5. (Optional) Add User Message Mapping
+
+```dart
+// In lib/presentation/shared/extensions/failure_extensions.dart
+extension FailureMessage on Failure {
+  String toUserMessage(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    if (kDebugMode) return '$code: $message';
+
+    return switch (this) {
+      ScheduleOverlapFailure() => l10n.scheduleOverlapError,
+      // ... other mappings
+      _ => l10n.error,
+    };
+  }
+}
+```
+
+#### 6. Add Localized Strings
+
+```json
+// lib/l10n/app_en.arb
+{
+  "scheduleOverlapError": "This schedule overlaps with another appointment",
+  "@scheduleOverlapError": {
+    "description": "Error shown when schedule times conflict"
+  }
+}
+
+// lib/l10n/app_ko.arb
+{
+  "scheduleOverlapError": "다른 약속과 시간이 겹쳤어요"
+}
+```
+
+## Migration Checklist
+
+When converting existing code to use Result pattern:
+
+### Repository
+
+- [ ] Update interface to return `Result<T, Failure>`
+- [ ] Add `ErrorLoggerService` dependency injection
+- [ ] Wrap operations in `try/catch`
+- [ ] Map exceptions using `ExceptionToFailureMapper`
+- [ ] Log failures before returning
+- [ ] Return `Success(value)` or `Err(failure)`
+- [ ] Update stream types to `Stream<Result<T, Failure>>`
+
+### Use Case
+
+- [ ] Update return type to `Result<T, Failure>`
+- [ ] Remove `try/catch` blocks (let Result flow through)
+- [ ] Use `.map()` / `.flatMap()` for transformations
+- [ ] For streams, yield `Result` values
+
+### BLoC/Cubit
+
+- [ ] Add `Failure? failure` field to state
+- [ ] Update event handlers to use `.fold()`
+- [ ] Emit state with failure on error path
+- [ ] Clear failure on success path
+- [ ] For `emit.forEach`, unwrap Result in `onData`
+
+### UI/Widget
+
+- [ ] Check `state.failure` and show `ErrorMessageBubble`
+- [ ] Use `failure.toUserMessage(context)` for display
+
+### Tests
+
+- [ ] Test both success and failure paths
+- [ ] Use `expect(result.isSuccess, true)` / `expect(result.isFailure, true)`
+- [ ] Use `result.fold()` or `.failureOrNull` to inspect failure
+- [ ] Mock repositories to return specific failures
+- [ ] Verify UI shows ErrorMessageBubble for failure states
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: "Result type doesn't match"
+
+```
+Error: The argument type 'Result<X, Failure>' can't be assigned
+to the parameter type 'X'
+```
+
+**Solution**: You're passing a Result where the unwrapped value is expected. Use `.fold()`, `.successOrNull`, or await and handle the Result.
+
+**Issue**: "Can't return void from Result function"
+
+```
+Error: A value of type 'Result<Unit, Failure>' can't be returned
+from the method because it has a return type of 'Future<void>'
+```
+
+**Solution**: Change return type from `Future<void>` to `Future<Result<Unit, Failure>>`.
+
+**Issue**: "Failures not showing in UI"
+**Solution**:
+
+1. Check BLoC state includes `Failure? failure` field
+2. Verify event handler calls `emit(state.copyWith(failure: failure))`
+3. Ensure UI checks `state.failure != null` and renders ErrorMessageBubble
+
+**Issue**: "Tests failing after migration"
+**Solution**: Update test expectations to check `Result` instead of raw values:
+
+```dart
+// Before
+expect(await useCase.call(), someValue);
+
+// After
+final result = await useCase.call();
+expect(result.isSuccess, true);
+expect(result.successOrNull, someValue);
+```
+
+## Advanced Topics
+
+### Custom Result Extension Methods
+
+You can add domain-specific extensions:
+
+```dart
+extension ResultExtensions<S, F> on Result<S, F> {
+  // Get value or provide default
+  S getOrDefault(S defaultValue) {
+    return successOrNull ?? defaultValue;
+  }
+
+  // Convert to nullable without throwing
+  S? toNullable() => successOrNull;
+
+  // Log failure and return null
+  S? orLogAndNull(ErrorLoggerService logger) {
+    if (this is Err<S, F>) {
+      logger.log((this as Err<S, F>).failure);
+    }
+    return successOrNull;
+  }
+}
+```
+
+### Combining Multiple Results
+
+```dart
+// Sequential (short-circuit on first failure)
+Future<Result<Unit, Failure>> updateBoth() async {
+  return (await _repo1.update())
+      .flatMap((_) => _repo2.update());
+}
+
+// Parallel (collect all failures)
+Future<Result<Unit, Failure>> updateMultiple() async {
+  final results = await Future.wait([
+    _repo1.update(),
+    _repo2.update(),
+    _repo3.update(),
+  ]);
+
+  final failures = results
+      .where((r) => r.isFailure)
+      .map((r) => r.failureOrNull!)
+      .toList();
+
+  if (failures.isNotEmpty) {
+    return Err(UnexpectedFailure(
+      message: 'Multiple operations failed: ${failures.length}',
+      code: 'MULTIPLE_FAILURES',
+    ));
+  }
+
+  return Success(unit);
+}
+```
+
+### Retry Logic
+
+```dart
+Future<Result<T, Failure>> withRetry<T>(
+  Future<Result<T, Failure>> Function() operation, {
+  int maxAttempts = 3,
+  Duration delay = const Duration(seconds: 1),
+}) async {
+  var attempts = 0;
+
+  while (attempts < maxAttempts) {
+    final result = await operation();
+
+    if (result.isSuccess) return result;
+
+    // Retry on network failures only
+    if (result.failureOrNull is NetworkFailure && attempts < maxAttempts - 1) {
+      attempts++;
+      await Future.delayed(delay * attempts);
+      continue;
+    }
+
+    return result;
+  }
+
+  return Err(NetworkFailure.timeout(
+    message: 'Operation failed after $maxAttempts attempts',
+  ));
+}
+```
+
+## Summary
+
+### Key Takeaways
+
+1. **Result type** makes error handling explicit and type-safe
+2. **Failure hierarchy** provides structured error information across layers
+3. **Automatic logging** captures errors in production without manual intervention
+4. **Environment-aware messaging** shows details to developers, friendly messages to users
+5. **Testing** is straightforward with clear success/failure paths
+6. **Migration** is systematic: update signatures layer-by-layer from data → domain → presentation
+
+### Quick Reference
+
+```dart
+// Return Result from operations
+Future<Result<Unit, Failure>> operation() async {
+  try {
+    // ... do work
+    return Success(unit);
+  } catch (e, stackTrace) {
+    final failure = ExceptionToFailureMapper.map(e, stackTrace);
+    await _logger.log(failure);
+    return Err(failure);
+  }
+}
+
+// Handle Result in BLoC
+result.fold(
+  onSuccess: (value) => emit(state.copyWith(data: value, failure: null)),
+  onFailure: (failure) => emit(state.copyWith(failure: failure)),
+);
+
+// Test Result
+expect(result.isSuccess, true);
+expect(result.successOrNull, expectedValue);
+
+// Or
+result.fold(
+  onSuccess: (value) => expect(value, expectedValue),
+  onFailure: (_) => fail('Should not fail'),
+);
+```
+
+### Benefits
+
+✅ **Compiler-enforced error handling** - Cannot forget to handle failures  
+✅ **Clear failure propagation** - Errors flow upward through Result types  
+✅ **Better debugging** - Structured failures with codes and context  
+✅ **Production safety** - Automatic logging without manual try/catch everywhere  
+✅ **Testability** - Easy to test both success and failure scenarios  
+✅ **Maintainability** - Consistent pattern across entire codebase

--- a/Home.md
+++ b/Home.md
@@ -1,1 +1,46 @@
-Welcome to the OnTime-front wiki!
+# OnTime Flutter Project Wiki
+
+Welcome to the OnTime-front project documentation! This wiki contains everything new developers need to understand and contribute to the project.
+
+## 📚 Documentation Index
+
+### Getting Started
+- [Wiki Management Guide](./Wiki-Management.md) - How to modify and upload wiki content
+- [Project Architecture](./Architecture.md) - Understanding the project structure
+- [Git Workflow](./Git.md) - Git strategy and commit message formats
+
+### Technical Deep Dives
+- [Error Handling System](./Error-Handling-Result-System.md) - Result-based error handling architecture
+- [Schedule Timer System](./Schedule-Timer-System.md) - Automatic timer and preparation tracking
+
+### Development Resources
+- 🚧 **Getting Started Guide** *(Coming Soon)* - Setup and installation
+- 🚧 **Development Guide** *(Coming Soon)* - Development workflow and best practices
+- 🚧 **API Documentation** *(Coming Soon)* - Backend API reference
+- 🚧 **Testing Guide** *(Coming Soon)* - Testing procedures and guidelines
+
+## 🎯 Quick Links
+
+- [Main Repository](https://github.com/DevKor-github/OnTime-front)
+- [Issues](https://github.com/DevKor-github/OnTime-front/issues)
+- [Pull Requests](https://github.com/DevKor-github/OnTime-front/pulls)
+- [Widgetbook](https://on-time-front-widgetbook.web.app/)
+
+## 🤝 Contributing
+
+New to the project? Start here:
+
+1. **Read the [Wiki Management Guide](./Wiki-Management.md)** to understand how documentation works
+2. **Review the [Architecture](./Architecture.md)** to understand the project structure
+3. **Follow the [Git Workflow](./Git.md)** for consistent development practices
+4. **Set up your development environment** *(guide coming soon)*
+
+## 📝 Need Help?
+
+- Create an issue for bugs or feature requests
+- Ask questions in team discussions
+- Contribute to documentation improvements
+
+---
+
+*This wiki is maintained by the OnTime development team and integrated with the main repository.*

--- a/Preparation-Form-Structure.md
+++ b/Preparation-Form-Structure.md
@@ -1,0 +1,303 @@
+# Preparation Form Structure
+
+This document outlines the architecture, component structure, and responsibilities of the Preparation Form used in the application. This form is utilized in two primary contexts:
+
+1.  **Schedule Creation**: Defining preparation steps for a new schedule.
+2.  **My Page**: Editing default preparation and spare time settings.
+
+## Architecture Overview
+
+The preparation form is built using the **BLoC (Business Logic Component)** pattern for state management and **Flutter Widgets** for UI composition. It relies on a primary BLoC (`PreparationFormBloc`) to manage the list of preparation steps and a temporary Cubit (`PreparationStepFormCubit`) for handling the input of new steps before they are committed to the list.
+
+### Usage Scenarios
+
+| Feature             | Screen                           | Parent Bloc                           | Description                                                                                                                |
+| :------------------ | :------------------------------- | :------------------------------------ | :------------------------------------------------------------------------------------------------------------------------- |
+| **Schedule Create** | `PreparationEditForm`            | N/A                                   | Used directly within the schedule creation flow. Initializes `PreparationFormBloc` with an existing entity or empty state. |
+| **My Page**         | `PreparationSpareTimeEditScreen` | `DefaultPreparationSpareTimeFormBloc` | Used to edit user's default settings. Wraps the form logic and handles saving to the user repository.                      |
+
+## Class Responsibilities
+
+### State Management (Blocs & Cubits)
+
+#### `PreparationFormBloc`
+
+**Responsibility**: Manages the main state of the preparation form.
+
+- **State**: Holds the list of `PreparationStepFormState` (the steps), validation status (`isValid`), and the current form status (e.g., `adding`, `initial`).
+- **Actions**:
+  - Handling edits to existing steps (name, time).
+  - Reordering steps.
+  - Removing steps.
+  - Adding new steps (committed from the cubit).
+  - Validating the entire list.
+
+#### `DefaultPreparationSpareTimeFormBloc`
+
+**Responsibility**: Manages the "My Page" specific logic for editing default preparation and spare time.
+
+- **State**: Holds the user's current default preparation entity and spare time duration.
+- **Actions**:
+  - Fetching existing defaults on load.
+  - Updating spare time (increase/decrease).
+  - Submitting the final `PreparationEntity` (derived from `PreparationFormBloc`) and spare time to the backend/database.
+
+#### `PreparationStepFormCubit`
+
+**Responsibility**: Manages the _transient_ state of a new preparation step being created.
+
+- **Scope**: Created only when the user clicks "add step" and is typing in the new step details.
+- **State**: Holds the `PreparationNameInputModel` and `PreparationTimeInputModel` for the new step.
+- **Actions**:
+  - Validating real-time input for the new step.
+  - Triggering the "save" action which adds the step to the parent `PreparationFormBloc`.
+
+### UI Components
+
+#### `PreparationFormCreateList`
+
+**Responsibility**: The main container widget for the preparation form UI.
+
+- **Composition**:
+  - Displays the list of existing steps using `PreparationFormReorderableList`.
+  - Conditionally displays the input field for a new step using `PreparationStepFormCubit` and `PreparationFormListField` when in `adding` mode.
+  - Displays the "Add" button (`CreateIconButton`).
+
+#### `PreparationFormReorderableList`
+
+**Responsibility**: Renders the list of existing steps with reordering and deletion capabilities.
+
+- **Features**:
+  - Wraps `ReorderableListView` to allow drag-and-drop sorting.
+  - Implements `SwipeActionCell` for swipe-to-delete functionality.
+  - Delegates rendering of individual items to `PreparationFormListField`.
+
+#### `PreparationFormListField`
+
+**Responsibility**: Renders a single preparation step row.
+
+- **Usage**: Used for both _existing_ items (in the list) and the _new_ item (in the add section).
+- **Features**:
+  - Displays the drag handle (if reorderable).
+  - Displays the name input field (`TextFormField`).
+  - Displays the time input widget (`PreparationTimeInput`).
+  - Handles focus management and "save on submit/blur" logic for new items.
+
+#### `PreparationTimeInput`
+
+**Responsibility**: A specialized widget for selecting duration.
+
+- **Features**:
+  - Displays the current duration in minutes.
+  - Opens a `CupertinoPickerModal` on tap for selecting the time.
+
+## Component Diagrams
+
+The following diagrams illustrate the relationships and data flow for each specific usage context.
+
+### Diagram 1: Schedule Create Flow
+
+In the Schedule Create flow, `PreparationEditForm` directly initializes and interacts with `PreparationFormBloc`. This is a simpler flow focused on defining steps for a specific schedule.
+
+```mermaid
+classDiagram
+    class PreparationEditForm {
+        +PreparationEntity initialData
+    }
+    class PreparationFormBloc {
+        +state: PreparationFormState
+    }
+    class Components {
+        PreparationFormCreateList
+    }
+
+    PreparationEditForm --> PreparationFormBloc : 1. Init with Entity
+    PreparationEditForm ..> Components : Renders
+    Components --> PreparationFormBloc : 2. User Edits
+    PreparationEditForm --> PreparationFormBloc : 3. Checks Validity
+```
+
+### Diagram 2: My Page Flow
+
+In the My Page flow, `PreparationSpareTimeEditScreen` first uses `DefaultPreparationSpareTimeFormBloc` to load the user's default settings. It then initializes `PreparationFormBloc` with these defaults. The final submission goes back through `DefaultPreparationSpareTimeFormBloc` to save changes.
+
+```mermaid
+classDiagram
+    class PreparationSpareTimeEditScreen
+    class DefaultPreparationSpareTimeFormBloc {
+        +LoadDefaults()
+        +SaveDefaults()
+    }
+    class PreparationFormBloc {
+        +state: PreparationFormState
+    }
+
+    PreparationSpareTimeEditScreen --> DefaultPreparationSpareTimeFormBloc : 1. Load User Defaults
+    DefaultPreparationSpareTimeFormBloc --> PreparationSpareTimeEditScreen : 2. Returns Data
+    PreparationSpareTimeEditScreen --> PreparationFormBloc : 3. Init with Defaults
+    PreparationSpareTimeEditScreen --> DefaultPreparationSpareTimeFormBloc : 4. Submit Updated Data
+```
+
+### Overall Component Relationships
+
+This diagram shows the detailed relationships between screens, state management classes, and UI components across the system.
+
+```mermaid
+classDiagram
+    %% Contexts
+    class PreparationSpareTimeEditScreen {
+        +Build()
+    }
+    class PreparationEditForm {
+        +Build()
+    }
+
+    %% State Management
+    class DefaultPreparationSpareTimeFormBloc {
+        +DefaultPreparationSpareTimeFormState state
+        +add(FormSubmitted)
+    }
+
+    class PreparationFormBloc {
+        +PreparationFormState state
+        +add(StepCreated)
+        +add(StepRemoved)
+        +add(StepReordered)
+    }
+
+    class PreparationStepFormCubit {
+        +PreparationStepFormState state
+        +nameChanged()
+        +timeChanged()
+        +preparationStepSaved()
+    }
+
+    %% Components
+    class PreparationFormCreateList {
+        +onNameChanged
+        +onCreationRequested
+    }
+
+    class PreparationFormReorderableList {
+        +onReorder
+        +onTimeChanged
+    }
+
+    class PreparationFormListField {
+        +TextFormField name
+        +PreparationTimeInput time
+    }
+
+    class PreparationTimeInput {
+        +CupertinoPickerModal picker
+    }
+
+    %% Relationships
+    PreparationSpareTimeEditScreen ..> DefaultPreparationSpareTimeFormBloc : Provides and Consumes
+    PreparationSpareTimeEditScreen ..> PreparationFormBloc : Provides and Consumes
+
+    PreparationEditForm ..> PreparationFormBloc : Provides and Consumes
+
+    PreparationFormCreateList ..> PreparationFormBloc : Consumes
+    PreparationFormCreateList ..> PreparationStepFormCubit : Provides Scope Adding
+
+    PreparationStepFormCubit --> PreparationFormBloc : Adds Step Event
+
+    PreparationFormCreateList *-- PreparationFormReorderableList : Contains
+    PreparationFormCreateList *-- PreparationFormListField : Contains (New Step)
+
+    PreparationFormReorderableList *-- PreparationFormListField : Contains (List Items)
+
+    PreparationFormListField *-- PreparationTimeInput : Contains
+```
+
+## Data Flow & Communication
+
+The components communicate using a combination of **Bloc Events** (upward), **Callbacks** (upward), and **Widget Properties** (downward).
+
+### Communication Pattern
+
+1.  **Downward (Data Passing)**:
+
+    - Parent widgets pass state and data down to children via constructor arguments (parameters).
+    - Example: `PreparationFormCreateList` receives the list of steps (`preparationStepList`) from `PreparationFormBloc`'s state and passes individual steps down to `PreparationFormReorderableList` and `PreparationFormListField`.
+
+2.  **Upward (Events & Actions)**:
+
+    - Child widgets notify parents of user interactions via callback functions (e.g., `onNameChanged`).
+    - These callbacks eventually trigger BLoC events (e.g., `PreparationFormPreparationStepNameChanged`) to update the global state.
+    - For complex temporary state (like adding a new item), a Cubit (`PreparationStepFormCubit`) is used to hold the state locally before "committing" it up to the main BLoC.
+
+3.  **Upward (Form Submission)**:
+    - When the form is complete (saved), the UI extracts the final state from the `PreparationFormBloc`.
+    - The UI then passes this data "up" to the navigation stack (pop) or to a parent BLoC (`DefaultPreparationSpareTimeFormBloc`).
+    - _Note: `PreparationFormBloc` does not directly call its parent context; the UI acts as the coordinator._
+
+### Data Flow Diagrams
+
+#### 1. Editing an Existing Step (List Item)
+
+This flow illustrates how a change in a child component updates the central BLoC state.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ListField as PreparationFormListField
+    participant CreateList as PreparationFormCreateList
+    participant Bloc as PreparationFormBloc
+
+    User->>ListField: Types Name "Pack Bag"
+    ListField->>CreateList: onNameChanged(index, "Pack Bag")
+    Note right of ListField: Callback passed up
+    CreateList->>Bloc: add(PreparationFormPreparationStepNameChanged)
+    Bloc-->>CreateList: New State (Updated List)
+    CreateList-->>ListField: Re-renders with new value
+```
+
+#### 2. Adding a New Step
+
+This flow shows the interaction between the temporary Cubit and the main BLoC.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ListField as PreparationFormListField (New)
+    participant Cubit as PreparationStepFormCubit
+    participant Bloc as PreparationFormBloc
+
+    User->>ListField: Types Name "Shower"
+    ListField->>Cubit: nameChanged("Shower")
+    Cubit-->>ListField: Emits new valid state
+
+    User->>ListField: Submits / Blurs
+    ListField->>Cubit: preparationStepSaved()
+    Cubit->>Bloc: add(PreparationFormPreparationStepCreated)
+    Note right of Cubit: Commit to main list
+    Bloc-->>ListField: New State (List has "Shower")
+```
+
+#### 3. Submitting the Form
+
+This flow shows how the data leaves `PreparationFormBloc` and goes to the parent context.
+
+```mermaid
+sequenceDiagram
+    participant Parent as Parent (Nav/Bloc)
+    participant UI as Screen Widget
+    participant Bloc as PreparationFormBloc
+
+    loop Editing
+        Bloc->>UI: Emits State (Updates View)
+    end
+
+    Note over UI: User clicks "Save"
+
+    UI->>Bloc: Read Current State
+    Bloc-->>UI: Return State.preparationStepList
+
+    alt Schedule Create
+        UI->>Parent: Navigator.pop(result)
+    else My Page
+        UI->>Parent: ParentBloc.add(FormSubmitted(result))
+    end
+```

--- a/Schedule-Timer-System.md
+++ b/Schedule-Timer-System.md
@@ -1,0 +1,132 @@
+# Schedule Timer System
+
+The OnTime app includes an automatic timer system within the `ScheduleBloc` that manages precise timing for schedule start notifications. This system ensures that schedule start events are triggered at the exact scheduled time.
+
+## 🎯 Overview
+
+The timer system automatically:
+
+- Starts when an upcoming schedule is received
+- Triggers a `ScheduleStarted` event at exactly x minute 00 seconds
+- Handles proper cleanup and timer management
+- Ensures thread-safety and prevents memory leaks
+
+## 🔄 Timer Flow
+
+```mermaid
+sequenceDiagram
+    participant UC as UseCase
+    participant SB as ScheduleBloc
+    participant Timer as Timer
+    participant State as State
+
+    UC->>SB: ScheduleUpcomingReceived(schedule)
+    SB->>SB: Cancel existing timer
+    SB->>SB: _startScheduleTimer(schedule)
+    SB->>Timer: Create Timer(targetTime)
+    Note over Timer: Timer set for schedule.scheduleTime<br/>at x minute 00 seconds
+    SB->>State: emit(ScheduleState.upcoming/ongoing)
+
+    Timer-->>SB: Timer fires at exact minute
+    SB->>SB: add(ScheduleStarted())
+    SB->>SB: _onScheduleStarted()
+    SB->>State: emit(ScheduleState.started)
+
+    Note over SB: Timer cleanup on close()<br/>or new schedule received
+```
+
+## 📋 Implementation Details
+
+### Key Components
+
+1. **Timer Management**
+
+   - `_scheduleStartTimer`: Dart Timer instance that handles the countdown
+   - `_currentScheduleId`: Tracks the active schedule to prevent stale events
+
+2. **Event Handling**
+
+   - `ScheduleUpcomingReceived`: Triggers timer setup
+   - `ScheduleStarted`: Fired when timer completes
+
+3. **State Transitions**
+   - `upcoming` → `started`: When timer fires for upcoming schedules
+   - `ongoing` → `started`: When timer fires for preparation-in-progress schedules
+
+### Timer Calculation
+
+The timer calculates the exact target time as:
+
+```dart
+final targetTime = DateTime(
+  scheduleTime.year,
+  scheduleTime.month,
+  scheduleTime.day,
+  scheduleTime.hour,
+  scheduleTime.minute,
+  0, // Always trigger at 00 seconds
+  0, // 0 milliseconds
+);
+```
+
+### Safety Features
+
+- **Timer Cancellation**: Previous timers are automatically cancelled when new schedules arrive
+- **Bloc State Validation**: Timer callbacks verify the bloc is still active before firing events
+- **Schedule ID Matching**: Events only fire for the currently tracked schedule
+- **Proper Cleanup**: All timers are cancelled when the bloc is disposed
+
+## 🛡️ Error Handling
+
+The system includes several safety mechanisms:
+
+1. **Past Schedule Protection**: Timers are not set for schedules in the past
+2. **Bloc Lifecycle Management**: Timer callbacks check `isClosed` before adding events
+3. **Memory Leak Prevention**: All timers are properly cancelled in `close()`
+4. **Race Condition Prevention**: Schedule ID tracking prevents stale timer events
+
+## 📱 Usage Example
+
+The timer system works automatically within the `ScheduleBloc`:
+
+```dart
+// When a new schedule is received
+bloc.add(ScheduleSubscriptionRequested());
+
+// The bloc will:
+// 1. Listen for upcoming schedules
+// 2. Automatically start timers for each schedule
+// 3. Emit ScheduleStarted events at the exact scheduled time
+// 4. Transition to 'started' state
+
+// Listen for state changes
+bloc.stream.listen((state) {
+  if (state.status == ScheduleStatus.started) {
+    // Handle schedule start (e.g., show notification, start tracking)
+  }
+});
+```
+
+## 🔧 Configuration
+
+The timer system requires no additional configuration and works automatically with:
+
+- Any `ScheduleWithPreparationEntity` that has a valid `scheduleTime`
+- Both upcoming and ongoing schedule states
+- All timezone-aware DateTime calculations
+
+## 📊 Performance Considerations
+
+- **Single Timer**: Only one timer runs at a time per bloc instance
+- **Minimal Memory Footprint**: Timers are created/destroyed as needed
+- **Precise Timing**: Uses Dart's native Timer for accurate scheduling
+- **Efficient Cleanup**: No lingering resources after bloc disposal
+
+## 🚀 Future Enhancements
+
+Potential improvements to consider:
+
+- Multiple concurrent schedule timers
+- Configurable timer precision (seconds vs milliseconds)
+- Timer persistence across app restarts
+- Integration with system-level scheduling APIs

--- a/Wiki-Management.md
+++ b/Wiki-Management.md
@@ -1,0 +1,335 @@
+# Wiki Management Guide
+
+This guide explains how to modify, create, and upload wiki documentation for the OnTime Flutter project.
+
+## 📖 Overview
+
+Our project wiki is integrated directly into the main repository using Git subtrees. This means:
+
+- Wiki content is stored in the `docs/` folder
+- Changes are version-controlled with the main codebase
+- Documentation stays in sync with code changes
+- New developers can access docs offline
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- Git configured with your GitHub account
+- Access to the OnTime-front repository
+- Basic knowledge of Markdown
+
+### Current Wiki Structure
+
+```
+docs/
+├── Architecture.md      # Project structure and architecture
+├── Git.md              # Git workflow and commit guidelines
+├── Home.md             # Wiki homepage
+└── Wiki-Management.md  # This guide
+```
+
+## ✏️ Modifying Existing Wiki Pages
+
+### 1. Edit Files Locally
+
+Navigate to the `docs/` folder and edit any `.md` file:
+
+```bash
+# Navigate to docs folder
+cd docs/
+
+# Edit existing files with your preferred editor
+code Architecture.md
+# or
+vim Home.md
+# or
+nano Git.md
+```
+
+### 2. Preview Your Changes
+
+Use any Markdown preview tool or your IDE's built-in preview to review changes before committing.
+
+### 3. Commit Changes to Main Repository
+
+```bash
+# From project root
+git add docs/
+git commit -m "docs: update [filename] with [brief description]"
+```
+
+## 📝 Creating New Wiki Pages
+
+### 1. Create New Markdown File
+
+```bash
+# From project root
+touch docs/New-Page-Name.md
+```
+
+### 2. Add Content
+
+Use standard Markdown syntax. Here's a template:
+
+````markdown
+# Page Title
+
+Brief description of what this page covers.
+
+## Section 1
+
+Content here...
+
+### Subsection
+
+More detailed content...
+
+## Code Examples
+
+\```dart
+// Flutter/Dart code examples
+void main() {
+print('Hello OnTime!');
+}
+\```
+
+## Links and References
+
+- [Internal Link](./Other-Page.md)
+- [External Link](https://flutter.dev)
+````
+
+### 3. Update Navigation
+
+If creating a major new page, consider updating `Home.md` to include a link to your new page.
+
+## 🔄 Syncing with GitHub Wiki
+
+Our project uses Git subtree to keep the main repository and GitHub wiki synchronized.
+
+### Push Local Changes to GitHub Wiki
+
+After committing your documentation changes to the main repository:
+
+```bash
+# Push documentation changes to GitHub wiki
+git subtree push --prefix=docs wiki master
+```
+
+**What this does:**
+
+- Takes all changes from the `docs/` folder
+- Pushes them to the GitHub wiki repository
+- Updates the online wiki at `https://github.com/DevKor-github/OnTime-front/wiki`
+
+### Force push to GitHub Wiki (use with extreme caution)
+
+Sometimes the wiki remote can get out of sync (e.g., someone edited pages directly on GitHub and you want to **overwrite** the wiki with your local `docs/` state). In that case, you _can_ force push — but note:
+
+- **This rewrites the wiki repo history** and can discard other people's edits.
+- Only do this if the team agrees and you’re sure your local `docs/` is the desired source of truth.
+- Consider pulling first (`git subtree pull --prefix=docs wiki master --squash`) to avoid needing force.
+
+`git subtree push` doesn’t accept `--force`, so you force-push by splitting and pushing the split commit:
+
+```bash
+# 0) Make sure your docs changes are committed
+git status
+
+# 1) Create a split commit containing only docs/ history
+git subtree split --prefix=docs -b docs/wiki-split
+
+# 2) Force push that split to the wiki remote
+git push wiki docs/wiki-split:master --force
+```
+
+If you don’t want to keep the temporary branch around:
+
+```bash
+# Create the split commit SHA and force push it directly
+SPLIT_SHA=$(git subtree split --prefix=docs HEAD)
+git push wiki "$SPLIT_SHA":master --force-with-lease
+```
+
+Afterwards, it’s safe to delete the temp branch:
+
+```bash
+git branch -D docs/wiki-split
+```
+
+### Pull Changes from GitHub Wiki
+
+If someone edits the wiki directly on GitHub:
+
+```bash
+# Pull changes from GitHub wiki to local docs folder
+git subtree pull --prefix=docs wiki master --squash
+```
+
+**When to use this:**
+
+- Someone edited wiki pages directly on GitHub
+- You want to sync external wiki changes to your local repository
+- Before starting major documentation work (to avoid conflicts)
+
+### Troubleshooting subtree sync
+
+**Issue: `fatal: working tree has modifications. Cannot add.`**
+
+`git subtree pull` requires a clean working tree.
+
+```bash
+git status
+# then either commit or stash
+git add docs/
+git commit -m "docs: WIP before subtree pull"
+# or
+git stash -u
+```
+
+**Issue: `fatal: refusing to merge unrelated histories`**
+
+This happens when your local `docs/` history and the GitHub wiki repository don’t share a common subtree “join” history (often because `docs/` wasn’t originally introduced via `git subtree add`, or the wiki was rewritten independently).
+
+Pick one of these paths:
+
+1. **Overwrite wiki with local `docs/`** (recommended if `docs/` is the source of truth):
+
+```bash
+git status
+git subtree split --prefix=docs -b docs/wiki-split
+git push wiki docs/wiki-split:master --force-with-lease
+git branch -D docs/wiki-split
+```
+
+2. **Import wiki into this repo (one-time) and then merge your local docs** (recommended if the wiki is the source of truth):
+
+```bash
+# Backup current docs
+git mv docs docs_local
+git commit -m "chore(docs): backup local docs before importing wiki"
+
+# Bring wiki content into docs/ (establishes subtree join history)
+git subtree add --prefix=docs wiki master --squash
+
+# Now manually reconcile docs_local/ -> docs/ as needed, then:
+rm -rf docs_local
+git add -A
+git commit -m "docs: reconcile local docs with wiki import"
+```
+
+## 🔧 Advanced Workflows
+
+### Working on Documentation-Heavy Features
+
+1. **Create a documentation branch:**
+
+   ```bash
+   git checkout -b docs/feature-name
+   ```
+
+2. **Make your documentation changes**
+
+3. **Commit and push to main repository:**
+
+   ```bash
+   git add docs/
+   git commit -m "docs: add documentation for feature-name"
+   git push origin docs/feature-name
+   ```
+
+4. **Create PR for review**
+
+5. **After PR merge, sync to wiki:**
+   ```bash
+   git checkout main
+   git pull origin main
+   git subtree push --prefix=docs wiki master
+   ```
+
+### Handling Merge Conflicts
+
+If you encounter conflicts when pulling from the wiki:
+
+1. **Resolve conflicts in the docs/ folder**
+2. **Commit the resolution:**
+   ```bash
+   git add docs/
+   git commit -m "docs: resolve wiki merge conflicts"
+   ```
+3. **Push resolved changes:**
+   ```bash
+   git subtree push --prefix=docs wiki master
+   ```
+
+## 📋 Documentation Best Practices
+
+### File Naming Convention
+
+- Use kebab-case: `Getting-Started.md`, `API-Guide.md`
+- Be descriptive but concise
+- Avoid spaces and special characters
+
+### Content Guidelines
+
+1. **Start with a clear title and overview**
+2. **Use consistent heading hierarchy (H1 → H2 → H3)**
+3. **Include code examples where relevant**
+4. **Add links to related documentation**
+5. **Keep content up-to-date with code changes**
+
+### Markdown Tips
+
+- Use `backticks` for inline code
+- Use triple backticks with language for code blocks
+- Use `**bold**` for emphasis
+- Use `> blockquotes` for important notes
+- Create tables for structured data
+
+## 🛠️ Troubleshooting
+
+### Common Issues
+
+**Issue: `fatal: working tree has modifications`**
+
+```bash
+# Solution: Commit or stash changes first
+git add .
+git commit -m "docs: work in progress"
+# or
+git stash
+```
+
+**Issue: Wiki changes not appearing on GitHub**
+
+```bash
+# Solution: Ensure you pushed to the wiki remote
+git subtree push --prefix=docs wiki master
+```
+
+**Issue: Local docs out of sync**
+
+```bash
+# Solution: Pull latest changes from wiki
+git subtree pull --prefix=docs wiki master --squash
+```
+
+### Getting Help
+
+- Check Git status: `git status`
+- View recent commits: `git log --oneline -10`
+- Check remotes: `git remote -v`
+- Ask team members or create an issue
+
+## 🎯 Recommended Documentation
+
+For new developers, consider creating these essential pages:
+
+- [ ] **Getting-Started.md** - Setup and installation guide
+- [ ] **Development-Guide.md** - Development workflow and tools
+- [ ] **API-Documentation.md** - Backend API reference
+- [ ] **Testing-Guide.md** - How to run and write tests
+- [ ] **Deployment.md** - Build and deployment procedures
+- [ ] **Contributing.md** - Contribution guidelines
+- [ ] **Troubleshooting.md** - Common issues and solutions

--- a/lib/presentation/alarm/components/alarm_graph_animator.dart
+++ b/lib/presentation/alarm/components/alarm_graph_animator.dart
@@ -3,10 +3,14 @@ import 'package:on_time_front/presentation/alarm/components/alarm_graph_componen
 
 class AlarmGraphAnimator extends StatefulWidget {
   final double progress;
+  final Color backgroundColor;
+  final Color progressColor;
 
   const AlarmGraphAnimator({
     super.key,
     required this.progress,
+    required this.backgroundColor,
+    required this.progressColor,
   });
 
   @override
@@ -72,6 +76,8 @@ class _AlarmGraphAnimatorState extends State<AlarmGraphAnimator>
           size: const Size(230, 115),
           painter: AlarmGraphComponent(
             progress: _progressAnimation.value,
+            backgroundColor: widget.backgroundColor,
+            progressColor: widget.progressColor,
           ),
         );
       },

--- a/lib/presentation/alarm/components/alarm_graph_component.dart
+++ b/lib/presentation/alarm/components/alarm_graph_component.dart
@@ -3,9 +3,13 @@ import 'dart:math' as math;
 
 class AlarmGraphComponent extends CustomPainter {
   final double progress; // 전체 진행률
+  final Color backgroundColor;
+  final Color progressColor;
 
   AlarmGraphComponent({
     required this.progress,
+    required this.backgroundColor,
+    required this.progressColor,
   });
 
   @override
@@ -21,14 +25,14 @@ class AlarmGraphComponent extends CustomPainter {
 
     // 채워지기 전 색
     final Paint backgroundPaint = Paint()
-      ..color = const Color(0xff3D54BC)
+      ..color = backgroundColor
       ..strokeWidth = 12
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round;
 
     // 채워진 후 색
     final Paint progressPaint = Paint()
-      ..color = const Color(0xffDCE3FF)
+      ..color = progressColor
       ..strokeWidth = 12
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round;

--- a/lib/presentation/alarm/components/alarm_screen_bottom_section.dart
+++ b/lib/presentation/alarm/components/alarm_screen_bottom_section.dart
@@ -93,13 +93,30 @@ class _EndPreparationButtonSection extends StatelessWidget {
   });
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    final baseButtonStyle = theme.elevatedButtonTheme.style;
     return Container(
       color: Colors.white,
       padding: const EdgeInsets.only(top: 16, bottom: 20),
-      child: Center(
-        child: ElevatedButton(
-          onPressed: onEndPreparation,
-          child: Text(AppLocalizations.of(context)!.finishPreparation),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: onEndPreparation,
+            style: baseButtonStyle?.copyWith(
+              backgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.disabled)) {
+                  return colorScheme.surfaceDim;
+                }
+                return colorScheme.primary;
+              }),
+              foregroundColor:
+                  WidgetStatePropertyAll<Color>(colorScheme.onPrimary),
+            ),
+            child: Text(AppLocalizations.of(context)!.finishPreparation),
+          ),
         ),
       ),
     );

--- a/lib/presentation/alarm/components/alarm_screen_top_section.dart
+++ b/lib/presentation/alarm/components/alarm_screen_top_section.dart
@@ -21,6 +21,7 @@ class AlarmScreenTopSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       children: [
         _BeforeOutTimeText(
@@ -31,6 +32,10 @@ class AlarmScreenTopSection extends StatelessWidget {
           preparationName: preparationName,
           preparationRemainingTime: preparationRemainingTime,
           progress: progress,
+          highlightColor: colorScheme.primaryContainer,
+          graphBackgroundColor:
+              colorScheme.onPrimaryContainer.withValues(alpha: 0.35),
+          graphProgressColor: colorScheme.primaryContainer,
         ),
       ],
     );
@@ -66,11 +71,17 @@ class _AlarmGraphSection extends StatelessWidget {
   final String preparationName;
   final int preparationRemainingTime;
   final double progress;
+  final Color highlightColor;
+  final Color graphBackgroundColor;
+  final Color graphProgressColor;
 
   const _AlarmGraphSection({
     required this.preparationName,
     required this.preparationRemainingTime,
     required this.progress,
+    required this.highlightColor,
+    required this.graphBackgroundColor,
+    required this.graphProgressColor,
   });
 
   @override
@@ -80,7 +91,11 @@ class _AlarmGraphSection extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          AlarmGraphAnimator(progress: progress),
+          AlarmGraphAnimator(
+            progress: progress,
+            backgroundColor: graphBackgroundColor,
+            progressColor: graphProgressColor,
+          ),
           Padding(
             padding: const EdgeInsets.only(top: 100),
             child: Column(
@@ -88,18 +103,18 @@ class _AlarmGraphSection extends StatelessWidget {
               children: [
                 Text(
                   preparationName,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.bold,
-                    color: Color(0xffDCE3FF),
+                    color: highlightColor,
                   ),
                 ),
                 const SizedBox(height: 8),
                 Text(
                   formatTimeTimer(preparationRemainingTime),
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 35,
-                    color: Colors.white,
+                    color: highlightColor,
                     fontWeight: FontWeight.bold,
                   ),
                 ),

--- a/lib/presentation/alarm/components/alarm_screen_top_section.dart
+++ b/lib/presentation/alarm/components/alarm_screen_top_section.dart
@@ -7,6 +7,7 @@ class AlarmScreenTopSection extends StatelessWidget {
   final bool isLate;
   final int beforeOutTime;
   final String preparationName;
+  final bool showPreparationName;
   final int preparationRemainingTime;
   final double progress;
 
@@ -15,6 +16,7 @@ class AlarmScreenTopSection extends StatelessWidget {
     required this.isLate,
     required this.beforeOutTime,
     required this.preparationName,
+    this.showPreparationName = true,
     required this.preparationRemainingTime,
     required this.progress,
   });
@@ -30,11 +32,13 @@ class AlarmScreenTopSection extends StatelessWidget {
         ),
         _AlarmGraphSection(
           preparationName: preparationName,
+          showPreparationName: showPreparationName,
           preparationRemainingTime: preparationRemainingTime,
           progress: progress,
           highlightColor: colorScheme.primaryContainer,
-          graphBackgroundColor:
-              colorScheme.onPrimaryContainer.withValues(alpha: 0.35),
+          graphBackgroundColor: isLate
+              ? colorScheme.primaryContainer
+              : colorScheme.onPrimaryContainer.withValues(alpha: 0.35),
           graphProgressColor: colorScheme.primaryContainer,
         ),
       ],
@@ -53,10 +57,13 @@ class _BeforeOutTimeText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final overdueText = formatTime(beforeOutTime.abs());
     return Padding(
       padding: const EdgeInsets.only(top: 75),
       child: Text(
-        isLate ? '지각이에요!' : '${formatTime(beforeOutTime)} 뒤에 나가야 해요',
+        isLate
+            ? '준비시간을 $overdueText 초과했어요'
+            : '${formatTime(beforeOutTime)} 뒤에 나가야 해요',
         style: const TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.bold,
@@ -69,6 +76,7 @@ class _BeforeOutTimeText extends StatelessWidget {
 
 class _AlarmGraphSection extends StatelessWidget {
   final String preparationName;
+  final bool showPreparationName;
   final int preparationRemainingTime;
   final double progress;
   final Color highlightColor;
@@ -77,6 +85,7 @@ class _AlarmGraphSection extends StatelessWidget {
 
   const _AlarmGraphSection({
     required this.preparationName,
+    required this.showPreparationName,
     required this.preparationRemainingTime,
     required this.progress,
     required this.highlightColor,
@@ -101,15 +110,17 @@ class _AlarmGraphSection extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  preparationName,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: highlightColor,
+                if (showPreparationName) ...[
+                  Text(
+                    preparationName,
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: highlightColor,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 8),
+                  const SizedBox(height: 8),
+                ],
                 Text(
                   formatTimeTimer(preparationRemainingTime),
                   style: TextStyle(

--- a/lib/presentation/alarm/components/preparation_completion_dialog.dart
+++ b/lib/presentation/alarm/components/preparation_completion_dialog.dart
@@ -7,6 +7,7 @@ Future<void> showPreparationCompletionDialog({
   required BuildContext context,
   required bool isLate,
   required VoidCallback onFinish,
+  VoidCallback? onContinue,
 }) async {
   final l10n = AppLocalizations.of(context)!;
   final result = await showTwoActionDialog(
@@ -30,5 +31,7 @@ Future<void> showPreparationCompletionDialog({
 
   if (result == DialogActionResult.primary) {
     onFinish();
+  } else if (result == DialogActionResult.secondary) {
+    onContinue?.call();
   }
 }

--- a/lib/presentation/alarm/components/preparation_step_tile.dart
+++ b/lib/presentation/alarm/components/preparation_step_tile.dart
@@ -25,6 +25,7 @@ class PreparationStepTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     String displayTime;
     if (preparationStepState == PreparationStateEnum.yet) {
       displayTime = preparationTime;
@@ -33,13 +34,13 @@ class PreparationStepTile extends StatelessWidget {
     }
 
     Widget circleContent = (preparationStepState == PreparationStateEnum.done)
-        ? const Icon(Icons.check, color: Color(0xff5C79FB))
+        ? Icon(Icons.check, color: colorScheme.primary)
         : Text(
             '$stepIndex',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.bold,
-              color: Color(0xff212F6F),
+              color: colorScheme.onPrimaryContainer,
             ),
           );
 
@@ -52,16 +53,16 @@ class PreparationStepTile extends StatelessWidget {
           height: 53,
           child: TextButton(
             style: TextButton.styleFrom(
-              backgroundColor: const Color(0xffDCE3FF),
+              backgroundColor: colorScheme.primaryContainer,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
             ),
             onPressed: onSkip,
-            child: const Text(
+            child: Text(
               '이 단계 건너 뛰기',
               style: TextStyle(
-                color: Color(0xff212F6F),
+                color: colorScheme.onPrimaryContainer,
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
               ),
@@ -87,7 +88,7 @@ class PreparationStepTile extends StatelessWidget {
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(Radius.circular(10)),
               border: (preparationStepState == PreparationStateEnum.now)
-                  ? Border.all(color: const Color(0xff5C79FB), width: 2)
+                  ? Border.all(color: colorScheme.primary, width: 2)
                   : null,
               color: Colors.white,
             ),
@@ -103,9 +104,9 @@ class PreparationStepTile extends StatelessWidget {
                           Container(
                             width: 34,
                             height: 34,
-                            decoration: const BoxDecoration(
+                            decoration: BoxDecoration(
                               shape: BoxShape.circle,
-                              color: Color(0xffDCE3FF),
+                              color: colorScheme.primaryContainer,
                             ),
                           ),
                           circleContent,
@@ -124,10 +125,10 @@ class PreparationStepTile extends StatelessWidget {
                       ),
                       Text(
                         displayTime,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 20,
                           fontWeight: FontWeight.bold,
-                          color: Color(0xff5C79FB),
+                          color: colorScheme.primary,
                         ),
                       ),
                     ],
@@ -148,7 +149,7 @@ class PreparationStepTile extends StatelessWidget {
               direction: Axis.vertical,
               lineLength: 23,
               lineThickness: 3,
-              dashColor: const Color(0xff5C79FB),
+              dashColor: colorScheme.primary,
               dashLength: 4,
               dashGapLength: 5,
             ),

--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -13,7 +13,12 @@ import 'package:on_time_front/presentation/alarm/components/preparation_completi
 import 'package:on_time_front/presentation/shared/utils/time_format.dart';
 
 class AlarmScreen extends StatefulWidget {
-  const AlarmScreen({super.key});
+  const AlarmScreen({
+    super.key,
+    this.nowProvider = DateTime.now,
+  });
+
+  final DateTime Function() nowProvider;
 
   @override
   State<AlarmScreen> createState() => _AlarmScreenState();
@@ -21,15 +26,30 @@ class AlarmScreen extends StatefulWidget {
 
 class _AlarmScreenState extends State<AlarmScreen> {
   bool _hasShownCompletionDialog = false;
+  bool _isContinuingAfterCompletion = false;
   bool _navigateAfterFinish = false;
   int? _pendingEarlyLateSeconds;
   bool? _pendingIsLate;
-  Timer? _upcomingCountdownTimer;
+  Timer? _uiTickerTimer;
+  String? _completionScheduleId;
 
   void _resetFinishNavigation() {
     _navigateAfterFinish = false;
     _pendingEarlyLateSeconds = null;
     _pendingIsLate = null;
+  }
+
+  void _resetCompletionUiState() {
+    _hasShownCompletionDialog = false;
+    _isContinuingAfterCompletion = false;
+  }
+
+  Duration _timeRemainingBeforeLeaving(ScheduleWithPreparationEntity schedule) {
+    return schedule.timeRemainingBeforeLeavingAt(widget.nowProvider());
+  }
+
+  bool _isLate(ScheduleWithPreparationEntity schedule) {
+    return schedule.isLateAt(widget.nowProvider());
   }
 
   void _onPreparationFinished(
@@ -42,15 +62,14 @@ class _AlarmScreenState extends State<AlarmScreen> {
     context.read<ScheduleBloc>().add(ScheduleFinished(latenessMinutes));
   }
 
-  void _ensureUpcomingTicker(bool active) {
+  void _ensureUiTicker(bool active) {
     if (!active) {
-      _upcomingCountdownTimer?.cancel();
-      _upcomingCountdownTimer = null;
+      _uiTickerTimer?.cancel();
+      _uiTickerTimer = null;
       return;
     }
-    if (_upcomingCountdownTimer != null) return;
-    _upcomingCountdownTimer =
-        Timer.periodic(const Duration(seconds: 1), (timer) {
+    if (_uiTickerTimer != null) return;
+    _uiTickerTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
       if (!mounted) return;
       setState(() {});
     });
@@ -68,7 +87,7 @@ class _AlarmScreenState extends State<AlarmScreen> {
 
   @override
   void dispose() {
-    _upcomingCountdownTimer?.cancel();
+    _uiTickerTimer?.cancel();
     super.dispose();
   }
 
@@ -106,6 +125,16 @@ class _AlarmScreenState extends State<AlarmScreen> {
               scheduleState.status == ScheduleStatus.started) {
             final schedule = scheduleState.schedule!;
             final preparation = schedule.preparation;
+            final scheduleChanged = _completionScheduleId != schedule.id;
+
+            if (scheduleChanged) {
+              _completionScheduleId = schedule.id;
+              _resetCompletionUiState();
+            }
+
+            if (!preparation.isAllStepsDone && _hasShownCompletionDialog) {
+              _resetCompletionUiState();
+            }
 
             if (preparation.isAllStepsDone && !_hasShownCompletionDialog) {
               _hasShownCompletionDialog = true;
@@ -113,27 +142,41 @@ class _AlarmScreenState extends State<AlarmScreen> {
                 if (!mounted) return;
                 showPreparationCompletionDialog(
                   context: context,
-                  isLate: schedule.isLate,
+                  isLate: _isLate(schedule),
                   onFinish: () {
+                    final timeRemainingBeforeLeaving =
+                        _timeRemainingBeforeLeaving(schedule);
                     _onPreparationFinished(
                       context,
-                      schedule.timeRemainingBeforeLeaving,
-                      schedule.isLate,
+                      timeRemainingBeforeLeaving,
+                      timeRemainingBeforeLeaving.isNegative,
                     );
+                  },
+                  onContinue: () {
+                    if (!mounted) return;
+                    setState(() {
+                      _isContinuingAfterCompletion = true;
+                    });
                   },
                 );
               });
             }
 
+            _ensureUiTicker(preparation.isAllStepsDone &&
+                _isContinuingAfterCompletion);
             return _buildAlarmScreen(
               schedule: schedule,
             );
           } else if (scheduleState.status == ScheduleStatus.upcoming &&
               scheduleState.schedule != null) {
-            _ensureUpcomingTicker(true);
+            _completionScheduleId = scheduleState.schedule!.id;
+            _resetCompletionUiState();
+            _ensureUiTicker(true);
             return _buildEarlyStartReadyScreen(scheduleState.schedule!);
           } else {
-            _ensureUpcomingTicker(false);
+            _completionScheduleId = null;
+            _resetCompletionUiState();
+            _ensureUiTicker(false);
             return const Scaffold(
               backgroundColor: Color(0xff5C79FB),
               body: Center(child: CircularProgressIndicator()),
@@ -147,8 +190,18 @@ class _AlarmScreenState extends State<AlarmScreen> {
   Widget _buildAlarmScreen({
     required ScheduleWithPreparationEntity schedule,
   }) {
-    _ensureUpcomingTicker(false);
+    final timeRemainingBeforeLeaving = _timeRemainingBeforeLeaving(schedule);
+    final isLate = timeRemainingBeforeLeaving.isNegative;
     final preparation = schedule.preparation;
+    final displayRemainingSeconds = preparation.isAllStepsDone &&
+            _isContinuingAfterCompletion
+        ? timeRemainingBeforeLeaving.inSeconds.abs()
+        : preparation.currentStepRemainingTime.inSeconds;
+
+    if (!(preparation.isAllStepsDone && _isContinuingAfterCompletion)) {
+      _ensureUiTicker(false);
+    }
+
     return Scaffold(
       backgroundColor: const Color(0xff5C79FB),
       body: Stack(
@@ -156,11 +209,10 @@ class _AlarmScreenState extends State<AlarmScreen> {
           Column(
             children: [
               AlarmScreenTopSection(
-                isLate: schedule.isLate,
-                beforeOutTime: schedule.timeRemainingBeforeLeaving.inSeconds,
+                isLate: isLate,
+                beforeOutTime: timeRemainingBeforeLeaving.inSeconds,
                 preparationName: preparation.currentStepName,
-                preparationRemainingTime:
-                    preparation.currentStepRemainingTime.inSeconds,
+                preparationRemainingTime: displayRemainingSeconds,
                 progress: preparation.progress,
               ),
               const SizedBox(height: 110),
@@ -172,8 +224,11 @@ class _AlarmScreenState extends State<AlarmScreen> {
                         .read<ScheduleBloc>()
                         .add(const ScheduleStepSkipped());
                   },
-                  onEndPreparation: () => _onPreparationFinished(context,
-                      schedule.timeRemainingBeforeLeaving, schedule.isLate),
+                  onEndPreparation: () => _onPreparationFinished(
+                    context,
+                    timeRemainingBeforeLeaving,
+                    isLate,
+                  ),
                 ),
               ),
             ],
@@ -186,7 +241,7 @@ class _AlarmScreenState extends State<AlarmScreen> {
   Widget _buildEarlyStartReadyScreen(ScheduleWithPreparationEntity schedule) {
     final l10n = AppLocalizations.of(context)!;
     final remaining =
-        schedule.preparationStartTime.difference(DateTime.now()).inSeconds;
+        schedule.preparationStartTime.difference(widget.nowProvider()).inSeconds;
     final clampedRemaining = remaining.isNegative ? 0 : remaining;
 
     return Scaffold(

--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -25,6 +25,8 @@ class AlarmScreen extends StatefulWidget {
 }
 
 class _AlarmScreenState extends State<AlarmScreen> {
+  static const _lateContinuePrimary = Color(0xFFFF6953);
+  static const _lateContinuePrimaryContainer = Color(0xFFFFEAE7);
   bool _hasShownCompletionDialog = false;
   bool _isContinuingAfterCompletion = false;
   bool _navigateAfterFinish = false;
@@ -50,6 +52,21 @@ class _AlarmScreenState extends State<AlarmScreen> {
 
   bool _isLate(ScheduleWithPreparationEntity schedule) {
     return schedule.isLateAt(widget.nowProvider());
+  }
+
+  ThemeData _buildAlarmTheme(BuildContext context, bool isLateContinueMode) {
+    if (!isLateContinueMode) {
+      return Theme.of(context);
+    }
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme.copyWith(
+      primary: _lateContinuePrimary,
+      primaryContainer: _lateContinuePrimaryContainer,
+      onPrimaryContainer: _lateContinuePrimary,
+    );
+
+    return theme.copyWith(colorScheme: colorScheme);
   }
 
   void _onPreparationFinished(
@@ -193,6 +210,8 @@ class _AlarmScreenState extends State<AlarmScreen> {
     final timeRemainingBeforeLeaving = _timeRemainingBeforeLeaving(schedule);
     final isLate = timeRemainingBeforeLeaving.isNegative;
     final preparation = schedule.preparation;
+    final isLateContinueMode =
+        preparation.isAllStepsDone && _isContinuingAfterCompletion && isLate;
     final displayRemainingSeconds = preparation.isAllStepsDone &&
             _isContinuingAfterCompletion
         ? timeRemainingBeforeLeaving.inSeconds.abs()
@@ -202,50 +221,61 @@ class _AlarmScreenState extends State<AlarmScreen> {
       _ensureUiTicker(false);
     }
 
-    return Scaffold(
-      backgroundColor: const Color(0xff5C79FB),
-      body: Stack(
-        children: [
-          Column(
-            children: [
-              AlarmScreenTopSection(
-                isLate: isLate,
-                beforeOutTime: timeRemainingBeforeLeaving.inSeconds,
-                preparationName: preparation.currentStepName,
-                preparationRemainingTime: displayRemainingSeconds,
-                progress: preparation.progress,
-              ),
-              const SizedBox(height: 110),
-              Expanded(
-                child: AlarmScreenBottomSection(
-                  preparation: preparation,
-                  onSkip: () {
-                    context
-                        .read<ScheduleBloc>()
-                        .add(const ScheduleStepSkipped());
-                  },
-                  onEndPreparation: () => _onPreparationFinished(
-                    context,
-                    timeRemainingBeforeLeaving,
-                    isLate,
-                  ),
+    final alarmTheme = _buildAlarmTheme(context, isLateContinueMode);
+
+    return Theme(
+      key: const ValueKey('alarm_screen_theme'),
+      data: alarmTheme,
+      child: Builder(
+        builder: (context) {
+          return Scaffold(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            body: Stack(
+              children: [
+                Column(
+                  children: [
+                    AlarmScreenTopSection(
+                      isLate: isLate,
+                      beforeOutTime: timeRemainingBeforeLeaving.inSeconds,
+                      preparationName: preparation.currentStepName,
+                      preparationRemainingTime: displayRemainingSeconds,
+                      progress: preparation.progress,
+                    ),
+                    const SizedBox(height: 110),
+                    Expanded(
+                      child: AlarmScreenBottomSection(
+                        preparation: preparation,
+                        onSkip: () {
+                          context
+                              .read<ScheduleBloc>()
+                              .add(const ScheduleStepSkipped());
+                        },
+                        onEndPreparation: () => _onPreparationFinished(
+                          context,
+                          timeRemainingBeforeLeaving,
+                          isLate,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-            ],
-          ),
-        ],
+              ],
+            ),
+          );
+        },
       ),
     );
   }
 
   Widget _buildEarlyStartReadyScreen(ScheduleWithPreparationEntity schedule) {
     final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
     final remaining =
         schedule.preparationStartTime.difference(widget.nowProvider()).inSeconds;
     final clampedRemaining = remaining.isNegative ? 0 : remaining;
 
     return Scaffold(
-      backgroundColor: const Color(0xff5C79FB),
+      backgroundColor: theme.colorScheme.primary,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 28),
@@ -265,10 +295,10 @@ class _AlarmScreenState extends State<AlarmScreen> {
               Text(
                 l10n.preparationStartsInFiveMinutes,
                 textAlign: TextAlign.center,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.w600,
-                  color: Color(0xffDCE3FF),
+                  color: theme.colorScheme.primaryContainer,
                 ),
               ),
               const SizedBox(height: 18),

--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -289,25 +289,25 @@ class _AlarmScreenState extends State<AlarmScreen> {
                     ),
                   ],
                 ),
-              ),
-            ],
-          ),
-          Positioned(
-            top: 0,
-            right: 0,
-            child: SafeArea(
-              minimum: EdgeInsets.zero,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 4),
-                child: IconButton(
-                  key: const Key('alarm_close_button'),
-                  icon: const Icon(Icons.close, color: Colors.white),
-                  onPressed: () => _showLeaveConfirmationDialog(context),
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: SafeArea(
+                    minimum: EdgeInsets.zero,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 4),
+                      child: IconButton(
+                        key: const Key('alarm_close_button'),
+                        icon: const Icon(Icons.close, color: Colors.white),
+                        onPressed: () => _showLeaveConfirmationDialog(context),
+                      ),
+                    ),
+                  ),
                 ),
-              ),
+              ],
             ),
-          ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -212,6 +212,9 @@ class _AlarmScreenState extends State<AlarmScreen> {
     final preparation = schedule.preparation;
     final isLateContinueMode =
         preparation.isAllStepsDone && _isContinuingAfterCompletion && isLate;
+    final timerLabel =
+        isLateContinueMode ? '지각이에요' : preparation.currentStepName;
+    final displayProgress = isLateContinueMode ? 0.0 : preparation.progress;
     final displayRemainingSeconds = preparation.isAllStepsDone &&
             _isContinuingAfterCompletion
         ? timeRemainingBeforeLeaving.inSeconds.abs()
@@ -237,9 +240,10 @@ class _AlarmScreenState extends State<AlarmScreen> {
                     AlarmScreenTopSection(
                       isLate: isLate,
                       beforeOutTime: timeRemainingBeforeLeaving.inSeconds,
-                      preparationName: preparation.currentStepName,
+                      preparationName: timerLabel,
+                      showPreparationName: true,
                       preparationRemainingTime: displayRemainingSeconds,
-                      progress: preparation.progress,
+                      progress: displayProgress,
                     ),
                     const SizedBox(height: 110),
                     Expanded(

--- a/test/domain/entities/preparation_timing_entity_test.dart
+++ b/test/domain/entities/preparation_timing_entity_test.dart
@@ -37,12 +37,16 @@ void main() {
       preparation: preparation,
     );
 
-    test('calculates time remaining and late status with explicit now', () {
+    test('calculates left time before leave with explicit now', () {
       final now = DateTime(2026, 3, 20, 9, 20);
       expect(
         schedule.timeRemainingBeforeLeavingAt(now),
         const Duration(minutes: 10),
       );
+    });
+
+    test('reports late status after leave time has passed', () {
+      final now = DateTime(2026, 3, 20, 9, 20);
       expect(schedule.isLateAt(now), isFalse);
 
       final lateNow = DateTime(2026, 3, 20, 9, 31);

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -23,6 +23,7 @@ import 'package:on_time_front/domain/use-cases/get_timed_preparation_snapshot_us
 import 'package:on_time_front/domain/use-cases/mark_early_start_session_use_case.dart';
 import 'package:on_time_front/domain/use-cases/save_timed_preparation_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/alarm/components/alarm_graph_animator.dart';
 import 'package:on_time_front/presentation/alarm/screens/alarm_screen.dart';
 import 'package:on_time_front/presentation/alarm/screens/schedule_start_screen.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
@@ -903,8 +904,28 @@ void main() {
         lateScaffold.backgroundColor!.value,
         const Color(0xFFFF6953).value,
       );
-      expect(find.text('지각이에요!'), findsOneWidget);
+      expect(
+        tester.widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator)).progress,
+        0.0,
+      );
+      expect(
+        tester
+            .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
+            .backgroundColor
+            .value,
+        const Color(0xFFFFEAE7).value,
+      );
+      expect(
+        tester
+            .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
+            .progressColor
+            .value,
+        const Color(0xFFFFEAE7).value,
+      );
+      expect(find.text('준비시간을 1분 초과했어요'), findsOneWidget);
+      expect(find.text('지각이에요'), findsOneWidget);
       expect(find.text('01 : 00'), findsOneWidget);
+      expect(find.text('Prep'), findsOneWidget);
 
       alarmBloc.add(const ScheduleFinished(0));
       await tester.pump();

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -650,14 +650,15 @@ void main() {
       expect(find.textContaining('EARLYLATE:true'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
-    testWidgets('completion dialog continue keeps user in alarm flow',
+    testWidgets(
+        'completion dialog continue shows live leave countdown for ongoing flow',
         (tester) async {
       await setLargeTestViewport(tester);
-      now = DateTime.now();
+      now = DateTime(2026, 3, 20, 9, 25);
 
       final schedule = buildSchedule(
         id: 's5',
-        scheduleTime: now.add(const Duration(minutes: 35)),
+        scheduleTime: DateTime(2026, 3, 20, 10, 0),
         steps: const [
           PreparationStepWithTimeEntity(
             id: 'p1',
@@ -675,7 +676,9 @@ void main() {
         routes: [
           GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
           GoRoute(
-              path: '/alarmScreen', builder: (_, __) => const AlarmScreen()),
+            path: '/alarmScreen',
+            builder: (_, __) => AlarmScreen(nowProvider: () => now),
+          ),
           GoRoute(
               path: '/earlyLate', builder: (_, __) => const Text('EARLYLATE')),
         ],
@@ -699,13 +702,158 @@ void main() {
       await pumpWithRouter(tester, bloc: alarmBloc, router: router);
       await pumpUntilFound(tester, find.byType(TwoActionDialog));
 
-      expect(find.byType(TwoActionDialog), findsOneWidget);
       await tapAndPump(tester, find.byType(ModalWideButton).first);
-      await tester.pump(const Duration(milliseconds: 200));
 
       expect(find.text('EARLYLATE'), findsNothing);
+      expect(find.text('5분 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('05 : 00'), findsOneWidget);
       expect(finishUseCase.calls, isEmpty);
-      // Explicitly finish to stop periodic timer before test ends.
+
+      now = now.add(const Duration(minutes: 1));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('4분 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('04 : 00'), findsOneWidget);
+
+      alarmBloc.add(const ScheduleFinished(0));
+      await tester.pump();
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets(
+        'completion dialog continue shows live leave countdown for early-start flow',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime(2026, 3, 20, 8, 30);
+
+      final schedule = buildSchedule(
+        id: 's5-early',
+        scheduleTime: DateTime(2026, 3, 20, 10, 0),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+            isDone: true,
+            elapsedTime: Duration(minutes: 10),
+          ),
+        ],
+      );
+
+      final router = GoRouter(
+        initialLocation: '/alarmScreen',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/alarmScreen',
+            builder: (_, __) => AlarmScreen(nowProvider: () => now),
+          ),
+          GoRoute(
+              path: '/earlyLate', builder: (_, __) => const Text('EARLYLATE')),
+        ],
+      );
+
+      final earlyBundle = createEarlyStartUseCaseBundle();
+      await earlyBundle.markUseCase(
+        scheduleId: schedule.id,
+        startedAt: now.subtract(const Duration(minutes: 1)),
+      );
+
+      final alarmBloc = ScheduleBloc.test(
+        StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
+        navigationService,
+        NoopSaveTimedPreparationUseCase(),
+        StubGetTimedPreparationSnapshotUseCase({}),
+        NoopClearTimedPreparationUseCase(),
+        finishUseCase,
+        markEarlyStartSessionUseCase: earlyBundle.markUseCase,
+        getEarlyStartSessionUseCase: earlyBundle.getUseCase,
+        clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
+        nowProvider: () => now,
+      );
+      addTearDown(alarmBloc.close);
+
+      await pumpWithRouter(tester, bloc: alarmBloc, router: router);
+      await pumpUntilFound(tester, find.byType(TwoActionDialog));
+
+      await tapAndPump(tester, find.byType(ModalWideButton).first);
+
+      expect(find.text('1시간 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('01 : 00 : 00'), findsOneWidget);
+
+      now = now.add(const Duration(minutes: 5));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('55분 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('55 : 00'), findsOneWidget);
+
+      alarmBloc.add(const ScheduleFinished(0));
+      await tester.pump();
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets(
+        'completion dialog continue keeps overdue timer running after leave time',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime(2026, 3, 20, 9, 29);
+
+      final schedule = buildSchedule(
+        id: 's5-late',
+        scheduleTime: DateTime(2026, 3, 20, 10, 0),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+            isDone: true,
+            elapsedTime: Duration(minutes: 10),
+          ),
+        ],
+      );
+
+      final router = GoRouter(
+        initialLocation: '/alarmScreen',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/alarmScreen',
+            builder: (_, __) => AlarmScreen(nowProvider: () => now),
+          ),
+          GoRoute(
+              path: '/earlyLate', builder: (_, __) => const Text('EARLYLATE')),
+        ],
+      );
+
+      final earlyBundle = createEarlyStartUseCaseBundle();
+      final alarmBloc = ScheduleBloc.test(
+        StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
+        navigationService,
+        NoopSaveTimedPreparationUseCase(),
+        StubGetTimedPreparationSnapshotUseCase({}),
+        NoopClearTimedPreparationUseCase(),
+        finishUseCase,
+        markEarlyStartSessionUseCase: earlyBundle.markUseCase,
+        getEarlyStartSessionUseCase: earlyBundle.getUseCase,
+        clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
+        nowProvider: () => now,
+      );
+      addTearDown(alarmBloc.close);
+
+      await pumpWithRouter(tester, bloc: alarmBloc, router: router);
+      await pumpUntilFound(tester, find.byType(TwoActionDialog));
+
+      await tapAndPump(tester, find.byType(ModalWideButton).first);
+
+      expect(find.text('1분 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('01 : 00'), findsOneWidget);
+
+      now = now.add(const Duration(minutes: 2));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('지각이에요!'), findsOneWidget);
+      expect(find.text('01 : 00'), findsOneWidget);
+
       alarmBloc.add(const ScheduleFinished(0));
       await tester.pump();
     }, timeout: const Timeout(Duration(seconds: 15)));

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -704,6 +704,32 @@ void main() {
 
       await tapAndPump(tester, find.byType(ModalWideButton).first);
 
+      final continuingTheme = tester
+          .widget<Theme>(find.byKey(const ValueKey('alarm_screen_theme')))
+          .data;
+      final continuingScaffold = tester.widget<Scaffold>(
+        find.descendant(
+          of: find.byKey(const ValueKey('alarm_screen_theme')),
+          matching: find.byType(Scaffold),
+        ),
+      );
+
+      expect(
+        continuingTheme.colorScheme.primary.value,
+        const Color(0xFF5C79FB).value,
+      );
+      expect(
+        continuingTheme.colorScheme.primaryContainer.value,
+        const Color(0xFFDCE3FF).value,
+      );
+      expect(
+        continuingTheme.colorScheme.onPrimaryContainer.value,
+        const Color(0xFF212F6F).value,
+      );
+      expect(
+        continuingScaffold.backgroundColor!.value,
+        const Color(0xFF5C79FB).value,
+      );
       expect(find.text('EARLYLATE'), findsNothing);
       expect(find.text('5분 뒤에 나가야 해요'), findsOneWidget);
       expect(find.text('05 : 00'), findsOneWidget);
@@ -851,6 +877,32 @@ void main() {
       now = now.add(const Duration(minutes: 2));
       await tester.pump(const Duration(seconds: 1));
 
+      final lateTheme = tester
+          .widget<Theme>(find.byKey(const ValueKey('alarm_screen_theme')))
+          .data;
+      final lateScaffold = tester.widget<Scaffold>(
+        find.descendant(
+          of: find.byKey(const ValueKey('alarm_screen_theme')),
+          matching: find.byType(Scaffold),
+        ),
+      );
+
+      expect(
+        lateTheme.colorScheme.primary.value,
+        const Color(0xFFFF6953).value,
+      );
+      expect(
+        lateTheme.colorScheme.primaryContainer.value,
+        const Color(0xFFFFEAE7).value,
+      );
+      expect(
+        lateTheme.colorScheme.onPrimaryContainer.value,
+        const Color(0xFFFF6953).value,
+      );
+      expect(
+        lateScaffold.backgroundColor!.value,
+        const Color(0xFFFF6953).value,
+      );
       expect(find.text('지각이에요!'), findsOneWidget);
       expect(find.text('01 : 00'), findsOneWidget);
 

--- a/widgetbook/lib/alarm_graph_component.dart
+++ b/widgetbook/lib/alarm_graph_component.dart
@@ -22,7 +22,11 @@ Widget alarmGraphComponentUseCase(BuildContext context) {
       child: Center(
         child: CustomPaint(
           size: const Size(230, 115),
-          painter: AlarmGraphComponent(progress: progress),
+          painter: AlarmGraphComponent(
+            progress: progress,
+            backgroundColor: const Color(0xFF3D54BC),
+            progressColor: const Color(0xFFDCE3FF),
+          ),
         ),
       ),
     ),

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -68,10 +68,10 @@ packages:
     dependency: transitive
     description:
       name: bloc
-      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.2.0"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
Summary
- Inject graph colors, text themes, and button states from the Alarm screen theme so preparation visuals respect the color scheme
- Keep preparation completion dialog continuations in the alarm flow, showing live leave countdowns and applying a late continuation theme when needed
- Refresh preparation tile styles and completion button states to use color scheme tokens instead of fixed values

Testing
- Not run (not requested)