### PR TITLE
Refresh calendar schedules on edit and refresh events

### DIFF
--- a/lib/data/repositories/schedule_repository_impl.dart
+++ b/lib/data/repositories/schedule_repository_impl.dart
@@ -45,7 +45,8 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
       await _clearTimedPreparationSafe(schedule.id);
       //await scheduleLocalDataSource.deleteSchedule(schedule);
       _scheduleStreamController.add(
-        Set.from(_scheduleStreamController.value)..remove(schedule),
+        Set.from(_scheduleStreamController.value)
+          ..removeWhere((existing) => existing.id == schedule.id),
       );
     } catch (e) {
       rethrow;
@@ -81,7 +82,11 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
           await _clearTimedPreparationSafe(schedule.id);
         }
       }
-      _emitUpsertedSchedules(schedules);
+      _replaceSchedulesInRange(
+        startDate: startDate,
+        endDate: endDate,
+        schedules: schedules,
+      );
       return schedules;
     } catch (e) {
       rethrow;
@@ -150,6 +155,24 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
         Set<ScheduleEntity>.from(_scheduleStreamController.value);
     for (final schedule in schedules) {
       nextSchedules.removeWhere((existing) => existing.id == schedule.id);
+      nextSchedules.add(schedule);
+    }
+    _scheduleStreamController.add(nextSchedules);
+  }
+
+  void _replaceSchedulesInRange({
+    required DateTime startDate,
+    required DateTime? endDate,
+    required Iterable<ScheduleEntity> schedules,
+  }) {
+    final nextSchedules =
+        Set<ScheduleEntity>.from(_scheduleStreamController.value)
+          ..removeWhere(
+            (existing) =>
+                !existing.scheduleTime.isBefore(startDate) &&
+                (endDate == null || existing.scheduleTime.isBefore(endDate)),
+          );
+    for (final schedule in schedules) {
       nextSchedules.add(schedule);
     }
     _scheduleStreamController.add(nextSchedules);

--- a/lib/data/repositories/schedule_repository_impl.dart
+++ b/lib/data/repositories/schedule_repository_impl.dart
@@ -25,16 +25,14 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
 
   @override
   Stream<Set<ScheduleEntity>> get scheduleStream =>
-      _scheduleStreamController.asBroadcastStream();
+      _scheduleStreamController.stream;
 
   @override
   Future<void> createSchedule(ScheduleEntity schedule) async {
     try {
       await scheduleRemoteDataSource.createSchedule(schedule);
       //await scheduleLocalDataSource.createSchedule(schedule);
-      _scheduleStreamController.add(
-        Set.from(_scheduleStreamController.value)..add(schedule),
-      );
+      _emitUpsertedSchedule(schedule);
     } catch (e) {
       rethrow;
     }
@@ -61,9 +59,7 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
       if (_isEnded(schedule.doneStatus)) {
         await _clearTimedPreparationSafe(schedule.id);
       }
-      _scheduleStreamController.add(
-        Set.from(_scheduleStreamController.value)..add(schedule),
-      );
+      _emitUpsertedSchedule(schedule);
       return schedule;
     } catch (e) {
       rethrow;
@@ -85,14 +81,7 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
           await _clearTimedPreparationSafe(schedule.id);
         }
       }
