### PR TITLE
Show exact early lead time on early-start prompt

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -225,6 +225,10 @@
     "@startPreparing": {
         "description": "Button text to start preparing"
     },
+    "prepareEarly": "Prepare Early",
+    "@prepareEarly": {
+        "description": "Button text on the early-start screen to start preparing before the scheduled preparation time"
+    },
     "confirmLeave": "Are you sure you want to leave?",
     "@confirmLeave": {
         "description": "Modal title to confirm leaving the screen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -427,9 +427,18 @@
     "@startInFiveMinutes": {
         "description": "Button text to start in 5 minutes"
     },
-    "preparationStartsLaterStartEarly": "Preparation starts a little later.\nWould you like to start preparing early now?",
+    "preparationStartsEarlyBy": "You're starting {duration} early.\nWould you like to start preparing early now?",
+    "@preparationStartsEarlyBy": {
+        "description": "Message shown when user opens schedule start before preparation start time from home, including the exact lead time",
+        "placeholders": {
+            "duration": {
+                "type": "String"
+            }
+        }
+    },
+    "preparationStartsLaterStartEarly": "You're a little early.\nWould you like to start preparing early now?",
     "@preparationStartsLaterStartEarly": {
-        "description": "Message shown when user opens schedule start before preparation start time from home"
+        "description": "Fallback message shown when user opens schedule start before preparation start time from home but exact lead time is unavailable"
     },
     "continuePreparingNext": "Continue preparing",
     "@continuePreparingNext": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -53,6 +53,7 @@
     "ok": "확인",
     "youWillBeLate": "지금 준비 시작 안하면 늦어요!",
     "startPreparing": "준비 시작",
+    "prepareEarly": "미리 준비하기",
     "confirmLeave": "정말 나가시겠어요?",
     "confirmLeaveDescription": "이 화면을 나가면\n함께 약속을 준비할 수 없게 돼요",
     "leave": "나갈래요",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -135,9 +135,18 @@
     "@startInFiveMinutes": {
         "description": "Button text to start in 5 minutes"
     },
-    "preparationStartsLaterStartEarly": "아직 준비 시작 시간 전이에요.\n지금 미리 준비를 시작할까요?",
+    "preparationStartsEarlyBy": "{duration} 일찍 준비를 시작할 수 있어요.\n지금 미리 준비를 시작할까요?",
+    "@preparationStartsEarlyBy": {
+        "description": "Message shown when user opens schedule start before preparation start time from home, including the exact lead time",
+        "placeholders": {
+            "duration": {
+                "type": "String"
+            }
+        }
+    },
+    "preparationStartsLaterStartEarly": "조금 일찍 준비를 시작할 수 있어요.\n지금 미리 준비를 시작할까요?",
     "@preparationStartsLaterStartEarly": {
-        "description": "Message shown when user opens schedule start before preparation start time from home"
+        "description": "Fallback message shown when user opens schedule start before preparation start time from home but exact lead time is unavailable"
     },
     "continuePreparingNext": "이어서 준비하세요",
     "@continuePreparingNext": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -674,10 +674,16 @@ abstract class AppLocalizations {
   /// **'Start in 5 minutes'**
   String get startInFiveMinutes;
 
-  /// Message shown when user opens schedule start before preparation start time from home
+  /// Message shown when user opens schedule start before preparation start time from home, including the exact lead time
   ///
   /// In en, this message translates to:
-  /// **'Preparation starts a little later.\nWould you like to start preparing early now?'**
+  /// **'You\'re starting {duration} early.\nWould you like to start preparing early now?'**
+  String preparationStartsEarlyBy(String duration);
+
+  /// Fallback message shown when user opens schedule start before preparation start time from home but exact lead time is unavailable
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re a little early.\nWould you like to start preparing early now?'**
   String get preparationStartsLaterStartEarly;
 
   /// Notification body text for continuing preparation

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -422,6 +422,12 @@ abstract class AppLocalizations {
   /// **'Start Preparing'**
   String get startPreparing;
 
+  /// Button text on the early-start screen to start preparing before the scheduled preparation time
+  ///
+  /// In en, this message translates to:
+  /// **'Prepare Early'**
+  String get prepareEarly;
+
   /// Modal title to confirm leaving the screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -342,8 +342,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get startInFiveMinutes => 'Start in 5 minutes';
 
   @override
+  String preparationStartsEarlyBy(String duration) {
+    return 'You\'re starting $duration early.\nWould you like to start preparing early now?';
+  }
+
+  @override
   String get preparationStartsLaterStartEarly =>
-      'Preparation starts a little later.\nWould you like to start preparing early now?';
+      'You\'re a little early.\nWould you like to start preparing early now?';
 
   @override
   String get continuePreparingNext => 'Continue preparing';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -185,6 +185,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get startPreparing => 'Start Preparing';
 
   @override
+  String get prepareEarly => 'Prepare Early';
+
+  @override
   String get confirmLeave => 'Are you sure you want to leave?';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -318,8 +318,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get startInFiveMinutes => '5분 뒤에 시작하기';
 
   @override
+  String preparationStartsEarlyBy(String duration) {
+    return '$duration 일찍 준비를 시작할 수 있어요.\n지금 미리 준비를 시작할까요?';
+  }
+
+  @override
   String get preparationStartsLaterStartEarly =>
-      '아직 준비 시작 시간 전이에요.\n지금 미리 준비를 시작할까요?';
+      '조금 일찍 준비를 시작할 수 있어요.\n지금 미리 준비를 시작할까요?';
 
   @override
   String get continuePreparingNext => '이어서 준비하세요';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -179,6 +179,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get startPreparing => '준비 시작';
 
   @override
+  String get prepareEarly => '미리 준비하기';
+
+  @override
   String get confirmLeave => '정말 나가시겠어요?';
 
   @override

--- a/lib/presentation/alarm/screens/schedule_start_screen.dart
+++ b/lib/presentation/alarm/screens/schedule_start_screen.dart
@@ -133,8 +133,6 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
   Widget build(BuildContext context) {
     final scheduleState = context.watch<ScheduleBloc>().state;
     final promptVariant = _resolvedPromptVariant();
-    final isDualActionVariant =
-        promptVariant != ScheduleStartPromptVariant.defaultPrompt;
     final schedule = scheduleState.schedule;
 
     return Scaffold(
@@ -203,9 +201,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
                       ),
                       Padding(
                         padding: EdgeInsets.only(bottom: bottomGap),
-                        child: isDualActionVariant
-                            ? _buildTwoButtonLayout(context, promptVariant)
-                            : _buildSingleButton(context),
+                        child: _buildActionLayout(context, promptVariant),
                       ),
                     ],
                   ),
@@ -226,7 +222,11 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     );
   }
 
