### PR TITLE
Add top-right leave confirmation button to active alarm screen

### DIFF
--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -10,6 +10,8 @@ import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart'
 import 'package:on_time_front/presentation/alarm/components/alarm_screen_bottom_section.dart';
 import 'package:on_time_front/presentation/alarm/components/alarm_screen_top_section.dart';
 import 'package:on_time_front/presentation/alarm/components/preparation_completion_dialog.dart';
+import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
+import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
 import 'package:on_time_front/presentation/shared/utils/time_format.dart';
 
 class AlarmScreen extends StatefulWidget {
@@ -144,6 +146,30 @@ class _AlarmScreenState extends State<AlarmScreen> {
     );
   }
 
+  Future<void> _showLeaveConfirmationDialog(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final result = await showTwoActionDialog(
+      context,
+      config: TwoActionDialogConfig(
+        title: l10n.confirmLeave,
+        description: l10n.confirmLeaveDescription,
+        barrierDismissible: false,
+        secondaryAction: DialogActionConfig(
+          label: l10n.leave,
+          variant: ModalWideButtonVariant.neutral,
+        ),
+        primaryAction: DialogActionConfig(
+          label: l10n.stay,
+          variant: ModalWideButtonVariant.primary,
+        ),
+      ),
+    );
+
+    if (result == DialogActionResult.secondary && context.mounted) {
+      context.go('/home');
+    }
+  }
+
   Widget _buildAlarmScreen({
     required ScheduleWithPreparationEntity schedule,
   }) {
@@ -177,6 +203,21 @@ class _AlarmScreenState extends State<AlarmScreen> {
                 ),
               ),
             ],
+          ),
+          Positioned(
+            top: 0,
+            right: 0,
+            child: SafeArea(
+              minimum: EdgeInsets.zero,
+              child: Padding(
+                padding: const EdgeInsets.only(right: 4),
+                child: IconButton(
+                  key: const Key('alarm_close_button'),
+                  icon: const Icon(Icons.close, color: Colors.white),
+                  onPressed: () => _showLeaveConfirmationDialog(context),
+                ),
+              ),
+            ),
           ),
         ],
       ),

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -527,6 +527,172 @@ void main() {
       expect(find.text('HOME_ROUTE'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
+    testWidgets('active alarm screen renders top-corner close button',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime.now();
+
+      final schedule = buildSchedule(
+        id: 's-active-close',
+        scheduleTime: now.add(const Duration(minutes: 35)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+
+      final router = GoRouter(
+        initialLocation: '/alarmScreen',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/alarmScreen',
+            builder: (_, __) => const AlarmScreen(),
+          ),
+        ],
+      );
+
+      final earlyBundle = createEarlyStartUseCaseBundle();
+      final alarmBloc = ScheduleBloc.test(
+        StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
+        navigationService,
+        NoopSaveTimedPreparationUseCase(),
+        StubGetTimedPreparationSnapshotUseCase({}),
+        NoopClearTimedPreparationUseCase(),
+        finishUseCase,
+        markEarlyStartSessionUseCase: earlyBundle.markUseCase,
+        getEarlyStartSessionUseCase: earlyBundle.getUseCase,
+        clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
+        nowProvider: () => now,
+      );
+      addTearDown(alarmBloc.close);
+
+      await pumpWithRouter(tester, bloc: alarmBloc, router: router);
+      await pumpUntilFound(tester, find.byKey(const Key('alarm_close_button')));
+
+      expect(find.byKey(const Key('alarm_close_button')), findsOneWidget);
+      alarmBloc.add(const ScheduleFinished(0));
+      await tester.pump();
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets(
+        'active alarm close button shows confirm dialog and stay keeps alarm',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime.now();
+
+      final schedule = buildSchedule(
+        id: 's-active-stay',
+        scheduleTime: now.add(const Duration(minutes: 35)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+
+      final router = GoRouter(
+        initialLocation: '/alarmScreen',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/alarmScreen',
+            builder: (_, __) => const AlarmScreen(),
+          ),
+        ],
+      );
+
+      final earlyBundle = createEarlyStartUseCaseBundle();
+      final alarmBloc = ScheduleBloc.test(
+        StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
+        navigationService,
+        NoopSaveTimedPreparationUseCase(),
+        StubGetTimedPreparationSnapshotUseCase({}),
+        NoopClearTimedPreparationUseCase(),
+        finishUseCase,
+        markEarlyStartSessionUseCase: earlyBundle.markUseCase,
+        getEarlyStartSessionUseCase: earlyBundle.getUseCase,
+        clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
+        nowProvider: () => now,
+      );
+      addTearDown(alarmBloc.close);
+
+      await pumpWithRouter(tester, bloc: alarmBloc, router: router);
+      await tapAndPump(tester, find.byKey(const Key('alarm_close_button')));
+      await pumpUntilFound(tester, find.byType(TwoActionDialog));
+
+      await tapAndPump(tester, find.text("I'll stay"));
+      await tester.pump(const Duration(milliseconds: 150));
+
+      expect(find.text('HOME'), findsNothing);
+      expect(find.byType(AlarmScreen), findsOneWidget);
+      alarmBloc.add(const ScheduleFinished(0));
+      await tester.pump();
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets('active alarm close button leave action navigates home',
+        (tester) async {
+      await setLargeTestViewport(tester);
+      now = DateTime.now();
+
+      final schedule = buildSchedule(
+        id: 's-active-leave',
+        scheduleTime: now.add(const Duration(minutes: 35)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'p1',
+            preparationName: 'Prep',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+
+      final router = GoRouter(
+        initialLocation: '/alarmScreen',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/alarmScreen',
+            builder: (_, __) => const AlarmScreen(),
+          ),
+        ],
+      );
+
+      final earlyBundle = createEarlyStartUseCaseBundle();
+      final alarmBloc = ScheduleBloc.test(
+        StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
+        navigationService,
+        NoopSaveTimedPreparationUseCase(),
+        StubGetTimedPreparationSnapshotUseCase({}),
+        NoopClearTimedPreparationUseCase(),
+        finishUseCase,
+        markEarlyStartSessionUseCase: earlyBundle.markUseCase,
+        getEarlyStartSessionUseCase: earlyBundle.getUseCase,
+        clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
+        nowProvider: () => now,
+      );
+      addTearDown(alarmBloc.close);
+
+      await pumpWithRouter(tester, bloc: alarmBloc, router: router);
+      await tapAndPump(tester, find.byKey(const Key('alarm_close_button')));
+      await pumpUntilFound(tester, find.byType(TwoActionDialog));
+
+      await tapAndPump(tester, find.text("I'm leaving"));
+      await pumpUntilRouteText(tester, 'HOME');
+
+      expect(find.text('HOME'), findsOneWidget);
+      alarmBloc.add(const ScheduleFinished(0));
+      await tester.pump();
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
     testWidgets(
         'manual finish before leave time sends lateness 0 and navigates',
         (tester) async {


### PR DESCRIPTION
Summary
- add a top-right “Back to Home” close button in the active alarm view so the escape control stays consistently accessible
- reuse the existing leave confirmation dialog and keep the early-start/home behavior unchanged
- navigate to `/home` only after confirming the leave dialog to avoid accidental exits

Testing
- Not run (not requested)