-      final mergedSchedules = Set<ScheduleEntity>.from(
-        _scheduleStreamController.value,
-      );
-      for (final schedule in schedules) {
-        mergedSchedules.removeWhere((existing) => existing.id == schedule.id);
-        mergedSchedules.add(schedule);
-      }
-      _scheduleStreamController.add(mergedSchedules);
+      _emitUpsertedSchedules(schedules);
       return schedules;
     } catch (e) {
       rethrow;
@@ -104,11 +93,13 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
     try {
       await scheduleRemoteDataSource.updateSchedule(schedule);
       await _clearTimedPreparationSafe(schedule.id);
-      _scheduleStreamController.add(
-        Set.from(_scheduleStreamController.value)
-          ..remove(schedule)
-          ..add(schedule),
+      final refreshedSchedule = await scheduleRemoteDataSource.getScheduleById(
+        schedule.id,
       );
+      if (_isEnded(refreshedSchedule.doneStatus)) {
+        await _clearTimedPreparationSafe(refreshedSchedule.id);
+      }
+      _emitUpsertedSchedule(refreshedSchedule);
       //await scheduleLocalDataSource.updateSchedule(schedule);
     } catch (e) {
       rethrow;
@@ -126,11 +117,7 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
       final schedule = _scheduleStreamController.value.firstWhere(
         (schedule) => schedule.id == scheduleId,
       );
-      _scheduleStreamController.add(
-        Set.from(_scheduleStreamController.value)
-          ..remove(schedule)
-          ..add(schedule.copyWith(doneStatus: lateStatus)),
-      );
+      _emitUpsertedSchedule(schedule.copyWith(doneStatus: lateStatus));
     } catch (e) {
       rethrow;
     }
@@ -148,5 +135,23 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
     } catch (_) {
       // Best-effort cleanup: cache invalidation must not fail schedule operations.
     }
+  }
+
+  void _emitUpsertedSchedule(ScheduleEntity schedule) {
+    final nextSchedules =
+        Set<ScheduleEntity>.from(_scheduleStreamController.value)
+          ..removeWhere((existing) => existing.id == schedule.id)
+          ..add(schedule);
+    _scheduleStreamController.add(nextSchedules);
+  }
+
+  void _emitUpsertedSchedules(Iterable<ScheduleEntity> schedules) {
+    final nextSchedules =
+        Set<ScheduleEntity>.from(_scheduleStreamController.value);
+    for (final schedule in schedules) {
+      nextSchedules.removeWhere((existing) => existing.id == schedule.id);
+      nextSchedules.add(schedule);
+    }
+    _scheduleStreamController.add(nextSchedules);
   }
 }

--- a/lib/domain/entities/place_entity.dart
+++ b/lib/domain/entities/place_entity.dart
@@ -1,6 +1,8 @@
+import 'package:equatable/equatable.dart';
+
 import '/core/database/database.dart';
 
-class PlaceEntity {
+class PlaceEntity extends Equatable {
   final String id;
   final String placeName;
 
@@ -22,4 +24,7 @@ class PlaceEntity {
       placeName: placeName,
     );
   }
+
+  @override
+  List<Object?> get props => [id, placeName];
 }

--- a/lib/domain/entities/schedule_entity.dart
+++ b/lib/domain/entities/schedule_entity.dart
@@ -96,18 +96,6 @@ class ScheduleEntity extends Equatable {
   }
 
   @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is ScheduleEntity && other.id == id;