-  Widget _buildSingleButton(BuildContext context) {
+  Widget _buildPrimaryButton(
+    BuildContext context,
+    ScheduleStartPromptVariant variant,
+  ) {
+    final l10n = AppLocalizations.of(context)!;
     return Align(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 358),
@@ -235,16 +235,30 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
           height: 57,
           child: ElevatedButton(
             onPressed: () async {
-              _onPrimaryActionPressed(
-                context,
-                ScheduleStartPromptVariant.defaultPrompt,
-              );
+              _onPrimaryActionPressed(context, variant);
             },
-            child: Text(AppLocalizations.of(context)!.startPreparing),
+            child: Text(
+              variant == ScheduleStartPromptVariant.earlyStart
+                  ? l10n.prepareEarly
+                  : l10n.startPreparing,
+            ),
           ),
         ),
       ),
     );
+  }
+
+  Widget _buildActionLayout(
+    BuildContext context,
+    ScheduleStartPromptVariant variant,
+  ) {
+    switch (variant) {
+      case ScheduleStartPromptVariant.fiveMinutes:
+        return _buildTwoButtonLayout(context, variant);
+      case ScheduleStartPromptVariant.earlyStart:
+      case ScheduleStartPromptVariant.defaultPrompt:
+        return _buildPrimaryButton(context, variant);
+    }
   }
 
   Widget _buildTwoButtonLayout(

--- a/lib/presentation/alarm/screens/schedule_start_screen.dart
+++ b/lib/presentation/alarm/screens/schedule_start_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
 import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
 import 'package:on_time_front/presentation/shared/constants/app_colors.dart';
+import 'package:on_time_front/presentation/shared/utils/duration_format.dart';
 
 enum ScheduleStartPromptVariant {
   defaultPrompt,
@@ -76,6 +78,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     if (widget.promptVariant != ScheduleStartPromptVariant.defaultPrompt) {
       return widget.promptVariant;
     }
+    // ignore: deprecated_member_use_from_same_package
     if (widget.isFiveMinutesBefore) {
       return ScheduleStartPromptVariant.fiveMinutes;
     }
@@ -83,15 +86,37 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
   }
 
   String _buildPromptMessage(
-      BuildContext context, ScheduleStartPromptVariant variant) {
+    BuildContext context,
+    ScheduleStartPromptVariant variant,
+    ScheduleWithPreparationEntity? schedule,
+  ) {
     switch (variant) {
       case ScheduleStartPromptVariant.fiveMinutes:
         return AppLocalizations.of(context)!.preparationStartsInFiveMinutes;
       case ScheduleStartPromptVariant.earlyStart:
-        return AppLocalizations.of(context)!.preparationStartsLaterStartEarly;
+        return _buildEarlyStartPromptMessage(context, schedule);
       case ScheduleStartPromptVariant.defaultPrompt:
         return AppLocalizations.of(context)!.youWillBeLate;
     }
+  }
+
+  String _buildEarlyStartPromptMessage(
+    BuildContext context,
+    ScheduleWithPreparationEntity? schedule,
+  ) {
+    final l10n = AppLocalizations.of(context)!;
+    if (schedule == null) {
+      return l10n.preparationStartsLaterStartEarly;
+    }
+
+    final remainingLeadTime =
+        schedule.preparationStartTime.difference(DateTime.now());
+    if (remainingLeadTime.inMinutes <= 0) {
+      return l10n.preparationStartsLaterStartEarly;
+    }
+
+    final formattedLeadTime = formatDuration(context, remainingLeadTime);
+    return l10n.preparationStartsEarlyBy(formattedLeadTime);
   }
 
   void _onPrimaryActionPressed(
@@ -106,10 +131,11 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final scheduleState = context.watch<ScheduleBloc>().state;
     final promptVariant = _resolvedPromptVariant();
     final isDualActionVariant =
         promptVariant != ScheduleStartPromptVariant.defaultPrompt;
-    final schedule = context.read<ScheduleBloc>().state.schedule;
+    final schedule = scheduleState.schedule;
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -156,7 +182,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
                       ),
                       const SizedBox(height: 12),
                       Text(
-                        _buildPromptMessage(context, promptVariant),
+                        _buildPromptMessage(context, promptVariant, schedule),
                         style: TextStyle(
                           fontSize: messageFontSize,
                           fontWeight: FontWeight.w600,

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
@@ -260,6 +259,14 @@ Future<void> pumpUntilRouteText(
   );
 }
 
+Finder findTextMatching(RegExp pattern) {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is Text && widget.data != null && pattern.hasMatch(widget.data!),
+    description: 'Text matching ${pattern.pattern}',
+  );
+}
+
 Future<void> setLargeTestViewport(WidgetTester tester) async {
   tester.view.devicePixelRatio = 1.0;
   tester.view.physicalSize = const Size(1200, 2200);
@@ -423,7 +430,21 @@ void main() {
     testWidgets('early-start variant is shown with dedicated prompt',
         (tester) async {
       await setLargeTestViewport(tester);
+      now = DateTime.now();
 
+      final schedule = buildSchedule(
+        id: 'early-prompt',
+        scheduleTime: now.add(const Duration(minutes: 63, seconds: 30)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+      bloc.emit(ScheduleState.upcoming(schedule));
       final router = GoRouter(
         initialLocation: '/scheduleStart',
         routes: [
@@ -442,8 +463,58 @@ void main() {
       await pumpWithRouter(tester, bloc: bloc, router: router);
       await tester.pump(const Duration(milliseconds: 100));
 
-      expect(find.textContaining('starts a little later'), findsOneWidget);
+      expect(
+        findTextMatching(RegExp(r"You're starting \d+ minutes early\.")),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Would you like to start preparing early now?'),
+        findsOneWidget,
+      );
       expect(find.byType(ElevatedButton), findsNWidgets(2));
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets('early-start variant formats hour and minute lead time',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime.now();
+
+      final schedule = buildSchedule(
+        id: 'early-hour-minute',
+        scheduleTime:
+            now.add(const Duration(hours: 1, minutes: 55, seconds: 30)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+      bloc.emit(ScheduleState.upcoming(schedule));
+      final router = GoRouter(
+        initialLocation: '/scheduleStart',
+        routes: [
+          GoRoute(
+            path: '/scheduleStart',
+            builder: (_, __) => const ScheduleStartScreen(
+              promptVariant: ScheduleStartPromptVariant.earlyStart,
+            ),
+          ),
+          GoRoute(
+              path: '/alarmScreen', builder: (_, __) => const Text('ALARM')),
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+        ],
+      );
+
+      await pumpWithRouter(tester, bloc: bloc, router: router);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(
+        findTextMatching(RegExp(r"You're starting 1 hour 15 minutes early\.")),
+        findsOneWidget,
+      );
     }, timeout: const Timeout(Duration(seconds: 15)));
 
     testWidgets('early-start primary action starts preparation and navigates',

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -471,7 +471,9 @@ void main() {
         find.textContaining('Would you like to start preparing early now?'),
         findsOneWidget,
       );
-      expect(find.byType(ElevatedButton), findsNWidgets(2));
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.text('Home'), findsNothing);
+      expect(find.text('Prepare Early'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
     testWidgets('early-start variant formats hour and minute lead time',
@@ -552,13 +554,14 @@ void main() {
       );
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
-      await tapAndPump(tester, find.text('Start Preparing'));
+      await tapAndPump(tester, find.text('Prepare Early'));
       await pumpUntilRouteText(tester, 'ALARM_ROUTE');
 
       expect(find.text('ALARM_ROUTE'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
-    testWidgets('early-start secondary action navigates home', (tester) async {
+    testWidgets('early-start relies on close button instead of home button',
+        (tester) async {
       await setLargeTestViewport(tester);
 
       final schedule = buildSchedule(
@@ -592,10 +595,8 @@ void main() {
       );
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
-      await tapAndPump(tester, find.text('Home'));
-      await pumpUntilRouteText(tester, 'HOME_ROUTE');
-
-      expect(find.text('HOME_ROUTE'), findsOneWidget);
+      expect(find.text('Home'), findsNothing);
+      expect(find.byIcon(Icons.close), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
     testWidgets(


### PR DESCRIPTION
Summary
- compute remaining lead time for the early-start prompt and format it via the shared duration helper
- expose localized message that accepts the formatted duration and fall back to the generic copy when needed
- update localization resources, implementation, and widget tests to assert the dynamic text and formatter behavior

Testing
- Not run (not requested)