### PR TITLE
[codex] Normalize schedule start prompt variants

### DIFF
--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -364,7 +364,7 @@ class NotificationService {
       if (type != null && type.contains('5min')) {
         getIt.get<NavigationService>().push(
           '/scheduleStart',
-          extra: {'isFiveMinutesBefore': true},
+          extra: {'promptVariant': 'earlyStart'},
         );
       } else if (type != null &&
               (type.startsWith('schedule_') ||
@@ -390,7 +390,7 @@ class NotificationService {
     if (type != null && type.contains('5min')) {
       getIt.get<NavigationService>().push(
         '/scheduleStart',
-        extra: {'isFiveMinutesBefore': true},
+        extra: {'promptVariant': 'earlyStart'},
       );
     } else if (type != null &&
             (type.startsWith('schedule_') || type.startsWith('preparation_')) ||

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -225,9 +225,13 @@
     "@startPreparing": {
         "description": "Button text to start preparing"
     },
-    "prepareEarly": "Prepare Early",
-    "@prepareEarly": {
-        "description": "Button text on the early-start screen to start preparing before the scheduled preparation time"
+    "startPreparingNow": "Start preparing now",
+    "@startPreparingNow": {
+        "description": "Primary button text on the early-start screen to start preparing immediately"
+    },
+    "notNow": "Not now",
+    "@notNow": {
+        "description": "Secondary button text on the early-start screen to decline starting preparation now"
     },
     "confirmLeave": "Are you sure you want to leave?",
     "@confirmLeave": {
@@ -426,10 +430,6 @@
     "preparationStartsInFiveMinutes": "Preparation starts in 5 minutes.\nWould you like to start preparing early?",
     "@preparationStartsInFiveMinutes": {
         "description": "Message shown when receiving 5 minutes before notification"
-    },
-    "startInFiveMinutes": "Start in 5 minutes",
-    "@startInFiveMinutes": {
-        "description": "Button text to start in 5 minutes"
     },
     "preparationStartsEarlyBy": "You're starting {duration} early.\nWould you like to start preparing early now?",
     "@preparationStartsEarlyBy": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -53,7 +53,8 @@
     "ok": "확인",
     "youWillBeLate": "지금 준비 시작 안하면 늦어요!",
     "startPreparing": "준비 시작",
-    "prepareEarly": "미리 준비하기",
+    "startPreparingNow": "지금 준비 시작",
+    "notNow": "나중에",
     "confirmLeave": "정말 나가시겠어요?",
     "confirmLeaveDescription": "이 화면을 나가면\n함께 약속을 준비할 수 없게 돼요",
     "leave": "나갈래요",
@@ -131,10 +132,6 @@
     "preparationStartsInFiveMinutes": "5분 뒤에 준비가 시작돼요.\n미리 준비를 시작하시겠어요?",
     "@preparationStartsInFiveMinutes": {
         "description": "Message shown when receiving 5 minutes before notification"
-    },
-    "startInFiveMinutes": "5분 뒤에 시작하기",
-    "@startInFiveMinutes": {
-        "description": "Button text to start in 5 minutes"
     },
     "preparationStartsEarlyBy": "{duration} 일찍 준비를 시작할 수 있어요.\n지금 미리 준비를 시작할까요?",
     "@preparationStartsEarlyBy": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -422,11 +422,17 @@ abstract class AppLocalizations {
   /// **'Start Preparing'**
   String get startPreparing;
 
-  /// Button text on the early-start screen to start preparing before the scheduled preparation time
+  /// Primary button text on the early-start screen to start preparing immediately
   ///
   /// In en, this message translates to:
-  /// **'Prepare Early'**
-  String get prepareEarly;
+  /// **'Start preparing now'**
+  String get startPreparingNow;
+
+  /// Secondary button text on the early-start screen to decline starting preparation now
+  ///
+  /// In en, this message translates to:
+  /// **'Not now'**
+  String get notNow;
 
   /// Modal title to confirm leaving the screen
   ///
@@ -673,12 +679,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Preparation starts in 5 minutes.\nWould you like to start preparing early?'**
   String get preparationStartsInFiveMinutes;
-
-  /// Button text to start in 5 minutes
-  ///
-  /// In en, this message translates to:
-  /// **'Start in 5 minutes'**
-  String get startInFiveMinutes;
 
   /// Message shown when user opens schedule start before preparation start time from home, including the exact lead time
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -185,7 +185,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get startPreparing => 'Start Preparing';
 
   @override
-  String get prepareEarly => 'Prepare Early';
+  String get startPreparingNow => 'Start preparing now';
+
+  @override
+  String get notNow => 'Not now';
 
   @override
   String get confirmLeave => 'Are you sure you want to leave?';
@@ -340,9 +343,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get preparationStartsInFiveMinutes =>
       'Preparation starts in 5 minutes.\nWould you like to start preparing early?';
-
-  @override
-  String get startInFiveMinutes => 'Start in 5 minutes';
 
   @override
   String preparationStartsEarlyBy(String duration) {

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -179,7 +179,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get startPreparing => '준비 시작';
 
   @override
-  String get prepareEarly => '미리 준비하기';
+  String get startPreparingNow => '지금 준비 시작';
+
+  @override
+  String get notNow => '나중에';
 
   @override
   String get confirmLeave => '정말 나가시겠어요?';
@@ -316,9 +319,6 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get preparationStartsInFiveMinutes =>
       '5분 뒤에 준비가 시작돼요.\n미리 준비를 시작하시겠어요?';
-
-  @override
-  String get startInFiveMinutes => '5분 뒤에 시작하기';
 
   @override
   String preparationStartsEarlyBy(String duration) {

--- a/lib/presentation/alarm/screens/schedule_start_screen.dart
+++ b/lib/presentation/alarm/screens/schedule_start_screen.dart
@@ -12,8 +12,7 @@ import 'package:on_time_front/presentation/shared/constants/app_colors.dart';
 import 'package:on_time_front/presentation/shared/utils/duration_format.dart';
 
 enum ScheduleStartPromptVariant {
-  defaultPrompt,
-  fiveMinutes,
+  officialStart,
   earlyStart,
 }
 
@@ -21,13 +20,24 @@ ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteValue(
   String? value,
 ) {
   switch (value) {
-    case 'fiveMinutes':
-      return ScheduleStartPromptVariant.fiveMinutes;
     case 'earlyStart':
+    case 'fiveMinutes':
       return ScheduleStartPromptVariant.earlyStart;
     default:
-      return ScheduleStartPromptVariant.defaultPrompt;
+      return ScheduleStartPromptVariant.officialStart;
   }
+}
+
+ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteExtra(
+  Map<String, dynamic>? extra,
+) {
+  final isFiveMinutesBefore = extra?['isFiveMinutesBefore'] as bool? ?? false;
+  if (isFiveMinutesBefore) {
+    return ScheduleStartPromptVariant.earlyStart;
+  }
+  return scheduleStartPromptVariantFromRouteValue(
+    extra?['promptVariant'] as String?,
+  );
 }
 
 class ScheduleStartScreen extends StatefulWidget {
@@ -40,7 +50,7 @@ class ScheduleStartScreen extends StatefulWidget {
 
   const ScheduleStartScreen({
     super.key,
-    this.promptVariant = ScheduleStartPromptVariant.defaultPrompt,
+    this.promptVariant = ScheduleStartPromptVariant.officialStart,
     this.isFiveMinutesBefore = false,
   });
 
@@ -75,14 +85,14 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
   }
 
   ScheduleStartPromptVariant _resolvedPromptVariant() {
-    if (widget.promptVariant != ScheduleStartPromptVariant.defaultPrompt) {
+    if (widget.promptVariant != ScheduleStartPromptVariant.officialStart) {
       return widget.promptVariant;
     }
     // ignore: deprecated_member_use_from_same_package
     if (widget.isFiveMinutesBefore) {
-      return ScheduleStartPromptVariant.fiveMinutes;
+      return ScheduleStartPromptVariant.earlyStart;
     }
-    return ScheduleStartPromptVariant.defaultPrompt;
+    return ScheduleStartPromptVariant.officialStart;
   }
 
   String _buildPromptMessage(
@@ -91,11 +101,9 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     ScheduleWithPreparationEntity? schedule,
   ) {
     switch (variant) {
-      case ScheduleStartPromptVariant.fiveMinutes:
-        return AppLocalizations.of(context)!.preparationStartsInFiveMinutes;
       case ScheduleStartPromptVariant.earlyStart:
         return _buildEarlyStartPromptMessage(context, schedule);
-      case ScheduleStartPromptVariant.defaultPrompt:
+      case ScheduleStartPromptVariant.officialStart:
         return AppLocalizations.of(context)!.youWillBeLate;
     }
   }
@@ -123,7 +131,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     BuildContext context,
     ScheduleStartPromptVariant variant,
   ) {
-    if (variant != ScheduleStartPromptVariant.defaultPrompt) {
+    if (variant != ScheduleStartPromptVariant.officialStart) {
       context.read<ScheduleBloc>().add(const SchedulePreparationStarted());
     }
     context.go('/alarmScreen');
@@ -239,7 +247,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
             },
             child: Text(
               variant == ScheduleStartPromptVariant.earlyStart
-                  ? l10n.prepareEarly
+                  ? l10n.startPreparingNow
                   : l10n.startPreparing,
             ),
           ),
@@ -253,10 +261,9 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     ScheduleStartPromptVariant variant,
   ) {
     switch (variant) {
-      case ScheduleStartPromptVariant.fiveMinutes:
-        return _buildTwoButtonLayout(context, variant);
       case ScheduleStartPromptVariant.earlyStart:
-      case ScheduleStartPromptVariant.defaultPrompt:
+        return _buildTwoButtonLayout(context, variant);
+      case ScheduleStartPromptVariant.officialStart:
         return _buildPrimaryButton(context, variant);
     }
   }
@@ -278,7 +285,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
                 onPressed: () async {
                   _onPrimaryActionPressed(context, variant);
                 },
-                child: Text(AppLocalizations.of(context)!.startPreparing),
+                child: Text(AppLocalizations.of(context)!.startPreparingNow),
               ),
             ),
             const SizedBox(height: 12),
@@ -294,11 +301,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
                       Theme.of(context).colorScheme.primaryContainer,
                   foregroundColor: Theme.of(context).colorScheme.primary,
                 ),
-                child: Text(
-                  variant == ScheduleStartPromptVariant.fiveMinutes
-                      ? AppLocalizations.of(context)!.startInFiveMinutes
-                      : AppLocalizations.of(context)!.home,
-                ),
+                child: Text(AppLocalizations.of(context)!.notNow),
               ),
             ),
           ],

--- a/lib/presentation/shared/router/go_router.dart
+++ b/lib/presentation/shared/router/go_router.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/core/services/navigation_service.dart';
 import 'package:on_time_front/core/services/notification_service.dart';
-import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/presentation/alarm/screens/alarm_screen.dart';
 import 'package:on_time_front/presentation/alarm/screens/schedule_start_screen.dart';
 import 'package:on_time_front/presentation/app/bloc/auth/auth_bloc.dart';
@@ -130,12 +129,7 @@ GoRouter goRouterConfig(AuthBloc authBloc, ScheduleBloc scheduleBloc) {
             return const SizedBox.shrink();
           }
           final extra = state.extra as Map<String, dynamic>?;
-          final promptVariantRaw = extra?['promptVariant'] as String?;
-          final promptVariant = promptVariantRaw != null
-              ? scheduleStartPromptVariantFromRouteValue(promptVariantRaw)
-              : ((extra?['isFiveMinutesBefore'] as bool? ?? false)
-                  ? ScheduleStartPromptVariant.fiveMinutes
-                  : ScheduleStartPromptVariant.defaultPrompt);
+          final promptVariant = scheduleStartPromptVariantFromRouteExtra(extra);
           return ScheduleStartScreen(promptVariant: promptVariant);
         },
       ),

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -324,7 +324,48 @@ void main() {
       await controller.close();
     });
 
-    testWidgets('five-minute start screen variant is shown with route extra',
+    test('schedule start route values normalize legacy inputs', () {
+      expect(
+        scheduleStartPromptVariantFromRouteValue('earlyStart'),
+        ScheduleStartPromptVariant.earlyStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteValue('fiveMinutes'),
+        ScheduleStartPromptVariant.earlyStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteValue(null),
+        ScheduleStartPromptVariant.officialStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteValue('unknown'),
+        ScheduleStartPromptVariant.officialStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(
+          const {'promptVariant': 'earlyStart'},
+        ),
+        ScheduleStartPromptVariant.earlyStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(
+          const {'promptVariant': 'fiveMinutes'},
+        ),
+        ScheduleStartPromptVariant.earlyStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(
+          const {'isFiveMinutesBefore': true},
+        ),
+        ScheduleStartPromptVariant.earlyStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(const {}),
+        ScheduleStartPromptVariant.officialStart,
+      );
+    });
+
+    testWidgets('early-start screen variant is shown with two choices',
         (tester) async {
       await setLargeTestViewport(tester);
 
@@ -334,7 +375,7 @@ void main() {
           GoRoute(
             path: '/scheduleStart',
             builder: (_, __) => const ScheduleStartScreen(
-              promptVariant: ScheduleStartPromptVariant.fiveMinutes,
+              promptVariant: ScheduleStartPromptVariant.earlyStart,
             ),
           ),
           GoRoute(
@@ -348,9 +389,12 @@ void main() {
 
       expect(find.byType(ScheduleStartScreen), findsOneWidget);
       expect(find.byType(ElevatedButton), findsNWidgets(2));
+      expect(find.text('Start preparing now'), findsOneWidget);
+      expect(find.text('Not now'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
-    testWidgets('schedule start button navigates to alarm', (tester) async {
+    testWidgets('early-start start-now button navigates to alarm',
+        (tester) async {
       await setLargeTestViewport(tester);
 
       final schedule = buildSchedule(
@@ -373,7 +417,7 @@ void main() {
           GoRoute(
             path: '/scheduleStart',
             builder: (_, __) => const ScheduleStartScreen(
-              promptVariant: ScheduleStartPromptVariant.fiveMinutes,
+              promptVariant: ScheduleStartPromptVariant.earlyStart,
             ),
           ),
           GoRoute(
@@ -384,12 +428,12 @@ void main() {
       );
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
-      await tapAndPump(tester, find.text('Start Preparing'));
+      await tapAndPump(tester, find.text('Start preparing now'));
       await pumpUntilRouteText(tester, 'ALARM_ROUTE');
       expect(find.text('ALARM_ROUTE'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
-    testWidgets('schedule start in five button navigates home', (tester) async {
+    testWidgets('early-start not-now button navigates home', (tester) async {
       await setLargeTestViewport(tester);
 
       final schedule = buildSchedule(
@@ -412,7 +456,7 @@ void main() {
           GoRoute(
             path: '/scheduleStart',
             builder: (_, __) => const ScheduleStartScreen(
-              promptVariant: ScheduleStartPromptVariant.fiveMinutes,
+              promptVariant: ScheduleStartPromptVariant.earlyStart,
             ),
           ),
           GoRoute(
@@ -423,9 +467,36 @@ void main() {
       );
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
-      await tapAndPump(tester, find.text('Start in 5 minutes'));
+      await tapAndPump(tester, find.text('Not now'));
       await pumpUntilRouteText(tester, 'HOME_ROUTE');
       expect(find.text('HOME_ROUTE'), findsOneWidget);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    testWidgets('deprecated five-minute flag resolves to early-start choices',
+        (tester) async {
+      await setLargeTestViewport(tester);
+
+      final router = GoRouter(
+        initialLocation: '/scheduleStart',
+        routes: [
+          GoRoute(
+            path: '/scheduleStart',
+            builder: (_, __) => const ScheduleStartScreen(
+              // ignore: deprecated_member_use_from_same_package
+              isFiveMinutesBefore: true,
+            ),
+          ),
+          GoRoute(
+              path: '/alarmScreen', builder: (_, __) => const Text('ALARM')),
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+        ],
+      );
+
+      await pumpWithRouter(tester, bloc: bloc, router: router);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Start preparing now'), findsOneWidget);
+      expect(find.text('Not now'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
     testWidgets('early-start variant is shown with dedicated prompt',
@@ -472,9 +543,10 @@ void main() {
         find.textContaining('Would you like to start preparing early now?'),
         findsOneWidget,
       );
-      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.byType(ElevatedButton), findsNWidgets(2));
       expect(find.text('Home'), findsNothing);
-      expect(find.text('Prepare Early'), findsOneWidget);
+      expect(find.text('Start preparing now'), findsOneWidget);
+      expect(find.text('Not now'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
     testWidgets('early-start variant formats hour and minute lead time',
@@ -555,13 +627,13 @@ void main() {
       );
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
-      await tapAndPump(tester, find.text('Prepare Early'));
+      await tapAndPump(tester, find.text('Start preparing now'));
       await pumpUntilRouteText(tester, 'ALARM_ROUTE');
 
       expect(find.text('ALARM_ROUTE'), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
-    testWidgets('early-start relies on close button instead of home button',
+    testWidgets('early-start has explicit not-now instead of home button',
         (tester) async {
       await setLargeTestViewport(tester);
 
@@ -597,6 +669,7 @@ void main() {
 
       await pumpWithRouter(tester, bloc: bloc, router: router);
       expect(find.text('Home'), findsNothing);
+      expect(find.text('Not now'), findsOneWidget);
       expect(find.byIcon(Icons.close), findsOneWidget);
     }, timeout: const Timeout(Duration(seconds: 15)));
 
@@ -1143,7 +1216,9 @@ void main() {
         const Color(0xFFFF6953).value,
       );
       expect(
-        tester.widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator)).progress,
+        tester
+            .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
+            .progress,
         0.0,
       );
       expect(


### PR DESCRIPTION
## Summary
- normalize `/scheduleStart` prompt variants to `officialStart` and `earlyStart`
- map legacy five-minute route inputs to `earlyStart` while preserving compatibility
- update early-start actions and localization copy for “Start preparing now” and “Not now”
- send normalized `promptVariant: earlyStart` extras from five-minute notification taps

## Validation
- `flutter test test/presentation/alarm/screens/preparation_flow_widget_test.dart`
- `flutter test test/presentation/home/utils/today_tile_navigation_test.dart`

## Notes
- `flutter analyze` still fails on existing unrelated Widgetbook issues: missing `widgetbook_workspace/dialog_story_helpers.dart` and missing generated `main.directories.g.dart`.

Closes #361
