### PR TITLE
[codex] Show ready state after preparation completion

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -95,6 +95,10 @@
     "@finishPreparation": {
         "description": "Button text to finish preparing"
     },
+    "preparationReadyToGo": "Ready to go",
+    "@preparationReadyToGo": {
+        "description": "Center timer label shown after all preparation steps are complete and there is still time before leaving"
+    },
     "signInSlogan": "We'll find your lost leisure.",
     "@signInSlogan": {
         "description": "Slogan on the sign-in screen"

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -23,6 +23,7 @@
     "preparationCompletedDescription": "준비 단계를 모두 완료했어요.\n지금 종료하거나 계속 준비할 수 있어요.",
     "continuePreparing": "계속 준비",
     "finishPreparation": "준비 종료",
+    "preparationReadyToGo": "출발 준비 완료",
     "signInSlogan": "당신의 잃어버린 여유를 찾아드립니다.",
     "welcome": "반가워요!",
     "onboardingStartSubtitle": "Ontime과 함께 준비하기 위해서\n평소 본인의 준비 과정을 알려주세요",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -242,6 +242,12 @@ abstract class AppLocalizations {
   /// **'Finish Preparation'**
   String get finishPreparation;
 
+  /// Center timer label shown after all preparation steps are complete and there is still time before leaving
+  ///
+  /// In en, this message translates to:
+  /// **'Ready to go'**
+  String get preparationReadyToGo;
+
   /// Slogan on the sign-in screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -86,6 +86,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get finishPreparation => 'Finish Preparation';
 
   @override
+  String get preparationReadyToGo => 'Ready to go';
+
+  @override
   String get signInSlogan => 'We\'ll find your lost leisure.';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -84,6 +84,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get finishPreparation => '준비 종료';
 
   @override
+  String get preparationReadyToGo => '출발 준비 완료';
+
+  @override
   String get signInSlogan => '당신의 잃어버린 여유를 찾아드립니다.';
 
   @override

--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -181,8 +181,8 @@ class _AlarmScreenState extends State<AlarmScreen> {
               });
             }
 
-            _ensureUiTicker(preparation.isAllStepsDone &&
-                _isContinuingAfterCompletion);
+            _ensureUiTicker(
+                preparation.isAllStepsDone && _isContinuingAfterCompletion);
             return _buildAlarmScreen(
               schedule: schedule,
             );