-  }
-
-  @override
-  int get hashCode {
-    return id.hashCode;
-  }
-
-  @override
   List<Object?> get props => [
         id,
         place,

--- a/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
@@ -29,6 +29,7 @@ class MonthlySchedulesBloc
   ) : super(MonthlySchedulesState()) {
     on<MonthlySchedulesSubscriptionRequested>(_onSubscriptionRequested);
     on<MonthlySchedulesMonthAdded>(_onMonthAdded);
+    on<MonthlySchedulesRefreshRequested>(_onRefreshRequested);
     on<MonthlySchedulesScheduleDeleted>(_onScheduleDeleted);
     on<MonthlySchedulesVisibleDateChanged>(_onVisibleDateChanged);
     on<MonthlySchedulesPreparationsPrefetchRequested>(
@@ -159,6 +160,19 @@ class MonthlySchedulesBloc
       ));
       await _deleteScheduleUseCase(event.schedule);
     } catch (e) {
+      emit(state.copyWith(
+        status: () => MonthlySchedulesStatus.error,
+      ));
+    }
+  }
+
+  Future<void> _onRefreshRequested(
+    MonthlySchedulesRefreshRequested event,
+    Emitter<MonthlySchedulesState> emit,
+  ) async {
+    try {
+      await _loadSchedulesForMonthUseCase(event.date);
+    } catch (_) {
       emit(state.copyWith(
         status: () => MonthlySchedulesStatus.error,
       ));

--- a/lib/presentation/calendar/bloc/monthly_schedules_event.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_event.dart
@@ -32,6 +32,15 @@ final class MonthlySchedulesMonthAdded extends MonthlySchedulesEvent {
   List<Object> get props => [date];
 }
 
+final class MonthlySchedulesRefreshRequested extends MonthlySchedulesEvent {
+  final DateTime date;
+
+  const MonthlySchedulesRefreshRequested({required this.date});
+
+  @override
+  List<Object> get props => [date.year, date.month];
+}
+
 final class MonthlySchedulesScheduleDeleted extends MonthlySchedulesEvent {
   final ScheduleEntity schedule;
 

--- a/lib/presentation/calendar/component/schedule_detail.dart
+++ b/lib/presentation/calendar/component/schedule_detail.dart
@@ -81,10 +81,20 @@ class _ScheduleDetailState extends State<ScheduleDetail> {
     bottom: 4.0,
   );
 
+  String get _scheduleRenderKey => [
+        widget.schedule.id,
+        widget.schedule.scheduleName,
+        widget.schedule.place.placeName,
+        widget.schedule.scheduleTime.millisecondsSinceEpoch,
+        widget.schedule.moveTime.inMinutes,
+        widget.schedule.scheduleSpareTime?.inMinutes ?? -1,
+        widget.schedule.doneStatus.name,
+      ].join('|');
+
   @override
   Widget build(BuildContext context) {
     return SwipeActionCell(
-      key: ValueKey<String>(widget.schedule.id),
+      key: ValueKey<String>(_scheduleRenderKey),
       backgroundColor: Colors.transparent,
       trailingActions: _buildSwipeActions(context),
       child: _buildScheduleContent(context),

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -71,6 +71,46 @@ class _CalendarScreenState extends State<CalendarScreen> {
     });
   }
 
+  Future<void> _refreshSchedulesIfSaved(
+      BuildContext context, bool? saved) async {
+    if (saved != true || !mounted) {
+      return;
+    }
+
+    context.read<MonthlySchedulesBloc>().add(
+          MonthlySchedulesRefreshRequested(date: _selectedDate),
+        );
+  }
+
+  Future<void> _openCreateScheduleSheet(BuildContext context) async {
+    final saved = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => ScheduleCreateScreen(
+        initialDate: _selectedDate,
+      ),
+    );
+
+    await _refreshSchedulesIfSaved(context, saved);
+  }
+
+  Future<void> _openEditScheduleSheet(
+    BuildContext context, {
+    required String scheduleId,
+  }) async {
+    final saved = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => ScheduleEditScreen(
+        scheduleId: scheduleId,
+      ),
+    );
+
+    await _refreshSchedulesIfSaved(context, saved);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -280,17 +320,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
                                   ),
                                   if (!isPastSelectedDay)
                                     ElevatedButton(
-                                      onPressed: () {
-                                        showModalBottomSheet(
-                                          context: context,
-                                          isScrollControlled: true,
-                                          backgroundColor: Colors.transparent,
-                                          builder: (context) =>
-                                              ScheduleCreateScreen(
-                                            initialDate: _selectedDate,
-                                          ),
-                                        );
-                                      },
+                                      onPressed: () =>
+                                          _openCreateScheduleSheet(context),
                                       style: ElevatedButton.styleFrom(
                                         backgroundColor:
                                             theme.colorScheme.surface,
@@ -332,13 +363,9 @@ class _CalendarScreenState extends State<CalendarScreen> {
                                       state.preparationDurationByScheduleId[
                                           schedule.id],
                                   onEdit: () {
-                                    showModalBottomSheet(
-                                      context: context,
-                                      isScrollControlled: true,
-                                      backgroundColor: Colors.transparent,
-                                      builder: (context) => ScheduleEditScreen(
-                                        scheduleId: schedule.id,
-                                      ),
+                                    _openEditScheduleSheet(
+                                      context,
+                                      scheduleId: schedule.id,
                                     );
                                   },
                                   onDeleted: () {

--- a/test/data/repositories/schedule_repository_impl_stream_test.dart
+++ b/test/data/repositories/schedule_repository_impl_stream_test.dart
@@ -32,10 +32,18 @@ class FakeScheduleLocalDataSource implements ScheduleLocalDataSource {
 }
 
 class FakeScheduleRemoteDataSource implements ScheduleRemoteDataSource {
-  FakeScheduleRemoteDataSource({required this.getSchedulesByDateHandler});
+  FakeScheduleRemoteDataSource({
+    required this.getSchedulesByDateHandler,
+    Future<ScheduleEntity> Function(String id)? getScheduleByIdHandler,
+    Future<void> Function(ScheduleEntity schedule)? updateScheduleHandler,
+  })  : getScheduleByIdHandler =
+            getScheduleByIdHandler ?? ((_) async => throw UnimplementedError()),
+        updateScheduleHandler = updateScheduleHandler ?? ((_) async {});
 
   Future<List<ScheduleEntity>> Function(DateTime startDate, DateTime? endDate)
       getSchedulesByDateHandler;
+  Future<ScheduleEntity> Function(String id) getScheduleByIdHandler;
+  Future<void> Function(ScheduleEntity schedule) updateScheduleHandler;
 
   @override
   Future<void> createSchedule(ScheduleEntity schedule) async {}
@@ -48,7 +56,7 @@ class FakeScheduleRemoteDataSource implements ScheduleRemoteDataSource {
 
   @override
   Future<ScheduleEntity> getScheduleById(String id) async {
-    throw UnimplementedError();
+    return getScheduleByIdHandler(id);
   }
 
   @override
@@ -60,7 +68,9 @@ class FakeScheduleRemoteDataSource implements ScheduleRemoteDataSource {
   }
 
   @override
-  Future<void> updateSchedule(ScheduleEntity schedule) async {}
+  Future<void> updateSchedule(ScheduleEntity schedule) {
+    return updateScheduleHandler(schedule);
+  }
 }
 
 class FakeTimedPreparationRepository implements TimedPreparationRepository {
@@ -137,5 +147,57 @@ void main() {
     expect(latest.first.scheduleName, 'New Name');
     expect(latest.first.place.placeName, 'New Place');
     expect(latest.first.moveTime, const Duration(minutes: 25));
+  });
+
+  test('updateSchedule refreshes edited schedule into stream cache', () async {
+    final initialSchedule = ScheduleEntity(
+      id: 'schedule-1',
+      place: PlaceEntity(id: 'place-1', placeName: 'Old Place'),
+      scheduleName: 'Old Name',
+      scheduleTime: DateTime(2026, 3, 20, 9, 0),
+      moveTime: const Duration(minutes: 10),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 5),
+      scheduleNote: 'old',
+    );
+
+    final editedSchedule = ScheduleEntity(
+      id: 'schedule-1',
+      place: PlaceEntity(id: 'place-1', placeName: 'New Place'),
+      scheduleName: 'Edited Name',
+      scheduleTime: DateTime(2026, 3, 20, 10, 30),
+      moveTime: const Duration(minutes: 20),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 15),
+      scheduleNote: 'updated',
+    );
+
+    final repository = ScheduleRepositoryImpl(
+      scheduleLocalDataSource: FakeScheduleLocalDataSource(),
+      scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+        getSchedulesByDateHandler: (_, __) async => [initialSchedule],
+        getScheduleByIdHandler: (_) async => editedSchedule,
+      ),
+      timedPreparationRepository: FakeTimedPreparationRepository(),
+    );
+
+    await repository.createSchedule(initialSchedule);
+    await repository.updateSchedule(editedSchedule);
+
+    final latest = await repository.scheduleStream.firstWhere(
+      (schedules) =>
+          schedules.length == 1 &&
+          schedules.first.scheduleName == 'Edited Name' &&
+          schedules.first.scheduleTime == DateTime(2026, 3, 20, 10, 30),
+    );
+
+    expect(latest.length, 1);
+    expect(latest.first.id, 'schedule-1');
+    expect(latest.first.scheduleName, 'Edited Name');
+    expect(latest.first.place.placeName, 'New Place');
+    expect(latest.first.moveTime, const Duration(minutes: 20));
+    expect(latest.first.scheduleSpareTime, const Duration(minutes: 15));
   });
 }

--- a/test/data/repositories/schedule_repository_impl_test.dart
+++ b/test/data/repositories/schedule_repository_impl_test.dart
@@ -268,10 +268,13 @@ void main() {
       () async {
         when(mockScheduleRemoteDataSource.updateSchedule(tScheduleEntity))
             .thenAnswer((_) async {});
+        when(mockScheduleRemoteDataSource.getScheduleById(scheduleEntityId))
+            .thenAnswer((_) async => tScheduleEntity);
 
         await scheduleRepository.updateSchedule(tScheduleEntity);
 
         verify(mockScheduleRemoteDataSource.updateSchedule(tScheduleEntity));
+        verify(mockScheduleRemoteDataSource.getScheduleById(scheduleEntityId));
         expect(fakeTimedPreparationRepository.clearedIds, [scheduleEntityId]);
       },
     );

--- a/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
+++ b/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
@@ -309,4 +309,82 @@ void main() {
       const Duration(minutes: 15),
     );
   });
+
+  test('schedule stream update refreshes schedule fields in monthly state',
+      () async {
+    final controller = StreamController<List<ScheduleEntity>>();
+    addTearDown(controller.close);
+    getSchedulesByDateUseCase = StubGetSchedulesByDateUseCase(
+      (_, __) => controller.stream,
+    );
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesVisibleDateChanged(date: selectedDate));
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+
+    controller.add([scheduleA, scheduleB]);
+    await bloc.stream.firstWhere(
+      (state) =>
+          state.schedules[selectedDate]?.any(
+            (schedule) => schedule.scheduleName == 'Meeting',
+          ) ??
+          false,
+    );
+
+    final updatedScheduleA = ScheduleEntity(
+      id: scheduleA.id,
+      place: PlaceEntity(id: scheduleA.place.id, placeName: 'New Office'),
+      scheduleName: 'Edited Meeting',
+      scheduleTime: DateTime(2026, 3, 20, 10, 30),
+      moveTime: const Duration(minutes: 45),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 20),
+      scheduleNote: '',
+    );
+
+    final updatedStateFuture = bloc.stream.firstWhere(
+      (state) =>
+          state.schedules[selectedDate]?.any(
+            (schedule) =>
+                schedule.id == scheduleA.id &&
+                schedule.scheduleName == 'Edited Meeting' &&
+                schedule.place.placeName == 'New Office' &&
+                schedule.scheduleTime == DateTime(2026, 3, 20, 10, 30),
+          ) ??
+          false,
+    );
+    controller.add([updatedScheduleA, scheduleB]);
+    final updatedState = await updatedStateFuture;
+
+    final updatedSchedule = updatedState.schedules[selectedDate]!.firstWhere(
+      (schedule) => schedule.id == scheduleA.id,
+    );
+    expect(updatedSchedule.scheduleName, 'Edited Meeting');
+    expect(updatedSchedule.place.placeName, 'New Office');
+    expect(updatedSchedule.scheduleTime, DateTime(2026, 3, 20, 10, 30));
+    expect(updatedSchedule.moveTime, const Duration(minutes: 45));
+    expect(updatedSchedule.scheduleSpareTime, const Duration(minutes: 20));
+  });
+
+  test('refresh requested reloads schedules for current month', () async {
+    var loadedDate = DateTime(2000);
+    loadSchedulesForMonthUseCase = StubLoadSchedulesForMonthUseCase(
+      (date) async {
+        loadedDate = date;
+      },
+    );
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(
+      MonthlySchedulesRefreshRequested(date: DateTime(2026, 3, 20)),
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(loadedDate, DateTime(2026, 3, 20));
+  });
 }

