### PR TITLE
[codex] Fix preparation start boundary

### DIFF
--- a/lib/presentation/app/bloc/schedule/schedule_bloc.dart
+++ b/lib/presentation/app/bloc/schedule/schedule_bloc.dart
@@ -179,7 +179,14 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     }
 
     _activeEarlyStartScheduleId = null;
-    if (_isPreparationOnGoing(resolvedSchedule)) {
+    if (_isAtPreparationStartBoundary(resolvedSchedule, now)) {
+      emit(ScheduleState.upcoming(resolvedSchedule));
+      debugPrint('preparation boundary reached: $resolvedSchedule');
+      add(const ScheduleStarted());
+      return;
+    }
+
+    if (_isPreparationOnGoing(resolvedSchedule, now)) {
       emit(ScheduleState.ongoing(resolvedSchedule));
       debugPrint(
           'ongoingSchedule: $resolvedSchedule, currentStep: ${resolvedSchedule.preparation.currentStep}');
@@ -267,15 +274,20 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       _activeEarlyStartScheduleId = null;
       _lastSnapshotSavedAt = null;
       emit(const ScheduleState.notExists());
-    } catch (_) {
-      debugPrint('error finishing schedule: $_');
+    } catch (error) {
+      debugPrint('error finishing schedule: $error');
     }
   }
 
   void _startScheduleTimer(ScheduleWithPreparationEntity schedule) {
     final now = _nowProvider();
     final target = schedule.preparationStartTime;
-    if (!target.isAfter(now)) return;
+    if (!target.isAfter(now)) {
+      if (!isClosed && _currentScheduleId == schedule.id) {
+        add(const ScheduleStarted());
+      }
+      return;
+    }
     final duration = target.difference(now);
     _scheduleStartTimer = Timer(duration, () {
       // Only add event if bloc is still active and schedule ID matches
@@ -363,9 +375,18 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     await _clearEarlyStartSessionUseCase(scheduleId);
   }
 
-  bool _isPreparationOnGoing(ScheduleWithPreparationEntity schedule) {
+  bool _isAtPreparationStartBoundary(
+    ScheduleWithPreparationEntity schedule,
+    DateTime now,
+  ) {
+    return schedule.preparationStartTime.isAtSameMomentAs(now);
+  }
+
+  bool _isPreparationOnGoing(
+    ScheduleWithPreparationEntity schedule,
+    DateTime now,
+  ) {
     final start = schedule.preparationStartTime;
-    final now = _nowProvider();
     return start.isBefore(now) && schedule.scheduleTime.isAfter(now);
   }
 

--- a/test/presentation/app/bloc/schedule/schedule_bloc_test.dart
+++ b/test/presentation/app/bloc/schedule/schedule_bloc_test.dart
@@ -301,6 +301,62 @@ void main() {
       expect(navigationService.pushedRoutes, ['/scheduleStart']);
     });
 
+    test(
+        'when received exactly at preparationStartTime it starts and navigates once',
+        () async {
+      final schedule = buildSchedule(
+        id: 'exact-boundary',
+        scheduleTime: now.add(const Duration(minutes: 40)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'a',
+            preparationName: 'a',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+      expect(schedule.preparationStartTime, now);
+
+      bloc.add(ScheduleUpcomingReceived(schedule));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.status, ScheduleStatus.started);
+      expect(bloc.state.schedule?.id, 'exact-boundary');
+      expect(bloc.state.isEarlyStarted, isFalse);
+      expect(navigationService.pushedRoutes, ['/scheduleStart']);
+    });
+
+    test(
+        'when early-started schedule is received at boundary it does not navigate again',
+        () async {
+      final schedule = buildSchedule(
+        id: 'early-boundary',
+        scheduleTime: now.add(const Duration(minutes: 40)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'a',
+            preparationName: 'a',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+      expect(schedule.preparationStartTime, now);
+      markEarlySessionUseCase.sessions['early-boundary'] =
+          now.subtract(const Duration(minutes: 1));
+
+      bloc.add(ScheduleUpcomingReceived(schedule));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.status, ScheduleStatus.started);
+      expect(bloc.state.schedule?.id, 'early-boundary');
+      expect(bloc.state.isEarlyStarted, isTrue);
+      expect(navigationService.pushedRoutes, isEmpty);
+    });
+
     test('late entry fast-forwards elapsed preparation to current step',
         () async {
       final schedule = buildSchedule(


### PR DESCRIPTION
## Summary
- handle schedules received exactly at `preparationStartTime` through the official `ScheduleStarted` path
- defensively start schedules when a timer target is already at or before `now`
- add boundary tests for exact receive and early-start sessions

Fixes #362

## Validation
- `flutter test test/presentation/app/bloc/schedule/schedule_bloc_test.dart`
- `dart analyze lib/presentation/app/bloc/schedule/schedule_bloc.dart test/presentation/app/bloc/schedule/schedule_bloc_test.dart`
- `git diff --check`

Note: full `flutter analyze` still reports existing unrelated widgetbook/generated-file errors.