@@ -236,17 +236,22 @@ class _AlarmScreenState extends State<AlarmScreen> {
     final timeRemainingBeforeLeaving = _timeRemainingBeforeLeaving(schedule);
     final isLate = timeRemainingBeforeLeaving.isNegative;
     final preparation = schedule.preparation;
-    final isLateContinueMode =
-        preparation.isAllStepsDone && _isContinuingAfterCompletion && isLate;
-    final timerLabel =
-        isLateContinueMode ? '지각이에요' : preparation.currentStepName;
+    final l10n = AppLocalizations.of(context)!;
+    final isContinuingAfterCompletion =
+        preparation.isAllStepsDone && _isContinuingAfterCompletion;
+    final isLateContinueMode = isContinuingAfterCompletion && isLate;
+    final isReadyContinueMode = isContinuingAfterCompletion && !isLate;
+    final timerLabel = isLateContinueMode
+        ? '지각이에요'
+        : isReadyContinueMode
+            ? l10n.preparationReadyToGo
+            : preparation.currentStepName;
     final displayProgress = isLateContinueMode ? 0.0 : preparation.progress;
-    final displayRemainingSeconds = preparation.isAllStepsDone &&
-            _isContinuingAfterCompletion
+    final displayRemainingSeconds = isContinuingAfterCompletion
         ? timeRemainingBeforeLeaving.inSeconds.abs()
         : preparation.currentStepRemainingTime.inSeconds;
 
-    if (!(preparation.isAllStepsDone && _isContinuingAfterCompletion)) {
+    if (!isContinuingAfterCompletion) {
       _ensureUiTicker(false);
     }
 
@@ -315,8 +320,9 @@ class _AlarmScreenState extends State<AlarmScreen> {
   Widget _buildEarlyStartReadyScreen(ScheduleWithPreparationEntity schedule) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final remaining =
-        schedule.preparationStartTime.difference(widget.nowProvider()).inSeconds;
+    final remaining = schedule.preparationStartTime
+        .difference(widget.nowProvider())
+        .inSeconds;
     final clampedRemaining = remaining.isNegative ? 0 : remaining;
 
     return Scaffold(

--- a/plans/364-ready-state-plan.md
+++ b/plans/364-ready-state-plan.md
@@ -1,0 +1,46 @@
+# Issue 364 Ready State Plan
+
+## Goal
+Make the alarm UI show an explicit ready/on-time state after every preparation step is complete, when the user chooses to keep the alarm screen open and the leave threshold has not yet passed.
+
+## Context
+- GitHub issue: https://github.com/DevKor-github/OnTime-front/issues/364
+- Current alarm UI logic lives in `lib/presentation/alarm/screens/alarm_screen.dart`.
+- `_buildAlarmScreen` currently sets `timerLabel` to `'지각이에요'` only for late-continue mode; otherwise it uses `preparation.currentStepName`.
+- When all steps are done, the user has tapped continue, and the leave threshold has not passed, `displayRemainingSeconds` already uses `timeRemainingBeforeLeaving`, so only the center label still looks like an active preparation step.
+- The completion dialog behavior should stay unchanged: completing all preparation steps shows the dialog but does not auto-finish the schedule.
+- Late-continue behavior should stay unchanged once `timeRemainingBeforeLeaving.isNegative` becomes true.
+- Localization sources live in `lib/l10n/app_en.arb` and `lib/l10n/app_ko.arb`; generated files live beside them.
+- Existing widget coverage is concentrated in `test/presentation/alarm/screens/preparation_flow_widget_test.dart`.
+
+## Decisions
+- Add a new localization key for the ready-state label rather than hard-coding copy in `AlarmScreen`.
+- Use `Ready to go` for English.
+- Use `출발 준비 완료` for Korean unless product/design requests different final wording.
+- Keep the current blue/on-time theme and progress behavior for all-done, continuing, not-late state.
+- Keep the red late-continue theme, zero graph progress, overdue countdown, and late label after the leave threshold.
+
+## Steps
+1. Add a ready-state localization key to `lib/l10n/app_en.arb` and `lib/l10n/app_ko.arb`, including an English description in the template ARB.
+2. Regenerate localization outputs with Flutter gen-l10n so `app_localizations.dart`, `app_localizations_en.dart`, and `app_localizations_ko.dart` expose the new getter.
+3. In `AlarmScreen._buildAlarmScreen`, derive three readable booleans:
+   - `isContinuingAfterCompletion = preparation.isAllStepsDone && _isContinuingAfterCompletion`
+   - `isLateContinueMode = isContinuingAfterCompletion && isLate`
+   - `isReadyContinueMode = isContinuingAfterCompletion && !isLate`
+4. Set `timerLabel` to:
+   - `l10n.lateContinueLabel` or the existing late copy key if one is introduced for the current hard-coded `'지각이에요'`
+   - `l10n.preparationReadyToGo` for ready-continue mode
+   - `preparation.currentStepName` for normal active-step mode
+5. Preserve the current `displayRemainingSeconds` behavior so both ready-continue and late-continue modes use `timeRemainingBeforeLeaving.inSeconds.abs()`, while active preparation still uses `preparation.currentStepRemainingTime`.
+6. Update `completion dialog continue shows live leave countdown for ongoing flow` to assert the ready label is visible and the final step name is no longer used as the center timer label in the ready-continue state.
+7. Update or keep `completion dialog continue keeps overdue timer running after leave time` to assert the late label still appears after crossing the threshold, the overdue countdown remains visible, and the step list can still show the completed step name.
+8. Add Korean-ready-label expectations only where the test locale is Korean; if the test harness defaults to Korean, assert `출발 준비 완료`. If an English-locale path is easy to set up in the existing helpers, add a small English assertion for `Ready to go`.
+
+## Validation
+- `flutter gen-l10n`
+- `dart format lib/l10n lib/presentation/alarm/screens/alarm_screen.dart test/presentation/alarm/screens/preparation_flow_widget_test.dart`
+- `flutter test test/presentation/alarm/screens/preparation_flow_widget_test.dart`
+- `flutter analyze`
+
+## Open Questions
+- Confirm whether `출발 준비 완료` is the final Korean copy. It is a safe implementation default because it is short, explicit, and clearly distinct from both an active preparation step and a late state.

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -970,6 +970,7 @@ void main() {
         const Color(0xFF5C79FB).value,
       );
       expect(find.text('EARLYLATE'), findsNothing);
+      expect(find.text('Ready to go'), findsOneWidget);
       expect(find.text('5분 뒤에 나가야 해요'), findsOneWidget);
       expect(find.text('05 : 00'), findsOneWidget);
       expect(finishUseCase.calls, isEmpty);
@@ -978,6 +979,7 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
 
       expect(find.text('4분 뒤에 나가야 해요'), findsOneWidget);
+      expect(find.text('Ready to go'), findsOneWidget);
       expect(find.text('04 : 00'), findsOneWidget);
 
       alarmBloc.add(const ScheduleFinished(0));
@@ -1143,7 +1145,9 @@ void main() {
         const Color(0xFFFF6953).value,
       );
       expect(
-        tester.widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator)).progress,
+        tester
+            .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
+            .progress,
         0.0,
       );
       expect(
@@ -1162,6 +1166,7 @@ void main() {
       );
       expect(find.text('준비시간을 1분 초과했어요'), findsOneWidget);
       expect(find.text('지각이에요'), findsOneWidget);
+      expect(find.text('Ready to go'), findsNothing);
       expect(find.text('01 : 00'), findsOneWidget);
       expect(find.text('Prep'), findsOneWidget);
 


### PR DESCRIPTION
## Summary
- Add a localized ready-state label for completed preparation before leave time.
- Show the ready label instead of the last preparation step while continuing before the leave threshold.
- Cover the ready state and late transition in the alarm preparation flow widget test.

Closes #364

## Validation
- `flutter gen-l10n`
- `dart format lib/l10n lib/presentation/alarm/screens/alarm_screen.dart test/presentation/alarm/screens/preparation_flow_widget_test.dart`
- `flutter test test/presentation/alarm/screens/preparation_flow_widget_test.dart`
- `dart analyze lib/presentation/alarm/screens/alarm_screen.dart lib/l10n test/presentation/alarm/screens/preparation_flow_widget_test.dart` (only existing deprecated `.value` infos in the test file)

## Notes
- Full `flutter analyze` still reports pre-existing unrelated issues, including missing/generated Widgetbook files.