--- a/test/presentation/calendar/component/schedule_detail_test.dart
+++ b/test/presentation/calendar/component/schedule_detail_test.dart
@@ -36,8 +36,10 @@ void main() {
 
   Future<void> pumpScheduleDetail(
     WidgetTester tester, {
+    ScheduleEntity? customSchedule,
     Duration? preparationTime,
   }) async {
+    final targetSchedule = customSchedule ?? schedule;
     await tester.pumpWidget(
       DefaultAssetBundle(
         bundle: _FakeSvgAssetBundle(),
@@ -47,7 +49,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: ScheduleDetail(
-              schedule: schedule,
+              schedule: targetSchedule,
               preparationTime: preparationTime,
             ),
           ),
@@ -140,5 +142,38 @@ void main() {
     final expandedHeight = getMaxActionButtonHeight(tester);
 
     expect(expandedHeight, greaterThan(collapsedHeight));
+  });
+
+  testWidgets('tile text updates when schedule fields change for same id',
+      (tester) async {
+    await pumpScheduleDetail(tester);
+
+    expect(find.text('Design Review'), findsOneWidget);
+    expect(find.text('Office'), findsOneWidget);
+    expect(find.text('09:00'), findsOneWidget);
+
+    final updatedSchedule = ScheduleEntity(
+      id: 'schedule-1',
+      place: PlaceEntity(id: 'place-1', placeName: 'New Office'),
+      scheduleName: 'Edited Review',
+      scheduleTime: DateTime(2026, 3, 20, 10, 30),
+      moveTime: const Duration(minutes: 45),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 20),
+      scheduleNote: '',
+    );
+
+    await pumpScheduleDetail(
+      tester,
+      customSchedule: updatedSchedule,
+    );
+
+    expect(find.text('Edited Review'), findsOneWidget);
+    expect(find.text('New Office'), findsOneWidget);
+    expect(find.text('10:30'), findsOneWidget);
+    expect(find.text('Design Review'), findsNothing);
+    expect(find.text('Office'), findsNothing);
+    expect(find.text('09:00'), findsNothing);
   });
 }

--- a/test/presentation/schedule_create/bloc/schedule_form_bloc_test.dart
+++ b/test/presentation/schedule_create/bloc/schedule_form_bloc_test.dart
@@ -219,6 +219,60 @@ void main() {
     );
   });
 
+  test('ScheduleFormUpdated sends edited schedule fields to update use case',
+      () async {
+    ScheduleEntity? updatedSchedule;
+    updateScheduleUseCase = StubUpdateScheduleUseCase((schedule) async {
+      updatedSchedule = schedule;
+    });
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    final editReady = bloc.stream.firstWhere(
+      (state) => state.status == ScheduleFormStatus.success,
+    );
+    bloc.add(const ScheduleFormEditRequested(scheduleId: 'schedule-1'));
+    await editReady;
+
+    bloc.add(
+      const ScheduleFormScheduleNameChanged(scheduleName: 'Edited Meeting'),
+    );
+    bloc.add(
+      ScheduleFormScheduleDateTimeChanged(
+        scheduleDate: DateTime(2026, 3, 21),
+        scheduleTime: DateTime(2026, 3, 21, 10, 30),
+      ),
+    );
+    bloc.add(const ScheduleFormPlaceNameChanged(placeName: 'New Office'));
+    bloc.add(
+      const ScheduleFormMoveTimeChanged(moveTime: Duration(minutes: 45)),
+    );
+    bloc.add(
+      const ScheduleFormScheduleSpareTimeChanged(
+        scheduleSpareTime: Duration(minutes: 25),
+      ),
+    );
+
+    final submitDone = bloc.stream.firstWhere(
+      (state) => state.submissionStatus == ScheduleFormSubmissionStatus.success,
+    );
+    bloc.add(const ScheduleFormUpdated());
+    await submitDone;
+
+    expect(updatedSchedule, isNotNull);
+    expect(updatedSchedule!.id, 'schedule-1');
+    expect(updatedSchedule!.place.id, 'place-1');
+    expect(updatedSchedule!.place.placeName, 'New Office');
+    expect(updatedSchedule!.scheduleName, 'Edited Meeting');
+    expect(updatedSchedule!.scheduleTime, DateTime(2026, 3, 21, 10, 30));
+    expect(updatedSchedule!.moveTime, const Duration(minutes: 45));
+    expect(
+      updatedSchedule!.scheduleSpareTime,
+      const Duration(minutes: 25),
+    );
+  });
+
   test('ScheduleFormUpdated emits submitting then failure on error', () async {
     updateScheduleUseCase =
         StubUpdateScheduleUseCase((_) => Future.error(Exception('update')));

--- a/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
+++ b/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
@@ -390,4 +390,43 @@ void main() {
     expect(find.byType(ScheduleMultiPageForm), findsOneWidget);
     expect(find.byType(SnackBar), findsOneWidget);
   });
+
+  testWidgets('edited name and place are submitted from form steps',
+      (tester) async {
+    ScheduleEntity? updatedSchedule;
+    updateScheduleUseCase.handler = (schedule) async {
+      updatedSchedule = schedule;
+    };
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    await _primeEditState(bloc);
+    await _pumpSheet(tester, bloc);
+
+    Finder nextButton() => find.descendant(
+          of: find.byType(TopBar),
+          matching: find.byType(TextButton),
+        );
+
+    await tester.enterText(find.byType(TextFormField).first, 'Edited Meeting');
+    await tester.pump();
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextFormField).first, 'New Office');
+    await tester.pump();
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    expect(updatedSchedule, isNotNull);
+    expect(updatedSchedule!.scheduleName, 'Edited Meeting');
+    expect(updatedSchedule!.place.placeName, 'New Office');
+  });
 }


### PR DESCRIPTION
## Summary
- ensure schedule stream controller emits updated cache entries and refreshes month data after create/edit operations
- key calendar tiles by all relevant schedule fields so Flutter rebuilds them when any detail changes
- wire calendar screen to refresh schedules after add/edit sheets and add bloc refresh event handling plus new tests for stream behavior and form submissions

## Testing
- Not run (not requested)