### PR TITLE
[codex] add native alarm client

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,7 +10,9 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  
+  exclude:
+    - widgetbook/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,6 +31,9 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        manifestPlaceholders = [
+            appAuthRedirectScheme: applicationId
+        ]
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" >
     <!-- Android 13(API 33) 이상 알림 권한 -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     
     <application
         android:label="on_time_front"
@@ -34,6 +36,14 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <receiver
+            android:name=".NativeAlarmBootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
+        </receiver>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/example/on_time_front/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/on_time_front/MainActivity.kt
@@ -1,5 +1,145 @@
 package com.example.on_time_front
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private var methodChannel: MethodChannel? = null
+
+    companion object {
+        private const val CHANNEL_NAME = "on_time_front/native_alarm"
+        const val ACTION_SCHEDULE_ALARM = "on_time_front.SCHEDULE_ALARM"
+        private var launchPayload: Map<String, String>? = null
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        payloadFromIntent(intent)?.let { launchPayload = it }
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        methodChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CHANNEL_NAME,
+        )
+        methodChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getCapabilities" -> result.success(
+                    mapOf(
+                        "supportsNativeAlarm" to true,
+                        "nativeAlarmProvider" to "androidAlarmManager",
+                        "fallbackProvider" to "localNotification",
+                    ),
+                )
+                "checkPermission" -> result.success("granted")
+                "requestPermission" -> result.success("granted")
+                "scheduleNativeAlarm" -> scheduleNativeAlarm(call, result)
+                "cancelNativeAlarm" -> cancelNativeAlarm(call, result)
+                "getLaunchPayload" -> {
+                    result.success(launchPayload)
+                    launchPayload = null
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        payloadFromIntent(intent)?.let {
+            launchPayload = it
+            methodChannel?.invokeMethod("alarmLaunch", it)
+        }
+    }
+
+    private fun scheduleNativeAlarm(call: MethodCall, result: MethodChannel.Result) {
+        val args = call.arguments as? Map<*, *>
+        if (args == null) {
+            result.error("invalidArguments", "Missing alarm arguments", null)
+            return
+        }
+
+        val triggerAtMillis = (args["alarmTime"] as? Number)?.toLong()
+        val scheduleId = args["scheduleId"]?.toString()
+        if (triggerAtMillis == null || scheduleId.isNullOrEmpty()) {
+            result.error("invalidArguments", "Missing scheduleId or alarmTime", null)
+            return
+        }
+        if (triggerAtMillis <= System.currentTimeMillis()) {
+            result.error("invalidArguments", "Cannot schedule a past alarm", null)
+            return
+        }
+
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        if (alarmManager == null) {
+            result.error("unsupported", "AlarmManager is unavailable", null)
+            return
+        }
+
+        val pendingIntent = pendingIntentFor(args, PendingIntent.FLAG_UPDATE_CURRENT)
+        val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerAtMillis, pendingIntent)
+        alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
+        result.success(null)
+    }
+
+    private fun cancelNativeAlarm(call: MethodCall, result: MethodChannel.Result) {
+        val args = call.arguments as? Map<*, *>
+        if (args == null) {
+            result.success(null)
+            return
+        }
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+        val pendingIntent = pendingIntentFor(args, PendingIntent.FLAG_NO_CREATE)
+        if (alarmManager != null && pendingIntent != null) {
+            alarmManager.cancel(pendingIntent)
+            pendingIntent.cancel()
+        }
+        result.success(null)
+    }
+
+    private fun pendingIntentFor(args: Map<*, *>, lookupFlag: Int): PendingIntent? {
+        val requestCode = (args["nativeAlarmId"] as? Number)?.toInt()
+            ?: args["scheduleId"].toString().hashCode()
+        val intent = Intent(this, MainActivity::class.java).apply {
+            action = ACTION_SCHEDULE_ALARM
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("type", "schedule_alarm")
+            putExtra("scheduleId", args["scheduleId"]?.toString())
+            putExtra("promptVariant", "alarm")
+            putExtra("alarmTime", args["alarmTime"]?.toString())
+            putExtra("preparationStartTime", args["preparationStartTime"]?.toString())
+
+            val payload = args["payload"] as? Map<*, *>
+            payload?.forEach { (key, value) ->
+                if (key != null && value != null) {
+                    putExtra(key.toString(), value.toString())
+                }
+            }
+        }
+        val flags = lookupFlag or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(this, requestCode, intent, flags)
+    }
+
+    private fun payloadFromIntent(intent: Intent?): Map<String, String>? {
+        if (intent?.action != ACTION_SCHEDULE_ALARM) return null
+        val extras = intent.extras ?: return null
+        val payload = mutableMapOf<String, String>()
+        for (key in extras.keySet()) {
+            extras.get(key)?.let { payload[key] = it.toString() }
+        }
+        payload["type"] = "schedule_alarm"
+        payload["promptVariant"] = "alarm"
+        return payload
+    }
+}

--- a/android/app/src/main/kotlin/com/example/on_time_front/NativeAlarmBootReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/on_time_front/NativeAlarmBootReceiver.kt
@@ -1,0 +1,114 @@
+package com.example.on_time_front
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+import org.json.JSONArray
+import org.json.JSONObject
+
+class NativeAlarmBootReceiver : BroadcastReceiver() {
+    companion object {
+        private const val NATIVE_PREF_NAME = "on_time_native_alarm"
+        private const val FLUTTER_PREF_NAME = "FlutterSharedPreferences"
+        private const val REGISTRY_PREF_KEY = "flutter.scheduled_alarm_registry"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        restorePersistedNativeAlarms(context)
+        context.getSharedPreferences(NATIVE_PREF_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean("boot_completed_since_last_launch", true)
+            .apply()
+    }
+
+    private fun restorePersistedNativeAlarms(context: Context) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+        val rawRegistry = context.getSharedPreferences(FLUTTER_PREF_NAME, Context.MODE_PRIVATE)
+            .getString(REGISTRY_PREF_KEY, null)
+            ?: return
+        val now = System.currentTimeMillis()
+        val records = try {
+            JSONArray(rawRegistry)
+        } catch (_: Exception) {
+            return
+        }
+
+        for (index in 0 until records.length()) {
+            val record = records.optJSONObject(index) ?: continue
+            if (record.optString("provider") != "androidAlarmManager") continue
+            val scheduleId = record.optString("scheduleId")
+            if (scheduleId.isEmpty()) continue
+            val alarmTime = parseAlarmTime(record.optString("alarmTime")) ?: continue
+            if (alarmTime <= now) continue
+            val pendingIntent = pendingIntentFor(context, record)
+            val alarmClockInfo = AlarmManager.AlarmClockInfo(alarmTime, pendingIntent)
+            alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
+        }
+    }
+
+    private fun pendingIntentFor(context: Context, record: JSONObject): PendingIntent {
+        val scheduleId = record.optString("scheduleId")
+        val requestCode = if (record.has("nativeAlarmId") && !record.isNull("nativeAlarmId")) {
+            record.optInt("nativeAlarmId")
+        } else {
+            scheduleId.hashCode()
+        }
+        val alarmTimeMillis = parseAlarmTime(record.optString("alarmTime"))
+        val preparationStartTimeMillis = parseAlarmTime(record.optString("preparationStartTime"))
+        val payload = record.optJSONObject("payload")
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_SCHEDULE_ALARM
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("type", "schedule_alarm")
+            putExtra("scheduleId", scheduleId)
+            putExtra("promptVariant", "alarm")
+            if (alarmTimeMillis != null) putExtra("alarmTime", alarmTimeMillis.toString())
+            if (preparationStartTimeMillis != null) {
+                putExtra("preparationStartTime", preparationStartTimeMillis.toString())
+            }
+            val payloadKeys = payload?.keys()
+            while (payloadKeys?.hasNext() == true) {
+                val key = payloadKeys.next()
+                payload.opt(key)?.let { value -> putExtra(key, value.toString()) }
+            }
+        }
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun parseAlarmTime(value: String?): Long? {
+        if (value.isNullOrBlank()) return null
+        value.toLongOrNull()?.let { return it }
+        val normalizedValue = value.replace(Regex("\\.(\\d{3})\\d+"), ".$1")
+        val patterns = listOf(
+            "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "yyyy-MM-dd'T'HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ss",
+        )
+        for (pattern in patterns) {
+            try {
+                val format = SimpleDateFormat(pattern, Locale.US)
+                if (pattern.endsWith("'Z'")) {
+                    format.timeZone = TimeZone.getTimeZone("UTC")
+                }
+                return format.parse(normalizedValue)?.time
+            } catch (_: Exception) {
+                continue
+            }
+        }
+        return null
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -2,9 +2,18 @@ import Flutter
 import UIKit
 import FirebaseCore
 import FirebaseMessaging
+#if canImport(AlarmKit)
+import AlarmKit
+import AppIntents
+import SwiftUI
+#endif
+
+private let onTimeAlarmLaunchPayloadDefaultsKey = "on_time_alarm_launch_payload"
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private var nativeAlarmChannel: FlutterMethodChannel?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -14,11 +23,333 @@ import FirebaseMessaging
     }
     FirebaseApp.configure()
     GeneratedPluginRegistrant.register(with: self)
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let channel = FlutterMethodChannel(
+        name: "on_time_front/native_alarm",
+        binaryMessenger: controller.binaryMessenger
+      )
+      nativeAlarmChannel = channel
+      channel.setMethodCallHandler { call, result in
+        self.handleNativeAlarmCall(call, result: result)
+      }
+    }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  private func handleNativeAlarmCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "getCapabilities":
+      result(nativeAlarmCapabilities())
+    case "checkPermission":
+      result(checkNativeAlarmPermission())
+    case "requestPermission":
+      requestNativeAlarmPermission(result: result)
+    case "scheduleNativeAlarm":
+      scheduleNativeAlarm(call, result: result)
+    case "cancelNativeAlarm":
+      cancelNativeAlarm(call, result: result)
+    case "getLaunchPayload":
+      result(takeStoredAlarmLaunchPayload())
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func nativeAlarmCapabilities() -> [String: Any] {
+    #if canImport(AlarmKit)
+    if #available(iOS 26.0, *) {
+      return [
+        "supportsNativeAlarm": true,
+        "nativeAlarmProvider": "iosAlarmKit",
+        "fallbackProvider": "localNotification"
+      ]
+    }
+    #endif
+    return [
+      "supportsNativeAlarm": false,
+      "nativeAlarmProvider": "none",
+      "fallbackProvider": "localNotification"
+    ]
+  }
+
+  private func checkNativeAlarmPermission() -> String {
+    #if canImport(AlarmKit)
+    if #available(iOS 26.0, *) {
+      return alarmPermissionWireValue(AlarmManager.shared.authorizationState)
+    }
+    #endif
+    return "unsupported"
+  }
+
+  private func requestNativeAlarmPermission(result: @escaping FlutterResult) {
+    #if canImport(AlarmKit)
+    if #available(iOS 26.0, *) {
+      Task {
+        do {
+          let state = try await AlarmManager.shared.requestAuthorization()
+          deliverFlutterResult(result, alarmPermissionWireValue(state))
+        } catch {
+          deliverFlutterResult(result, FlutterError(
+            code: "platformError",
+            message: "AlarmKit authorization failed: \(error.localizedDescription)",
+            details: nil
+          ))
+        }
+      }
+      return
+    }
+    #endif
+    result("unsupported")
+  }
+
+  private func scheduleNativeAlarm(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    #if canImport(AlarmKit)
+    if #available(iOS 26.0, *) {
+      guard let args = call.arguments as? [String: Any],
+            let scheduleId = args["scheduleId"] as? String,
+            !scheduleId.isEmpty,
+            let alarmTimeMillis = int64Value(args["alarmTime"]) else {
+        result(FlutterError(
+          code: "invalidArguments",
+          message: "Missing scheduleId or alarmTime",
+          details: nil
+        ))
+        return
+      }
+
+      let alarmDate = Date(timeIntervalSince1970: TimeInterval(alarmTimeMillis) / 1000)
+      guard alarmDate > Date() else {
+        result(FlutterError(
+          code: "invalidArguments",
+          message: "Cannot schedule a past alarm",
+          details: nil
+        ))
+        return
+      }
+
+      guard AlarmManager.shared.authorizationState == .authorized else {
+        result(FlutterError(
+          code: "permissionDenied",
+          message: "AlarmKit permission is not authorized",
+          details: nil
+        ))
+        return
+      }
+
+      let title = args["title"] as? String ?? "OnTime"
+      let body = args["body"] as? String ?? "It is time to get ready."
+      let payload = alarmPayload(from: args)
+      let alarmId = deterministicAlarmUUID(scheduleId)
+
+      Task {
+        do {
+          let alert = AlarmPresentation.Alert(
+            title: LocalizedStringResource(stringLiteral: title),
+            stopButton: AlarmButton(
+              text: "Stop",
+              textColor: .white,
+              systemImageName: "stop.circle"
+            ),
+            secondaryButton: AlarmButton(
+              text: "Open",
+              textColor: .white,
+              systemImageName: "arrow.up.forward.app"
+            ),
+            secondaryButtonBehavior: .custom
+          )
+          let presentation = AlarmPresentation(alert: alert)
+          let attributes = AlarmAttributes(
+            presentation: presentation,
+            metadata: OnTimeAlarmMetadata(
+              scheduleId: scheduleId,
+              title: title,
+              body: body
+            ),
+            tintColor: Color.orange
+          )
+          let configuration = AlarmManager.AlarmConfiguration.alarm(
+            schedule: .fixed(alarmDate),
+            attributes: attributes,
+            secondaryIntent: OpenScheduleAlarmIntent(payload: payload)
+          )
+          _ = try await AlarmManager.shared.schedule(
+            id: alarmId,
+            configuration: configuration
+          )
+          deliverFlutterResult(result, nil)
+        } catch {
+          deliverFlutterResult(result, FlutterError(
+            code: "platformError",
+            message: "AlarmKit scheduling failed: \(error.localizedDescription)",
+            details: nil
+          ))
+        }
+      }
+      return
+    }
+    #endif
+    result(FlutterError(
+      code: "unsupported",
+      message: "AlarmKit native scheduling is not available in this build or OS version.",
+      details: nil
+    ))
+  }
+
+  private func cancelNativeAlarm(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    #if canImport(AlarmKit)
+    if #available(iOS 26.0, *) {
+      guard let args = call.arguments as? [String: Any],
+            let scheduleId = args["scheduleId"] as? String,
+            !scheduleId.isEmpty else {
+        result(nil)
+        return
+      }
+      do {
+        try AlarmManager.shared.cancel(id: deterministicAlarmUUID(scheduleId))
+        result(nil)
+      } catch {
+        result(FlutterError(
+          code: "platformError",
+          message: "AlarmKit cancellation failed: \(error.localizedDescription)",
+          details: nil
+        ))
+      }
+      return
+    }
+    #endif
+    result(nil)
+  }
+
+  private func takeStoredAlarmLaunchPayload() -> [String: String]? {
+    let defaults = UserDefaults.standard
+    guard let payload = defaults.dictionary(
+      forKey: onTimeAlarmLaunchPayloadDefaultsKey
+    ) as? [String: String] else {
+      return nil
+    }
+    defaults.removeObject(forKey: onTimeAlarmLaunchPayloadDefaultsKey)
+    return payload
+  }
+
+  private func alarmPayload(from args: [String: Any]) -> [String: String] {
+    var payload: [String: String] = [:]
+    if let rawPayload = args["payload"] as? [String: Any] {
+      for (key, value) in rawPayload {
+        payload[key] = "\(value)"
+      }
+    }
+    payload["type"] = "schedule_alarm"
+    payload["promptVariant"] = "alarm"
+    if let scheduleId = args["scheduleId"] as? String {
+      payload["scheduleId"] = scheduleId
+    }
+    if let alarmTime = int64Value(args["alarmTime"]) {
+      payload["alarmTime"] = "\(alarmTime)"
+    }
+    if let preparationStartTime = int64Value(args["preparationStartTime"]) {
+      payload["preparationStartTime"] = "\(preparationStartTime)"
+    }
+    return payload
+  }
+
+  private func int64Value(_ value: Any?) -> Int64? {
+    if let number = value as? NSNumber {
+      return number.int64Value
+    }
+    if let int = value as? Int {
+      return Int64(int)
+    }
+    if let string = value as? String {
+      return Int64(string)
+    }
+    return nil
+  }
+
+  private func deliverFlutterResult(_ result: @escaping FlutterResult, _ value: Any?) {
+    DispatchQueue.main.async {
+      result(value)
+    }
+  }
+
   override func application(_ application: UIApplication, 
   didRegisterForRemoteNotificationsWithDeviceToken deviceToken:Data){
     Messaging.messaging().apnsToken = deviceToken
     super.application(application, didRegisterForRemoteNotificationsWithDeviceToken:deviceToken)
   }
 }
+
+#if canImport(AlarmKit)
+@available(iOS 26.0, *)
+private struct OnTimeAlarmMetadata: AlarmMetadata {
+  let scheduleId: String
+  let title: String
+  let body: String
+}
+
+@available(iOS 26.0, *)
+private struct OpenScheduleAlarmIntent: LiveActivityIntent {
+  static var title: LocalizedStringResource = "Open OnTime"
+  static var openAppWhenRun: Bool = true
+
+  @Parameter(title: "Payload")
+  var encodedPayload: String
+
+  init() {
+    encodedPayload = "{}"
+  }
+
+  init(payload: [String: String]) {
+    let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+    encodedPayload = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+  }
+
+  func perform() async throws -> some IntentResult {
+    if let data = encodedPayload.data(using: .utf8),
+       let payload = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+      UserDefaults.standard.set(payload, forKey: onTimeAlarmLaunchPayloadDefaultsKey)
+    }
+    return .result()
+  }
+}
+
+@available(iOS 26.0, *)
+private func alarmPermissionWireValue(_ state: AlarmManager.AuthorizationState) -> String {
+  switch state {
+  case .authorized:
+    return "granted"
+  case .denied:
+    return "denied"
+  case .notDetermined:
+    return "notDetermined"
+  @unknown default:
+    return "unsupported"
+  }
+}
+
+private func deterministicAlarmUUID(_ scheduleId: String) -> UUID {
+  var firstHash: UInt64 = 1469598103934665603
+  var secondHash: UInt64 = 1099511628211
+
+  for byte in scheduleId.utf8 {
+    firstHash = (firstHash ^ UInt64(byte)) &* 1099511628211
+  }
+  for byte in scheduleId.utf8.reversed() {
+    secondHash = (secondHash ^ UInt64(byte)) &* 1099511628211
+  }
+
+  var bytes = [UInt8](repeating: 0, count: 16)
+  for index in 0..<8 {
+    bytes[index] = UInt8((firstHash >> UInt64(index * 8)) & 0xff)
+    bytes[index + 8] = UInt8((secondHash >> UInt64(index * 8)) & 0xff)
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x50
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+
+  return UUID(uuid: (
+    bytes[0], bytes[1], bytes[2], bytes[3],
+    bytes[4], bytes[5], bytes[6], bytes[7],
+    bytes[8], bytes[9], bytes[10], bytes[11],
+    bytes[12], bytes[13], bytes[14], bytes[15]
+  ))
+}
+#endif

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -289,6 +289,7 @@ private struct OnTimeAlarmMetadata: AlarmMetadata {
 @available(iOS 26.0, *)
 private struct OpenScheduleAlarmIntent: LiveActivityIntent {
   static var title: LocalizedStringResource = "Open OnTime"
+  static var supportedModes: IntentModes = .foreground(.immediate)
   static var openAppWhenRun: Bool = true
 
   @Parameter(title: "Payload")

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -307,6 +307,7 @@ private struct OpenScheduleAlarmIntent: LiveActivityIntent {
     if let data = encodedPayload.data(using: .utf8),
        let payload = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
       UserDefaults.standard.set(payload, forKey: onTimeAlarmLaunchPayloadDefaultsKey)
+      UserDefaults.standard.synchronize()
     }
     return .result()
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,8 @@ import SwiftUI
 #endif
 
 private let onTimeAlarmLaunchPayloadDefaultsKey = "on_time_alarm_launch_payload"
+private let onTimeAlarmLaunchURLScheme = "ontime"
+private let onTimeAlarmLaunchURLHost = "alarm"
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -53,6 +55,17 @@ private let onTimeAlarmLaunchPayloadDefaultsKey = "on_time_alarm_launch_payload"
     default:
       result(FlutterMethodNotImplemented)
     }
+  }
+
+  override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey : Any] = [:]
+  ) -> Bool {
+    if handleAlarmLaunchURL(url) {
+      return true
+    }
+    return super.application(app, open: url, options: options)
   }
 
   private func nativeAlarmCapabilities() -> [String: Any] {
@@ -231,6 +244,53 @@ private let onTimeAlarmLaunchPayloadDefaultsKey = "on_time_alarm_launch_payload"
     return payload
   }
 
+  private func handleAlarmLaunchURL(_ url: URL) -> Bool {
+    guard url.scheme == onTimeAlarmLaunchURLScheme,
+          url.host == onTimeAlarmLaunchURLHost else {
+      return false
+    }
+
+    var payload: [String: String] = [
+      "type": "schedule_alarm",
+      "promptVariant": "alarm"
+    ]
+    if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+      for item in components.queryItems ?? [] {
+        if let value = item.value {
+          payload[item.name] = value
+        }
+      }
+    }
+    storeAlarmLaunchPayload(payload)
+    notifyFlutterAlarmLaunch(payload)
+    return true
+  }
+
+  fileprivate static func alarmLaunchURL(payload: [String: String]) -> URL? {
+    var components = URLComponents()
+    components.scheme = onTimeAlarmLaunchURLScheme
+    components.host = onTimeAlarmLaunchURLHost
+    components.queryItems = payload.keys.sorted().map { key in
+      URLQueryItem(name: key, value: payload[key])
+    }
+    return components.url
+  }
+
+  fileprivate static func storeAlarmLaunchPayload(_ payload: [String: String]) {
+    UserDefaults.standard.set(payload, forKey: onTimeAlarmLaunchPayloadDefaultsKey)
+    UserDefaults.standard.synchronize()
+  }
+
+  private func storeAlarmLaunchPayload(_ payload: [String: String]) {
+    Self.storeAlarmLaunchPayload(payload)
+  }
+
+  private func notifyFlutterAlarmLaunch(_ payload: [String: String]) {
+    DispatchQueue.main.async {
+      self.nativeAlarmChannel?.invokeMethod("alarmLaunch", arguments: payload)
+    }
+  }
+
   private func alarmPayload(from args: [String: Any]) -> [String: String] {
     var payload: [String: String] = [:]
     if let rawPayload = args["payload"] as? [String: Any] {
@@ -287,30 +347,34 @@ private struct OnTimeAlarmMetadata: AlarmMetadata {
 }
 
 @available(iOS 26.0, *)
-private struct OpenScheduleAlarmIntent: LiveActivityIntent {
-  static var title: LocalizedStringResource = "Open OnTime"
-  static var supportedModes: IntentModes = .foreground(.immediate)
-  static var openAppWhenRun: Bool = true
+public struct OpenScheduleAlarmIntent: LiveActivityIntent {
+  public static var title: LocalizedStringResource = "Open OnTime"
+  public static var supportedModes: IntentModes = .foreground(.immediate)
+  public static var openAppWhenRun: Bool = true
 
   @Parameter(title: "Payload")
-  var encodedPayload: String
+  public var encodedPayload: String
 
-  init() {
+  public init() {
     encodedPayload = "{}"
   }
 
-  init(payload: [String: String]) {
+  public init(payload: [String: String]) {
     let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
     encodedPayload = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
   }
 
-  func perform() async throws -> some IntentResult {
+  public func perform() async throws -> some IntentResult & OpensIntent {
     if let data = encodedPayload.data(using: .utf8),
        let payload = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
-      UserDefaults.standard.set(payload, forKey: onTimeAlarmLaunchPayloadDefaultsKey)
-      UserDefaults.standard.synchronize()
+      NSLog("OnTime AlarmKit Open intent invoked for scheduleId=%@", payload["scheduleId"] ?? "")
+      AppDelegate.storeAlarmLaunchPayload(payload)
+      if let url = AppDelegate.alarmLaunchURL(payload: payload) {
+        return .result(opensIntent: OpenURLIntent(url))
+      }
     }
-    return .result()
+    NSLog("OnTime AlarmKit Open intent invoked without a valid payload")
+    return .result(opensIntent: OpenURLIntent(URL(string: "\(onTimeAlarmLaunchURLScheme)://\(onTimeAlarmLaunchURLHost)")!))
   }
 }
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,6 +42,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>On Time uses alarms to remind you when it is time to prepare for schedules.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,6 +30,14 @@
 				<string>$(GOOGLE_RESERVED_CLIENT_ID_IOS)</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>club.devkor.ontime.alarm</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ontime</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>

--- a/lib/core/constants/endpoint.dart
+++ b/lib/core/constants/endpoint.dart
@@ -62,4 +62,15 @@ class Endpoint {
 
   static const _fcmToken = '/firebase-token'; // 사용자 fcm 토큰 등록
   static get fcmTokenRegister => _fcmToken;
+
+  // alarm
+  static const _alarmSettings = '/users/me/alarm-settings';
+  static const _currentDevice = '/users/me/devices/current';
+  static const _alarmWindow = '$_schedules/alarm-window';
+  static const _alarmStatus = '/users/me/alarm-status';
+
+  static get alarmSettings => _alarmSettings;
+  static get currentDevice => _currentDevice;
+  static get alarmWindow => _alarmWindow;
+  static get alarmStatus => _alarmStatus;
 }

--- a/lib/core/services/alarm_scheduler_service.dart
+++ b/lib/core/services/alarm_scheduler_service.dart
@@ -97,6 +97,12 @@ class AlarmSchedulerService {
       }
     });
 
+    await dispatchPendingLaunchPayload();
+  }
+
+  Future<void> dispatchPendingLaunchPayload() async {
+    final launchPayloadHandler = _launchPayloadHandler;
+    if (launchPayloadHandler == null) return;
     if (kIsWeb) return;
     try {
       final initialPayload = await _channel.invokeMapMethod<String, dynamic>(
@@ -104,7 +110,7 @@ class AlarmSchedulerService {
       );
       final payload = _payloadFromObject(initialPayload);
       if (payload != null) {
-        _launchPayloadHandler?.call(payload);
+        launchPayloadHandler(payload);
       }
     } on MissingPluginException {
       return;

--- a/lib/core/services/alarm_scheduler_service.dart
+++ b/lib/core/services/alarm_scheduler_service.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+typedef AlarmLaunchPayloadHandler = void Function(Map<String, String> payload);
+
+@Singleton()
+class AlarmSchedulerService {
+  static const _channel = MethodChannel('on_time_front/native_alarm');
+
+  AlarmLaunchPayloadHandler? _launchPayloadHandler;
+
+  Future<AlarmSchedulerCapabilities> getCapabilities() async {
+    if (kIsWeb) {
+      return AlarmSchedulerCapabilities.unsupported;
+    }
+    try {
+      final raw = await _channel.invokeMapMethod<String, dynamic>(
+        'getCapabilities',
+      );
+      return _capabilitiesFromMap(raw);
+    } on MissingPluginException {
+      return AlarmSchedulerCapabilities.unsupported;
+    } on PlatformException {
+      return AlarmSchedulerCapabilities.unsupported;
+    }
+  }
+
+  Future<AlarmPermissionState> checkPermission() async {
+    if (kIsWeb) return AlarmPermissionState.unsupported;
+    try {
+      final raw = await _channel.invokeMethod<String>('checkPermission');
+      return AlarmPermissionStateWireValue.fromWireValue(raw);
+    } on MissingPluginException {
+      return AlarmPermissionState.unsupported;
+    } on PlatformException {
+      return AlarmPermissionState.unsupported;
+    }
+  }
+
+  Future<AlarmPermissionState> requestPermission() async {
+    if (kIsWeb) return AlarmPermissionState.unsupported;
+    try {
+      final raw = await _channel.invokeMethod<String>('requestPermission');
+      return AlarmPermissionStateWireValue.fromWireValue(raw);
+    } on MissingPluginException {
+      return AlarmPermissionState.unsupported;
+    } on PlatformException {
+      return AlarmPermissionState.unsupported;
+    }
+  }
+
+  Future<void> scheduleNativeAlarm(ScheduledAlarmRecord record) async {
+    try {
+      await _channel.invokeMethod<void>(
+        'scheduleNativeAlarm',
+        _recordToMethodArguments(record),
+      );
+    } on PlatformException catch (error) {
+      throw _exceptionFromPlatformException(error);
+    }
+  }
+
+  Future<void> cancelNativeAlarm(ScheduledAlarmRecord record) async {
+    if (kIsWeb) return;
+    try {
+      await _channel.invokeMethod<void>(
+        'cancelNativeAlarm',
+        _recordToMethodArguments(record),
+      );
+    } on MissingPluginException {
+      return;
+    } on PlatformException catch (error) {
+      throw _exceptionFromPlatformException(error);
+    }
+  }
+
+  Future<void> cancelAllNativeAlarms(
+    List<ScheduledAlarmRecord> records,
+  ) async {
+    for (final record in records) {
+      await cancelNativeAlarm(record);
+    }
+  }
+
+  Future<void> initializeLaunchHandling(
+    AlarmLaunchPayloadHandler onPayload,
+  ) async {
+    _launchPayloadHandler = onPayload;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'alarmLaunch') {
+        final payload = _payloadFromObject(call.arguments);
+        if (payload != null) {
+          _launchPayloadHandler?.call(payload);
+        }
+      }
+    });
+
+    if (kIsWeb) return;
+    try {
+      final initialPayload = await _channel.invokeMapMethod<String, dynamic>(
+        'getLaunchPayload',
+      );
+      final payload = _payloadFromObject(initialPayload);
+      if (payload != null) {
+        _launchPayloadHandler?.call(payload);
+      }
+    } on MissingPluginException {
+      return;
+    } on PlatformException {
+      return;
+    }
+  }
+
+  Map<String, dynamic> _recordToMethodArguments(ScheduledAlarmRecord record) {
+    return {
+      'scheduleId': record.scheduleId,
+      'alarmTime': record.alarmTime.millisecondsSinceEpoch,
+      'preparationStartTime':
+          record.preparationStartTime.millisecondsSinceEpoch,
+      'nativeAlarmId': record.nativeAlarmId ?? stableAlarmId(record.scheduleId),
+      'title': record.scheduleTitle,
+      'body': 'It is time to get ready.',
+      'payload': record.payload,
+    };
+  }
+
+  AlarmSchedulerCapabilities _capabilitiesFromMap(Map<String, dynamic>? raw) {
+    if (raw == null) {
+      return AlarmSchedulerCapabilities.unsupported;
+    }
+    return AlarmSchedulerCapabilities(
+      supportsNativeAlarm: raw['supportsNativeAlarm'] as bool? ?? false,
+      nativeAlarmProvider: AlarmProviderWireValue.fromWireValue(
+        raw['nativeAlarmProvider'] as String?,
+      ),
+      fallbackProvider: AlarmProviderWireValue.fromWireValue(
+        raw['fallbackProvider'] as String?,
+      ),
+    );
+  }
+
+  AlarmSchedulingException _exceptionFromPlatformException(
+    PlatformException error,
+  ) {
+    switch (error.code) {
+      case 'permissionDenied':
+        return AlarmSchedulingException(
+          reason: AlarmFailureReason.platformError,
+          permissionIssue: AlarmPermissionIssue.nativePermissionDenied,
+          message: error.message ?? 'Native alarm permission denied',
+        );
+      case 'unsupported':
+        return AlarmSchedulingException(
+          reason: AlarmFailureReason.platformError,
+          message: error.message ?? 'Native alarms are unsupported',
+        );
+      default:
+        return AlarmSchedulingException(
+          reason: AlarmFailureReason.platformError,
+          message: error.message ?? error.code,
+        );
+    }
+  }
+
+  Map<String, String>? _payloadFromObject(Object? raw) {
+    if (raw is! Map) return null;
+    return raw.map(
+      (key, value) => MapEntry(key.toString(), value.toString()),
+    );
+  }
+}

--- a/lib/core/services/fallback_alarm_notification_service.dart
+++ b/lib/core/services/fallback_alarm_notification_service.dart
@@ -1,0 +1,58 @@
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+abstract interface class FallbackAlarmNotificationService {
+  Future<AlarmPermissionState> checkPermission();
+
+  Future<AlarmPermissionState> requestPermission();
+
+  Future<void> scheduleFallbackAlarm(ScheduledAlarmRecord record);
+
+  Future<void> cancelFallbackAlarm(ScheduledAlarmRecord record);
+}
+
+@Singleton(as: FallbackAlarmNotificationService)
+class FallbackAlarmNotificationServiceImpl
+    implements FallbackAlarmNotificationService {
+  @override
+  Future<AlarmPermissionState> checkPermission() async {
+    return _fromAuthorizationStatus(
+      await NotificationService.instance.checkNotificationPermission(),
+    );
+  }
+
+  @override
+  Future<AlarmPermissionState> requestPermission() async {
+    return _fromAuthorizationStatus(
+      await NotificationService.instance.requestPermission(),
+    );
+  }
+
+  @override
+  Future<void> scheduleFallbackAlarm(ScheduledAlarmRecord record) {
+    return NotificationService.instance.scheduleFallbackAlarm(record);
+  }
+
+  @override
+  Future<void> cancelFallbackAlarm(ScheduledAlarmRecord record) async {
+    final notificationId =
+        record.fallbackNotificationId ?? stableAlarmId(record.scheduleId);
+    await NotificationService.instance.cancelFallbackNotification(
+      notificationId,
+    );
+  }
+
+  AlarmPermissionState _fromAuthorizationStatus(AuthorizationStatus status) {
+    switch (status) {
+      case AuthorizationStatus.authorized:
+      case AuthorizationStatus.provisional:
+        return AlarmPermissionState.granted;
+      case AuthorizationStatus.denied:
+        return AlarmPermissionState.denied;
+      case AuthorizationStatus.notDetermined:
+        return AlarmPermissionState.notDetermined;
+    }
+  }
+}

--- a/lib/core/services/navigation_service.dart
+++ b/lib/core/services/navigation_service.dart
@@ -9,4 +9,8 @@ class NavigationService {
   void push(String routeName, {Object? extra}) {
     GoRouter.of(navigatorKey.currentContext!).push(routeName, extra: extra);
   }
+
+  void go(String routeName, {Object? extra}) {
+    GoRouter.of(navigatorKey.currentContext!).go(routeName, extra: extra);
+  }
 }

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -12,8 +12,12 @@ import 'package:on_time_front/core/services/js_interop_service.dart';
 import 'package:on_time_front/core/services/navigation_service.dart';
 import 'package:on_time_front/data/data_sources/notification_remote_data_source.dart';
 import 'package:on_time_front/data/models/fcm_token_register_request_model.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
 import 'package:permission_handler/permission_handler.dart'
     as permission_handler;
+import 'package:timezone/data/latest.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -35,6 +39,7 @@ class NotificationService {
   final _messaging = FirebaseMessaging.instance;
   final _localNotifications = FlutterLocalNotificationsPlugin();
   bool _isFlutterLocalNotificationsInitialized = false;
+  bool _isTimezoneInitialized = false;
 
   String get _locale {
     try {
@@ -136,8 +141,12 @@ class NotificationService {
 
       if (token != null) {
         try {
+          final deviceId = await getIt.get<AlarmRepository>().getDeviceId();
           await getIt.get<NotificationRemoteDataSource>().fcmTokenRegister(
-                FcmTokenRegisterRequestModel(firebaseToken: token),
+                FcmTokenRegisterRequestModel(
+                  firebaseToken: token,
+                  deviceId: deviceId,
+                ),
               );
           debugPrint('[FCM] FCM Token 서버 등록 완료');
         } catch (e) {
@@ -147,9 +156,14 @@ class NotificationService {
 
       _messaging.onTokenRefresh.listen((newToken) {
         debugPrint('[FCM] Token 갱신됨: $newToken');
-        getIt.get<NotificationRemoteDataSource>().fcmTokenRegister(
-              FcmTokenRegisterRequestModel(firebaseToken: newToken),
-            );
+        getIt.get<AlarmRepository>().getDeviceId().then((deviceId) {
+          getIt.get<NotificationRemoteDataSource>().fcmTokenRegister(
+                FcmTokenRegisterRequestModel(
+                  firebaseToken: newToken,
+                  deviceId: deviceId,
+                ),
+              );
+        });
       });
     } catch (e) {
       debugPrint('[FCM] Token 요청 오류: $e');
@@ -173,6 +187,18 @@ class NotificationService {
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>()
         ?.createNotificationChannel(channel);
+
+    const alarmChannel = AndroidNotificationChannel(
+      'scheduled_alarm_channel',
+      'Scheduled alarms',
+      description: 'Schedule preparation alarm fallback notifications.',
+      importance: Importance.max,
+    );
+
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(alarmChannel);
 
     const initializationSettingsAndroid =
         AndroidInitializationSettings('@mipmap/ic_launcher');
@@ -319,6 +345,71 @@ class NotificationService {
     );
   }
 
+  Future<bool> hasNotificationPermission() async {
+    final permission = await checkNotificationPermission();
+    return permission == AuthorizationStatus.authorized ||
+        permission == AuthorizationStatus.provisional;
+  }
+
+  Future<void> scheduleFallbackAlarm(
+    ScheduledAlarmRecord record,
+  ) async {
+    if (!await hasNotificationPermission()) {
+      throw const AlarmSchedulingException(
+        reason: AlarmFailureReason.platformError,
+        permissionIssue: AlarmPermissionIssue.notificationPermissionDenied,
+        message: 'Notification permission denied',
+      );
+    }
+
+    await setupFlutterNotifications();
+    _ensureTimezoneInitialized();
+
+    final notificationId =
+        record.fallbackNotificationId ?? stableAlarmId(record.scheduleId);
+    final scheduledAt = tz.TZDateTime.from(record.alarmTime, tz.local);
+    await _localNotifications.zonedSchedule(
+      notificationId,
+      record.scheduleTitle,
+      _getLocalizedText('준비를 시작할 시간입니다.', 'It is time to get ready.'),
+      scheduledAt,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'scheduled_alarm_channel',
+          'Scheduled alarms',
+          channelDescription:
+              'Schedule preparation alarm fallback notifications.',
+          importance: Importance.max,
+          priority: Priority.max,
+          category: AndroidNotificationCategory.alarm,
+          icon: '@mipmap/ic_launcher',
+          playSound: true,
+          enableVibration: true,
+        ),
+        iOS: DarwinNotificationDetails(
+          presentAlert: true,
+          presentBadge: true,
+          presentSound: true,
+        ),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exact,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      payload: jsonEncode(record.payload),
+    );
+  }
+
+  Future<void> cancelFallbackNotification(int notificationId) async {
+    await setupFlutterNotifications();
+    await _localNotifications.cancel(notificationId);
+  }
+
+  void _ensureTimezoneInitialized() {
+    if (_isTimezoneInitialized) return;
+    tz_data.initializeTimeZones();
+    _isTimezoneInitialized = true;
+  }
+
   Future<void> _setupMessageHandlers() async {
     //foreground message
     FirebaseMessaging.onMessage.listen(
@@ -361,7 +452,12 @@ class NotificationService {
       final scheduleId = data['scheduleId'] as String?;
       // final title = data['title'] as String?;
 
-      if (type != null && type.contains('5min')) {
+      if (type == 'schedule_alarm' && scheduleId != null) {
+        getIt.get<NavigationService>().push(
+              '/scheduleStart',
+              extra: data,
+            );
+      } else if (type != null && type.contains('5min')) {
         getIt.get<NavigationService>().push(
           '/scheduleStart',
           extra: {'promptVariant': 'earlyStart'},
@@ -387,7 +483,12 @@ class NotificationService {
     final scheduleId = message.data['scheduleId'] as String?;
     // final title = message.data['title'] as String?;
 
-    if (type != null && type.contains('5min')) {
+    if (type == 'schedule_alarm' && scheduleId != null) {
+      getIt.get<NavigationService>().push(
+            '/scheduleStart',
+            extra: message.data,
+          );
+    } else if (type != null && type.contains('5min')) {
       getIt.get<NavigationService>().push(
         '/scheduleStart',
         extra: {'promptVariant': 'earlyStart'},

--- a/lib/data/data_sources/alarm_registry_local_data_source.dart
+++ b/lib/data/data_sources/alarm_registry_local_data_source.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/data/models/scheduled_alarm_record_model.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract interface class AlarmRegistryLocalDataSource {
+  Future<List<ScheduledAlarmRecord>> loadAll();
+
+  Future<void> replaceAll(List<ScheduledAlarmRecord> records);
+}
+
+@Injectable(as: AlarmRegistryLocalDataSource)
+class AlarmRegistryLocalDataSourceImpl implements AlarmRegistryLocalDataSource {
+  static const _prefsKey = 'scheduled_alarm_registry';
+
+  @override
+  Future<List<ScheduledAlarmRecord>> loadAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final rawValue = prefs.getString(_prefsKey);
+    if (rawValue == null || rawValue.isEmpty) {
+      return const [];
+    }
+
+    try {
+      final decoded = jsonDecode(rawValue) as List<dynamic>;
+      return decoded
+          .map(
+            (item) => ScheduledAlarmRecordModel.fromJson(
+              item as Map<String, dynamic>,
+            ).record,
+          )
+          .toList();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  @override
+  Future<void> replaceAll(List<ScheduledAlarmRecord> records) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (records.isEmpty) {
+      await prefs.remove(_prefsKey);
+      return;
+    }
+
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode(
+        records
+            .map((record) => ScheduledAlarmRecordModel(record).toJson())
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/data/data_sources/alarm_remote_data_source.dart
+++ b/lib/data/data_sources/alarm_remote_data_source.dart
@@ -115,7 +115,7 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
       var result = await _postAlarmStatus(model.toJson());
       if (result.statusCode == 400 && _responseCode(result.data) == '400') {
         result = await _postAlarmStatus(
-          model.toJson(wireFormat: AlarmStatusReportWireFormat.lowerCamel),
+          model.toJson(wireFormat: AlarmStatusReportWireFormat.upperSnake),
         );
       }
       if (result.statusCode == 409 &&

--- a/lib/data/data_sources/alarm_remote_data_source.dart
+++ b/lib/data/data_sources/alarm_remote_data_source.dart
@@ -111,12 +111,19 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
   @override
   Future<void> postAlarmStatus(AlarmStatusReport report) async {
     try {
-      final result = await dio.post(
-        Endpoint.alarmStatus,
-        data: AlarmStatusReportModel(report).toJson(),
-      );
+      final model = AlarmStatusReportModel(report);
+      var result = await _postAlarmStatus(model.toJson());
+      if (result.statusCode == 400) {
+        result = await _postAlarmStatus(
+          model.toJson(wireFormat: AlarmStatusReportWireFormat.upperSnake),
+        );
+      }
+      if (result.statusCode == 409 &&
+          _errorCode(result.data) == 'DEVICE_SESSION_NOT_ACTIVE') {
+        throw const DeviceSessionNotActiveException();
+      }
       if (result.statusCode != 200) {
-        throw Exception('Error posting alarm status');
+        throw Exception('Error posting alarm status: ${result.statusCode}');
       }
     } on DioException catch (error) {
       if (error.response?.statusCode == 409 &&
@@ -125,6 +132,16 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
       }
       rethrow;
     }
+  }
+
+  Future<Response<dynamic>> _postAlarmStatus(Map<String, dynamic> data) {
+    return dio.post(
+      Endpoint.alarmStatus,
+      data: data,
+      options: Options(
+        validateStatus: (status) => status != null && status < 500,
+      ),
+    );
   }
 
   String? _errorCode(Object? data) {

--- a/lib/data/data_sources/alarm_remote_data_source.dart
+++ b/lib/data/data_sources/alarm_remote_data_source.dart
@@ -113,7 +113,7 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
     try {
       final model = AlarmStatusReportModel(report);
       var result = await _postAlarmStatus(model.toJson());
-      if (result.statusCode == 400) {
+      if (result.statusCode == 400 && _responseCode(result.data) == '400') {
         result = await _postAlarmStatus(
           model.toJson(wireFormat: AlarmStatusReportWireFormat.lowerCamel),
         );
@@ -147,12 +147,22 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
   String? _errorCode(Object? data) {
     if (data is Map<String, dynamic>) {
       final error = data['error'];
-      if (data['code'] is String) {
-        return data['code'] as String;
+      final code = _responseCode(data);
+      if (code != null) {
+        return code;
       }
       if (error is Map<String, dynamic> && error['code'] is String) {
         return error['code'] as String;
       }
+    }
+    return null;
+  }
+
+  String? _responseCode(Object? data) {
+    if (data is Map<String, dynamic>) {
+      final code = data['code'];
+      if (code is String) return code;
+      if (code is num) return code.toInt().toString();
     }
     return null;
   }

--- a/lib/data/data_sources/alarm_remote_data_source.dart
+++ b/lib/data/data_sources/alarm_remote_data_source.dart
@@ -115,7 +115,7 @@ class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
       var result = await _postAlarmStatus(model.toJson());
       if (result.statusCode == 400) {
         result = await _postAlarmStatus(
-          model.toJson(wireFormat: AlarmStatusReportWireFormat.upperSnake),
+          model.toJson(wireFormat: AlarmStatusReportWireFormat.lowerCamel),
         );
       }
       if (result.statusCode == 409 &&

--- a/lib/data/data_sources/alarm_remote_data_source.dart
+++ b/lib/data/data_sources/alarm_remote_data_source.dart
@@ -1,0 +1,142 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/constants/endpoint.dart';
+import 'package:on_time_front/data/models/alarm_device_model.dart';
+import 'package:on_time_front/data/models/alarm_settings_model.dart';
+import 'package:on_time_front/data/models/alarm_status_report_model.dart';
+import 'package:on_time_front/data/models/alarm_window_schedule_model.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+
+abstract interface class AlarmRemoteDataSource {
+  Future<AlarmSettings> getAlarmSettings();
+
+  Future<AlarmSettings> updateAlarmSettings({
+    required bool alarmsEnabled,
+  });
+
+  Future<void> registerCurrentDevice(AlarmDeviceInfo deviceInfo);
+
+  Future<void> unregisterCurrentDevice(String deviceId);
+
+  Future<List<ScheduleWithPreparationEntity>> getAlarmWindow(
+    DateTime startDate,
+    DateTime endDate,
+  );
+
+  Future<void> postAlarmStatus(AlarmStatusReport report);
+}
+
+@Injectable(as: AlarmRemoteDataSource)
+class AlarmRemoteDataSourceImpl implements AlarmRemoteDataSource {
+  final Dio dio;
+
+  AlarmRemoteDataSourceImpl(this.dio);
+
+  @override
+  Future<AlarmSettings> getAlarmSettings() async {
+    final result = await dio.get(Endpoint.alarmSettings);
+    if (result.statusCode == 200) {
+      return AlarmSettingsModel.fromJson(
+        result.data['data'] as Map<String, dynamic>,
+      ).toEntity();
+    }
+    throw Exception('Error getting alarm settings');
+  }
+
+  @override
+  Future<AlarmSettings> updateAlarmSettings({
+    required bool alarmsEnabled,
+  }) async {
+    final result = await dio.patch(
+      Endpoint.alarmSettings,
+      data: UpdateAlarmSettingsRequestModel(
+        alarmsEnabled: alarmsEnabled,
+      ).toJson(),
+    );
+    if (result.statusCode == 200) {
+      return AlarmSettingsModel.fromJson(
+        result.data['data'] as Map<String, dynamic>,
+      ).toEntity();
+    }
+    throw Exception('Error updating alarm settings');
+  }
+
+  @override
+  Future<void> registerCurrentDevice(AlarmDeviceInfo deviceInfo) async {
+    final result = await dio.put(
+      Endpoint.currentDevice,
+      data: AlarmDeviceInfoModel.fromEntity(deviceInfo).toJson(),
+    );
+    if (result.statusCode != 200) {
+      throw Exception('Error registering current device');
+    }
+  }
+
+  @override
+  Future<void> unregisterCurrentDevice(String deviceId) async {
+    final result = await dio.delete(
+      Endpoint.currentDevice,
+      data: {'deviceId': deviceId},
+    );
+    if (result.statusCode != 200) {
+      throw Exception('Error unregistering current device');
+    }
+  }
+
+  @override
+  Future<List<ScheduleWithPreparationEntity>> getAlarmWindow(
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
+    final result = await dio.get(
+      Endpoint.alarmWindow,
+      queryParameters: {
+        'startDate': startDate.toIso8601String(),
+        'endDate': endDate.toIso8601String(),
+      },
+    );
+    if (result.statusCode == 200) {
+      return (result.data['data'] as List<dynamic>)
+          .map(
+            (item) => AlarmWindowScheduleModel.fromJson(
+              item as Map<String, dynamic>,
+            ).toEntity(),
+          )
+          .toList();
+    }
+    throw Exception('Error getting alarm window');
+  }
+
+  @override
+  Future<void> postAlarmStatus(AlarmStatusReport report) async {
+    try {
+      final result = await dio.post(
+        Endpoint.alarmStatus,
+        data: AlarmStatusReportModel(report).toJson(),
+      );
+      if (result.statusCode != 200) {
+        throw Exception('Error posting alarm status');
+      }
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 409 &&
+          _errorCode(error.response?.data) == 'DEVICE_SESSION_NOT_ACTIVE') {
+        throw const DeviceSessionNotActiveException();
+      }
+      rethrow;
+    }
+  }
+
+  String? _errorCode(Object? data) {
+    if (data is Map<String, dynamic>) {
+      final error = data['error'];
+      if (data['code'] is String) {
+        return data['code'] as String;
+      }
+      if (error is Map<String, dynamic> && error['code'] is String) {
+        return error['code'] as String;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/data/models/alarm_device_model.dart
+++ b/lib/data/models/alarm_device_model.dart
@@ -1,0 +1,45 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+class AlarmDeviceInfoModel {
+  final String deviceId;
+  final String platform;
+  final String appVersion;
+  final String osVersion;
+  final bool supportsNativeAlarm;
+  final AlarmProvider nativeAlarmProvider;
+  final AlarmProvider fallbackProvider;
+
+  const AlarmDeviceInfoModel({
+    required this.deviceId,
+    required this.platform,
+    required this.appVersion,
+    required this.osVersion,
+    required this.supportsNativeAlarm,
+    required this.nativeAlarmProvider,
+    required this.fallbackProvider,
+  });
+
+  factory AlarmDeviceInfoModel.fromEntity(AlarmDeviceInfo entity) {
+    return AlarmDeviceInfoModel(
+      deviceId: entity.deviceId,
+      platform: entity.platform,
+      appVersion: entity.appVersion,
+      osVersion: entity.osVersion,
+      supportsNativeAlarm: entity.supportsNativeAlarm,
+      nativeAlarmProvider: entity.nativeAlarmProvider,
+      fallbackProvider: entity.fallbackProvider,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'deviceId': deviceId,
+      'platform': platform,
+      'appVersion': appVersion,
+      'osVersion': osVersion,
+      'supportsNativeAlarm': supportsNativeAlarm,
+      'nativeAlarmProvider': nativeAlarmProvider.wireValue,
+      'fallbackProvider': fallbackProvider.wireValue,
+    };
+  }
+}

--- a/lib/data/models/alarm_settings_model.dart
+++ b/lib/data/models/alarm_settings_model.dart
@@ -1,0 +1,60 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+class AlarmSettingsModel {
+  final bool alarmsEnabled;
+  final int defaultAlarmOffsetMinutes;
+  final DateTime? updatedAt;
+
+  const AlarmSettingsModel({
+    required this.alarmsEnabled,
+    required this.defaultAlarmOffsetMinutes,
+    this.updatedAt,
+  });
+
+  factory AlarmSettingsModel.fromJson(Map<String, dynamic> json) {
+    return AlarmSettingsModel(
+      alarmsEnabled: json['alarmsEnabled'] as bool? ?? true,
+      defaultAlarmOffsetMinutes:
+          (json['defaultAlarmOffsetMinutes'] as num?)?.toInt() ?? 5,
+      updatedAt: json['updatedAt'] == null
+          ? null
+          : DateTime.parse(json['updatedAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'alarmsEnabled': alarmsEnabled,
+      'defaultAlarmOffsetMinutes': defaultAlarmOffsetMinutes,
+      if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
+    };
+  }
+
+  AlarmSettings toEntity() {
+    return AlarmSettings(
+      alarmsEnabled: alarmsEnabled,
+      defaultAlarmOffsetMinutes: defaultAlarmOffsetMinutes,
+      updatedAt: updatedAt,
+    );
+  }
+
+  factory AlarmSettingsModel.fromEntity(AlarmSettings entity) {
+    return AlarmSettingsModel(
+      alarmsEnabled: entity.alarmsEnabled,
+      defaultAlarmOffsetMinutes: entity.defaultAlarmOffsetMinutes,
+      updatedAt: entity.updatedAt,
+    );
+  }
+}
+
+class UpdateAlarmSettingsRequestModel {
+  final bool alarmsEnabled;
+
+  const UpdateAlarmSettingsRequestModel({required this.alarmsEnabled});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'alarmsEnabled': alarmsEnabled,
+    };
+  }
+}

--- a/lib/data/models/alarm_status_report_model.dart
+++ b/lib/data/models/alarm_status_report_model.dart
@@ -1,8 +1,8 @@
 import 'package:on_time_front/domain/entities/alarm_entities.dart';
 
 enum AlarmStatusReportWireFormat {
-  upperSnake,
   lowerCamel,
+  upperSnake,
 }
 
 class AlarmStatusReportModel {
@@ -12,7 +12,7 @@ class AlarmStatusReportModel {
 
   Map<String, dynamic> toJson({
     AlarmStatusReportWireFormat wireFormat =
-        AlarmStatusReportWireFormat.upperSnake,
+        AlarmStatusReportWireFormat.lowerCamel,
   }) {
     return {
       'deviceId': report.deviceId,

--- a/lib/data/models/alarm_status_report_model.dart
+++ b/lib/data/models/alarm_status_report_model.dart
@@ -1,0 +1,34 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+class AlarmStatusReportModel {
+  final AlarmStatusReport report;
+
+  const AlarmStatusReportModel(this.report);
+
+  Map<String, dynamic> toJson() {
+    return {
+      'deviceId': report.deviceId,
+      'reconciledAt': report.reconciledAt.toIso8601String(),
+      'scheduleWindowStart': report.scheduleWindowStart.toIso8601String(),
+      'scheduleWindowEnd': report.scheduleWindowEnd.toIso8601String(),
+      'alarmCoverageStart': report.alarmCoverageStart.toIso8601String(),
+      'alarmCoverageEnd': report.alarmCoverageEnd.toIso8601String(),
+      'status': report.status.wireValue,
+      'permissionIssue': report.permissionIssue?.wireValue,
+      'nativeAlarmProvider': report.nativeAlarmProvider.wireValue,
+      'fallbackProvider': report.fallbackProvider.wireValue,
+      'armedScheduleCount': report.armedScheduleCount,
+      'armedScheduleIds': report.armedScheduleIds,
+      'skippedScheduleCount': report.skippedScheduleCount,
+      'failures': report.failures
+          .map(
+            (failure) => {
+              if (failure.scheduleId != null) 'scheduleId': failure.scheduleId,
+              'reason': failure.reason.wireValue,
+              if (failure.message != null) 'message': failure.message,
+            },
+          )
+          .toList(),
+    };
+  }
+}

--- a/lib/data/models/alarm_status_report_model.dart
+++ b/lib/data/models/alarm_status_report_model.dart
@@ -1,8 +1,8 @@
 import 'package:on_time_front/domain/entities/alarm_entities.dart';
 
 enum AlarmStatusReportWireFormat {
-  lowerCamel,
   upperSnake,
+  lowerCamel,
 }
 
 class AlarmStatusReportModel {
@@ -12,11 +12,11 @@ class AlarmStatusReportModel {
 
   Map<String, dynamic> toJson({
     AlarmStatusReportWireFormat wireFormat =
-        AlarmStatusReportWireFormat.lowerCamel,
+        AlarmStatusReportWireFormat.upperSnake,
   }) {
     return {
       'deviceId': report.deviceId,
-      'reconciledAt': _toBackendDateTimeString(report.reconciledAt),
+      'reconciledAt': _toBackendInstantString(report.reconciledAt),
       'scheduleWindowStart':
           _toBackendDateTimeString(report.scheduleWindowStart),
       'scheduleWindowEnd': _toBackendDateTimeString(report.scheduleWindowEnd),
@@ -47,18 +47,26 @@ class AlarmStatusReportModel {
     };
   }
 
+  String _toBackendInstantString(DateTime value) {
+    final utc = value.toUtc();
+    return '${_formatDateTime(utc)}Z';
+  }
+
   String _toBackendDateTimeString(DateTime value) {
-    final local = value.toLocal();
+    return _formatDateTime(value.toLocal());
+  }
+
+  String _formatDateTime(DateTime value) {
     String twoDigits(int value) => value.toString().padLeft(2, '0');
     String threeDigits(int value) => value.toString().padLeft(3, '0');
 
-    return '${local.year.toString().padLeft(4, '0')}-'
-        '${twoDigits(local.month)}-'
-        '${twoDigits(local.day)}T'
-        '${twoDigits(local.hour)}:'
-        '${twoDigits(local.minute)}:'
-        '${twoDigits(local.second)}.'
-        '${threeDigits(local.millisecond)}';
+    return '${value.year.toString().padLeft(4, '0')}-'
+        '${twoDigits(value.month)}-'
+        '${twoDigits(value.day)}T'
+        '${twoDigits(value.hour)}:'
+        '${twoDigits(value.minute)}:'
+        '${twoDigits(value.second)}.'
+        '${threeDigits(value.millisecond)}';
   }
 
   String _providerWireValue(

--- a/lib/data/models/alarm_status_report_model.dart
+++ b/lib/data/models/alarm_status_report_model.dart
@@ -1,22 +1,37 @@
 import 'package:on_time_front/domain/entities/alarm_entities.dart';
 
+enum AlarmStatusReportWireFormat {
+  lowerCamel,
+  upperSnake,
+}
+
 class AlarmStatusReportModel {
   final AlarmStatusReport report;
 
   const AlarmStatusReportModel(this.report);
 
-  Map<String, dynamic> toJson() {
+  Map<String, dynamic> toJson({
+    AlarmStatusReportWireFormat wireFormat =
+        AlarmStatusReportWireFormat.lowerCamel,
+  }) {
     return {
       'deviceId': report.deviceId,
-      'reconciledAt': report.reconciledAt.toIso8601String(),
-      'scheduleWindowStart': report.scheduleWindowStart.toIso8601String(),
-      'scheduleWindowEnd': report.scheduleWindowEnd.toIso8601String(),
-      'alarmCoverageStart': report.alarmCoverageStart.toIso8601String(),
-      'alarmCoverageEnd': report.alarmCoverageEnd.toIso8601String(),
-      'status': report.status.wireValue,
-      'permissionIssue': report.permissionIssue?.wireValue,
-      'nativeAlarmProvider': report.nativeAlarmProvider.wireValue,
-      'fallbackProvider': report.fallbackProvider.wireValue,
+      'reconciledAt': _toBackendDateTimeString(report.reconciledAt),
+      'scheduleWindowStart':
+          _toBackendDateTimeString(report.scheduleWindowStart),
+      'scheduleWindowEnd': _toBackendDateTimeString(report.scheduleWindowEnd),
+      'alarmCoverageStart': _toBackendDateTimeString(report.alarmCoverageStart),
+      'alarmCoverageEnd': _toBackendDateTimeString(report.alarmCoverageEnd),
+      'status': _statusWireValue(report.status, wireFormat),
+      if (report.permissionIssue != null)
+        'permissionIssue':
+            _permissionIssueWireValue(report.permissionIssue!, wireFormat),
+      'nativeAlarmProvider':
+          _providerWireValue(report.nativeAlarmProvider, wireFormat),
+      'fallbackProvider': _providerWireValue(
+        report.fallbackProvider,
+        wireFormat,
+      ),
       'armedScheduleCount': report.armedScheduleCount,
       'armedScheduleIds': report.armedScheduleIds,
       'skippedScheduleCount': report.skippedScheduleCount,
@@ -24,11 +39,101 @@ class AlarmStatusReportModel {
           .map(
             (failure) => {
               if (failure.scheduleId != null) 'scheduleId': failure.scheduleId,
-              'reason': failure.reason.wireValue,
+              'reason': _failureReasonWireValue(failure.reason, wireFormat),
               if (failure.message != null) 'message': failure.message,
             },
           )
           .toList(),
     };
+  }
+
+  String _toBackendDateTimeString(DateTime value) {
+    final local = value.toLocal();
+    String twoDigits(int value) => value.toString().padLeft(2, '0');
+    String threeDigits(int value) => value.toString().padLeft(3, '0');
+
+    return '${local.year.toString().padLeft(4, '0')}-'
+        '${twoDigits(local.month)}-'
+        '${twoDigits(local.day)}T'
+        '${twoDigits(local.hour)}:'
+        '${twoDigits(local.minute)}:'
+        '${twoDigits(local.second)}.'
+        '${threeDigits(local.millisecond)}';
+  }
+
+  String _providerWireValue(
+    AlarmProvider provider,
+    AlarmStatusReportWireFormat wireFormat,
+  ) {
+    if (wireFormat == AlarmStatusReportWireFormat.lowerCamel) {
+      return provider.wireValue;
+    }
+    switch (provider) {
+      case AlarmProvider.androidAlarmManager:
+        return 'ANDROID_ALARM_MANAGER';
+      case AlarmProvider.iosAlarmKit:
+        return 'IOS_ALARM_KIT';
+      case AlarmProvider.localNotification:
+        return 'LOCAL_NOTIFICATION';
+      case AlarmProvider.none:
+        return 'NONE';
+    }
+  }
+
+  String _statusWireValue(
+    AlarmReconciliationStatus status,
+    AlarmStatusReportWireFormat wireFormat,
+  ) {
+    if (wireFormat == AlarmStatusReportWireFormat.lowerCamel) {
+      return status.wireValue;
+    }
+    switch (status) {
+      case AlarmReconciliationStatus.armed:
+        return 'ARMED';
+      case AlarmReconciliationStatus.partial:
+        return 'PARTIAL';
+      case AlarmReconciliationStatus.disabled:
+        return 'DISABLED';
+      case AlarmReconciliationStatus.permissionNeeded:
+        return 'PERMISSION_NEEDED';
+      case AlarmReconciliationStatus.unsupported:
+        return 'UNSUPPORTED';
+      case AlarmReconciliationStatus.settingsUnavailable:
+        return 'SETTINGS_UNAVAILABLE';
+    }
+  }
+
+  String _permissionIssueWireValue(
+    AlarmPermissionIssue issue,
+    AlarmStatusReportWireFormat wireFormat,
+  ) {
+    if (wireFormat == AlarmStatusReportWireFormat.lowerCamel) {
+      return issue.wireValue;
+    }
+    switch (issue) {
+      case AlarmPermissionIssue.nativePermissionDenied:
+        return 'NATIVE_PERMISSION_DENIED';
+      case AlarmPermissionIssue.notificationPermissionDenied:
+        return 'NOTIFICATION_PERMISSION_DENIED';
+    }
+  }
+
+  String _failureReasonWireValue(
+    AlarmFailureReason reason,
+    AlarmStatusReportWireFormat wireFormat,
+  ) {
+    if (wireFormat == AlarmStatusReportWireFormat.lowerCamel) {
+      return reason.wireValue;
+    }
+    switch (reason) {
+      case AlarmFailureReason.preparationLoadFailed:
+        return 'PREPARATION_LOAD_FAILED';
+      case AlarmFailureReason.scheduleInvalid:
+        return 'SCHEDULE_INVALID';
+      case AlarmFailureReason.platformError:
+        return 'PLATFORM_ERROR';
+      case AlarmFailureReason.unknown:
+        return 'UNKNOWN';
+    }
   }
 }

--- a/lib/data/models/alarm_window_schedule_model.dart
+++ b/lib/data/models/alarm_window_schedule_model.dart
@@ -1,0 +1,117 @@
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+
+class AlarmWindowScheduleModel {
+  final String scheduleId;
+  final String scheduleName;
+  final PlaceEntity place;
+  final DateTime scheduleTime;
+  final int moveTime;
+  final int scheduleSpareTime;
+  final String doneStatus;
+  final List<AlarmWindowPreparationStepModel> preparations;
+
+  const AlarmWindowScheduleModel({
+    required this.scheduleId,
+    required this.scheduleName,
+    required this.place,
+    required this.scheduleTime,
+    required this.moveTime,
+    required this.scheduleSpareTime,
+    required this.doneStatus,
+    required this.preparations,
+  });
+
+  factory AlarmWindowScheduleModel.fromJson(Map<String, dynamic> json) {
+    final placeJson = json['place'] as Map<String, dynamic>? ?? const {};
+    final preparationJson =
+        (json['preparations'] as List<dynamic>? ?? const <dynamic>[]);
+    return AlarmWindowScheduleModel(
+      scheduleId: json['scheduleId'] as String,
+      scheduleName: json['scheduleName'] as String? ?? '',
+      place: PlaceEntity(
+        id: placeJson['placeId'] as String? ?? '',
+        placeName: placeJson['placeName'] as String? ?? '',
+      ),
+      scheduleTime: DateTime.parse(json['scheduleTime'] as String),
+      moveTime: (json['moveTime'] as num?)?.toInt() ?? 0,
+      scheduleSpareTime: (json['scheduleSpareTime'] as num?)?.toInt() ?? 0,
+      doneStatus: json['doneStatus'] as String? ?? 'NOT_ENDED',
+      preparations: preparationJson
+          .map((item) => AlarmWindowPreparationStepModel.fromJson(
+              item as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  ScheduleWithPreparationEntity toEntity() {
+    return ScheduleWithPreparationEntity(
+      id: scheduleId,
+      place: place,
+      scheduleName: scheduleName,
+      scheduleTime: scheduleTime,
+      moveTime: Duration(minutes: moveTime),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: Duration(minutes: scheduleSpareTime),
+      scheduleNote: '',
+      doneStatus: _mapDoneStatus(doneStatus),
+      preparation: PreparationWithTimeEntity.fromPreparation(
+        PreparationEntity(
+          preparationStepList:
+              preparations.map((step) => step.toEntity()).toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class AlarmWindowPreparationStepModel {
+  final String id;
+  final String preparationName;
+  final int preparationTime;
+  final String? nextPreparationId;
+
+  const AlarmWindowPreparationStepModel({
+    required this.id,
+    required this.preparationName,
+    required this.preparationTime,
+    this.nextPreparationId,
+  });
+
+  factory AlarmWindowPreparationStepModel.fromJson(Map<String, dynamic> json) {
+    return AlarmWindowPreparationStepModel(
+      id: json['preparationId'] as String,
+      preparationName: json['preparationName'] as String? ?? '',
+      preparationTime: (json['preparationTime'] as num?)?.toInt() ?? 0,
+      nextPreparationId: json['nextPreparationId'] as String?,
+    );
+  }
+
+  PreparationStepEntity toEntity() {
+    return PreparationStepEntity(
+      id: id,
+      preparationName: preparationName,
+      preparationTime: Duration(minutes: preparationTime),
+      nextPreparationId: nextPreparationId,
+    );
+  }
+}
+
+ScheduleDoneStatus _mapDoneStatus(String? serverValue) {
+  switch (serverValue) {
+    case 'LATE':
+      return ScheduleDoneStatus.lateEnd;
+    case 'NORMAL':
+      return ScheduleDoneStatus.normalEnd;
+    case 'ABNORMAL':
+      return ScheduleDoneStatus.abnormalEnd;
+    case 'NOT_ENDED':
+    default:
+      return ScheduleDoneStatus.notEnded;
+  }
+}

--- a/lib/data/models/fcm_token_register_request_model.dart
+++ b/lib/data/models/fcm_token_register_request_model.dart
@@ -5,9 +5,11 @@ part 'fcm_token_register_request_model.g.dart';
 @JsonSerializable()
 class FcmTokenRegisterRequestModel {
   final String firebaseToken;
+  final String? deviceId;
 
   FcmTokenRegisterRequestModel({
     required this.firebaseToken,
+    this.deviceId,
   });
 
   factory FcmTokenRegisterRequestModel.fromJson(Map<String, dynamic> json) =>

--- a/lib/data/models/scheduled_alarm_record_model.dart
+++ b/lib/data/models/scheduled_alarm_record_model.dart
@@ -1,0 +1,42 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+class ScheduledAlarmRecordModel {
+  final ScheduledAlarmRecord record;
+
+  const ScheduledAlarmRecordModel(this.record);
+
+  factory ScheduledAlarmRecordModel.fromJson(Map<String, dynamic> json) {
+    final payload = (json['payload'] as Map<String, dynamic>? ?? const {})
+        .map((key, value) => MapEntry(key, value.toString()));
+    return ScheduledAlarmRecordModel(
+      ScheduledAlarmRecord(
+        scheduleId: json['scheduleId'] as String,
+        alarmTime: DateTime.parse(json['alarmTime'] as String),
+        preparationStartTime:
+            DateTime.parse(json['preparationStartTime'] as String),
+        scheduleFingerprint: json['scheduleFingerprint'] as String? ?? '',
+        nativeAlarmId: (json['nativeAlarmId'] as num?)?.toInt(),
+        fallbackNotificationId:
+            (json['fallbackNotificationId'] as num?)?.toInt(),
+        provider:
+            AlarmProviderWireValue.fromWireValue(json['provider'] as String?),
+        scheduleTitle: json['scheduleTitle'] as String? ?? '',
+        payload: payload,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'scheduleId': record.scheduleId,
+      'alarmTime': record.alarmTime.toIso8601String(),
+      'preparationStartTime': record.preparationStartTime.toIso8601String(),
+      'scheduleFingerprint': record.scheduleFingerprint,
+      'nativeAlarmId': record.nativeAlarmId,
+      'fallbackNotificationId': record.fallbackNotificationId,
+      'provider': record.provider.wireValue,
+      'scheduleTitle': record.scheduleTitle,
+      'payload': record.payload,
+    };
+  }
+}

--- a/lib/data/models/sign_in_with_apple_request_model.dart
+++ b/lib/data/models/sign_in_with_apple_request_model.dart
@@ -16,15 +16,12 @@ class SignInWithAppleRequestModel {
     this.email,
   });
 
+  factory SignInWithAppleRequestModel.fromJson(Map<String, dynamic> json) =>
+      _$SignInWithAppleRequestModelFromJson(json);
+
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> map = {
-      'idToken': idToken,
-      'authCode': authCode,
-      'fullName': fullName,
-    };
-    if (email != null) {
-      map['email'] = email;
-    }
+    final map = _$SignInWithAppleRequestModelToJson(this);
+    map.removeWhere((key, value) => value == null);
     return map;
   }
 }

--- a/lib/data/models/sign_in_with_google_request_model.dart
+++ b/lib/data/models/sign_in_with_google_request_model.dart
@@ -6,16 +6,14 @@ part 'sign_in_with_google_request_model.g.dart';
 class SignInWithGoogleRequestModel {
   final String idToken;
   final String refreshToken;
-  
+
   SignInWithGoogleRequestModel({
     required this.idToken,
     required this.refreshToken,
   });
 
-  Map<String, dynamic> toJson() {
-    return {
-      'idToken': idToken,
-      'refreshToken': refreshToken,
-    };
-  }
+  factory SignInWithGoogleRequestModel.fromJson(Map<String, dynamic> json) =>
+      _$SignInWithGoogleRequestModelFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SignInWithGoogleRequestModelToJson(this);
 }

--- a/lib/data/repositories/alarm_registry_repository_impl.dart
+++ b/lib/data/repositories/alarm_registry_repository_impl.dart
@@ -1,0 +1,48 @@
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/data/data_sources/alarm_registry_local_data_source.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+
+@Singleton(as: AlarmRegistryRepository)
+class AlarmRegistryRepositoryImpl implements AlarmRegistryRepository {
+  final AlarmRegistryLocalDataSource localDataSource;
+
+  AlarmRegistryRepositoryImpl({required this.localDataSource});
+
+  @override
+  Future<List<ScheduledAlarmRecord>> loadAll() {
+    return localDataSource.loadAll();
+  }
+
+  @override
+  Future<void> upsert(ScheduledAlarmRecord record) async {
+    final records = await loadAll();
+    final nextRecords = records
+        .where((existing) => existing.scheduleId != record.scheduleId)
+        .toList()
+      ..add(record);
+    await replaceAll(nextRecords);
+  }
+
+  @override
+  Future<void> deleteByScheduleId(String scheduleId) async {
+    final records = await loadAll();
+    await replaceAll(
+      records.where((record) => record.scheduleId != scheduleId).toList(),
+    );
+  }
+
+  @override
+  Future<void> deleteAll() {
+    return replaceAll(const []);
+  }
+
+  @override
+  Future<void> replaceAll(List<ScheduledAlarmRecord> records) {
+    final byScheduleId = <String, ScheduledAlarmRecord>{};
+    for (final record in records) {
+      byScheduleId[record.scheduleId] = record;
+    }
+    return localDataSource.replaceAll(byScheduleId.values.toList());
+  }
+}

--- a/lib/data/repositories/alarm_repository_impl.dart
+++ b/lib/data/repositories/alarm_repository_impl.dart
@@ -1,0 +1,122 @@
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/device_info_service/shared.dart';
+import 'package:on_time_front/data/data_sources/alarm_remote_data_source.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+@Singleton(as: AlarmRepository)
+class AlarmRepositoryImpl implements AlarmRepository {
+  final AlarmRemoteDataSource remoteDataSource;
+  final AlarmSchedulerService schedulerService;
+
+  AlarmRepositoryImpl({
+    required this.remoteDataSource,
+    required this.schedulerService,
+  });
+
+  static const _deviceIdKey = 'alarm_device_id';
+
+  @override
+  Future<String> getDeviceId() async {
+    final prefs = await SharedPreferences.getInstance();
+    final existing = prefs.getString(_deviceIdKey);
+    if (existing != null && existing.isNotEmpty) {
+      return existing;
+    }
+
+    final next = const Uuid().v4();
+    await prefs.setString(_deviceIdKey, next);
+    return next;
+  }
+
+  @override
+  Future<AlarmDeviceInfo> buildCurrentDeviceInfo() async {
+    final capabilities = await schedulerService.getCapabilities();
+    return AlarmDeviceInfo(
+      deviceId: await getDeviceId(),
+      platform: _platformWireValue(),
+      appVersion: '1.0.0',
+      osVersion: _osWireValue(),
+      supportsNativeAlarm: capabilities.supportsNativeAlarm,
+      nativeAlarmProvider: capabilities.nativeAlarmProvider,
+      fallbackProvider: capabilities.fallbackProvider,
+    );
+  }
+
+  @override
+  Future<AlarmSettings> getAlarmSettings() {
+    return remoteDataSource.getAlarmSettings();
+  }
+
+  @override
+  Future<AlarmSettings> updateAlarmSettings({
+    required bool alarmsEnabled,
+  }) {
+    return remoteDataSource.updateAlarmSettings(
+      alarmsEnabled: alarmsEnabled,
+    );
+  }
+
+  @override
+  Future<void> registerCurrentDevice(AlarmDeviceInfo deviceInfo) {
+    return remoteDataSource.registerCurrentDevice(deviceInfo);
+  }
+
+  @override
+  Future<void> unregisterCurrentDevice(String deviceId) {
+    return remoteDataSource.unregisterCurrentDevice(deviceId);
+  }
+
+  @override
+  Future<List<ScheduleWithPreparationEntity>> getAlarmWindow(
+    DateTime startDate,
+    DateTime endDate,
+  ) {
+    return remoteDataSource.getAlarmWindow(startDate, endDate);
+  }
+
+  @override
+  Future<void> postAlarmStatus(AlarmStatusReport report) {
+    return remoteDataSource.postAlarmStatus(report);
+  }
+
+  String _platformWireValue() {
+    try {
+      switch (DeviceInfoService.platformType) {
+        case PlatformType.android:
+          return 'android';
+        case PlatformType.ios:
+          return 'ios';
+        case PlatformType.web:
+          return 'web';
+      }
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+
+  String _osWireValue() {
+    try {
+      switch (DeviceInfoService.osType) {
+        case OsType.android:
+          return 'android';
+        case OsType.ios:
+          return 'ios';
+        case OsType.macos:
+          return 'macos';
+        case OsType.windows:
+          return 'windows';
+        case OsType.linux:
+          return 'linux';
+        case OsType.unknown:
+          return 'unknown';
+      }
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+}

--- a/lib/data/repositories/preparation_repository_impl.dart
+++ b/lib/data/repositories/preparation_repository_impl.dart
@@ -109,6 +109,7 @@ class PreparationRepositoryImpl implements PreparationRepository {
     }
   }
 
+  @override
   Future<void> updateSpareTime(Duration newSpareTime) async {
     try {
       await preparationRemoteDataSource.updateSpareTime(newSpareTime);

--- a/lib/data/repositories/schedule_repository_impl.dart
+++ b/lib/data/repositories/schedule_repository_impl.dart
@@ -150,16 +150,6 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
     _scheduleStreamController.add(nextSchedules);
   }
 
-  void _emitUpsertedSchedules(Iterable<ScheduleEntity> schedules) {
-    final nextSchedules =
-        Set<ScheduleEntity>.from(_scheduleStreamController.value);
-    for (final schedule in schedules) {
-      nextSchedules.removeWhere((existing) => existing.id == schedule.id);
-      nextSchedules.add(schedule);
-    }
-    _scheduleStreamController.add(nextSchedules);
-  }
-
   void _replaceSchedulesInRange({
     required DateTime startDate,
     required DateTime? endDate,

--- a/lib/domain/entities/alarm_entities.dart
+++ b/lib/domain/entities/alarm_entities.dart
@@ -1,0 +1,498 @@
+import 'package:equatable/equatable.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+
+const alarmDefaultOffset = Duration(minutes: 5);
+
+enum AlarmProvider {
+  androidAlarmManager,
+  iosAlarmKit,
+  localNotification,
+  none,
+}
+
+enum AlarmPermissionState {
+  granted,
+  denied,
+  notDetermined,
+  unsupported,
+}
+
+enum AlarmPermissionIssue {
+  nativePermissionDenied,
+  notificationPermissionDenied,
+}
+
+enum AlarmFailureReason {
+  preparationLoadFailed,
+  scheduleInvalid,
+  platformError,
+  unknown,
+}
+
+enum AlarmReconciliationStatus {
+  armed,
+  partial,
+  disabled,
+  permissionNeeded,
+  unsupported,
+  settingsUnavailable,
+}
+
+extension AlarmProviderWireValue on AlarmProvider {
+  String get wireValue {
+    switch (this) {
+      case AlarmProvider.androidAlarmManager:
+        return 'androidAlarmManager';
+      case AlarmProvider.iosAlarmKit:
+        return 'iosAlarmKit';
+      case AlarmProvider.localNotification:
+        return 'localNotification';
+      case AlarmProvider.none:
+        return 'none';
+    }
+  }
+
+  static AlarmProvider fromWireValue(String? value) {
+    switch (value) {
+      case 'androidAlarmManager':
+        return AlarmProvider.androidAlarmManager;
+      case 'iosAlarmKit':
+        return AlarmProvider.iosAlarmKit;
+      case 'localNotification':
+        return AlarmProvider.localNotification;
+      case 'none':
+      default:
+        return AlarmProvider.none;
+    }
+  }
+}
+
+extension AlarmPermissionStateWireValue on AlarmPermissionState {
+  static AlarmPermissionState fromWireValue(String? value) {
+    switch (value) {
+      case 'granted':
+        return AlarmPermissionState.granted;
+      case 'denied':
+        return AlarmPermissionState.denied;
+      case 'notDetermined':
+        return AlarmPermissionState.notDetermined;
+      case 'unsupported':
+      default:
+        return AlarmPermissionState.unsupported;
+    }
+  }
+}
+
+extension AlarmPermissionIssueWireValue on AlarmPermissionIssue {
+  String get wireValue {
+    switch (this) {
+      case AlarmPermissionIssue.nativePermissionDenied:
+        return 'nativePermissionDenied';
+      case AlarmPermissionIssue.notificationPermissionDenied:
+        return 'notificationPermissionDenied';
+    }
+  }
+
+  static AlarmPermissionIssue? fromWireValue(String? value) {
+    switch (value) {
+      case 'nativePermissionDenied':
+        return AlarmPermissionIssue.nativePermissionDenied;
+      case 'notificationPermissionDenied':
+        return AlarmPermissionIssue.notificationPermissionDenied;
+      case null:
+        return null;
+      default:
+        return null;
+    }
+  }
+}
+
+extension AlarmFailureReasonWireValue on AlarmFailureReason {
+  String get wireValue {
+    switch (this) {
+      case AlarmFailureReason.preparationLoadFailed:
+        return 'preparationLoadFailed';
+      case AlarmFailureReason.scheduleInvalid:
+        return 'scheduleInvalid';
+      case AlarmFailureReason.platformError:
+        return 'platformError';
+      case AlarmFailureReason.unknown:
+        return 'unknown';
+    }
+  }
+
+  static AlarmFailureReason fromWireValue(String? value) {
+    switch (value) {
+      case 'preparationLoadFailed':
+        return AlarmFailureReason.preparationLoadFailed;
+      case 'scheduleInvalid':
+        return AlarmFailureReason.scheduleInvalid;
+      case 'platformError':
+        return AlarmFailureReason.platformError;
+      case 'unknown':
+      default:
+        return AlarmFailureReason.unknown;
+    }
+  }
+}
+
+extension AlarmReconciliationStatusWireValue on AlarmReconciliationStatus {
+  String get wireValue {
+    switch (this) {
+      case AlarmReconciliationStatus.armed:
+        return 'armed';
+      case AlarmReconciliationStatus.partial:
+        return 'partial';
+      case AlarmReconciliationStatus.disabled:
+        return 'disabled';
+      case AlarmReconciliationStatus.permissionNeeded:
+        return 'permissionNeeded';
+      case AlarmReconciliationStatus.unsupported:
+        return 'unsupported';
+      case AlarmReconciliationStatus.settingsUnavailable:
+        return 'settingsUnavailable';
+    }
+  }
+
+  static AlarmReconciliationStatus fromWireValue(String? value) {
+    switch (value) {
+      case 'armed':
+        return AlarmReconciliationStatus.armed;
+      case 'partial':
+        return AlarmReconciliationStatus.partial;
+      case 'disabled':
+        return AlarmReconciliationStatus.disabled;
+      case 'permissionNeeded':
+        return AlarmReconciliationStatus.permissionNeeded;
+      case 'unsupported':
+        return AlarmReconciliationStatus.unsupported;
+      case 'settingsUnavailable':
+      default:
+        return AlarmReconciliationStatus.settingsUnavailable;
+    }
+  }
+}
+
+class AlarmSchedulingException implements Exception {
+  final AlarmFailureReason reason;
+  final AlarmPermissionIssue? permissionIssue;
+  final String message;
+
+  const AlarmSchedulingException({
+    required this.reason,
+    required this.message,
+    this.permissionIssue,
+  });
+
+  @override
+  String toString() {
+    return 'AlarmSchedulingException(reason: $reason, permissionIssue: $permissionIssue, message: $message)';
+  }
+}
+
+class DeviceSessionNotActiveException implements Exception {
+  const DeviceSessionNotActiveException();
+
+  @override
+  String toString() => 'DeviceSessionNotActiveException';
+}
+
+class AlarmSettings extends Equatable {
+  final bool alarmsEnabled;
+  final int defaultAlarmOffsetMinutes;
+  final DateTime? updatedAt;
+
+  const AlarmSettings({
+    required this.alarmsEnabled,
+    this.defaultAlarmOffsetMinutes = 5,
+    this.updatedAt,
+  });
+
+  Duration get alarmOffset => Duration(minutes: defaultAlarmOffsetMinutes);
+
+  @override
+  List<Object?> get props => [
+        alarmsEnabled,
+        defaultAlarmOffsetMinutes,
+        updatedAt,
+      ];
+}
+
+class AlarmDeviceInfo extends Equatable {
+  final String deviceId;
+  final String platform;
+  final String appVersion;
+  final String osVersion;
+  final bool supportsNativeAlarm;
+  final AlarmProvider nativeAlarmProvider;
+  final AlarmProvider fallbackProvider;
+
+  const AlarmDeviceInfo({
+    required this.deviceId,
+    required this.platform,
+    required this.appVersion,
+    required this.osVersion,
+    required this.supportsNativeAlarm,
+    required this.nativeAlarmProvider,
+    required this.fallbackProvider,
+  });
+
+  @override
+  List<Object?> get props => [
+        deviceId,
+        platform,
+        appVersion,
+        osVersion,
+        supportsNativeAlarm,
+        nativeAlarmProvider,
+        fallbackProvider,
+      ];
+}
+
+class AlarmSchedulerCapabilities extends Equatable {
+  final bool supportsNativeAlarm;
+  final AlarmProvider nativeAlarmProvider;
+  final AlarmProvider fallbackProvider;
+
+  const AlarmSchedulerCapabilities({
+    required this.supportsNativeAlarm,
+    required this.nativeAlarmProvider,
+    this.fallbackProvider = AlarmProvider.localNotification,
+  });
+
+  static const unsupported = AlarmSchedulerCapabilities(
+    supportsNativeAlarm: false,
+    nativeAlarmProvider: AlarmProvider.none,
+    fallbackProvider: AlarmProvider.none,
+  );
+
+  @override
+  List<Object?> get props => [
+        supportsNativeAlarm,
+        nativeAlarmProvider,
+        fallbackProvider,
+      ];
+}
+
+class ScheduledAlarmRecord extends Equatable {
+  final String scheduleId;
+  final DateTime alarmTime;
+  final DateTime preparationStartTime;
+  final String scheduleFingerprint;
+  final int? nativeAlarmId;
+  final int? fallbackNotificationId;
+  final AlarmProvider provider;
+  final String scheduleTitle;
+  final Map<String, String> payload;
+
+  const ScheduledAlarmRecord({
+    required this.scheduleId,
+    required this.alarmTime,
+    required this.preparationStartTime,
+    required this.scheduleFingerprint,
+    required this.provider,
+    required this.scheduleTitle,
+    required this.payload,
+    this.nativeAlarmId,
+    this.fallbackNotificationId,
+  });
+
+  ScheduledAlarmRecord copyWith({
+    int? nativeAlarmId,
+    int? fallbackNotificationId,
+    AlarmProvider? provider,
+  }) {
+    return ScheduledAlarmRecord(
+      scheduleId: scheduleId,
+      alarmTime: alarmTime,
+      preparationStartTime: preparationStartTime,
+      scheduleFingerprint: scheduleFingerprint,
+      nativeAlarmId: nativeAlarmId ?? this.nativeAlarmId,
+      fallbackNotificationId:
+          fallbackNotificationId ?? this.fallbackNotificationId,
+      provider: provider ?? this.provider,
+      scheduleTitle: scheduleTitle,
+      payload: payload,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        scheduleId,
+        alarmTime,
+        preparationStartTime,
+        scheduleFingerprint,
+        nativeAlarmId,
+        fallbackNotificationId,
+        provider,
+        scheduleTitle,
+        payload,
+      ];
+}
+
+class AlarmFailure extends Equatable {
+  final String? scheduleId;
+  final AlarmFailureReason reason;
+  final String? message;
+
+  const AlarmFailure({
+    required this.reason,
+    this.scheduleId,
+    this.message,
+  });
+
+  @override
+  List<Object?> get props => [scheduleId, reason, message];
+}
+
+class AlarmReconciliationResult extends Equatable {
+  final AlarmReconciliationStatus status;
+  final AlarmPermissionIssue? permissionIssue;
+  final AlarmProvider nativeAlarmProvider;
+  final AlarmProvider fallbackProvider;
+  final List<String> armedScheduleIds;
+  final int skippedScheduleCount;
+  final List<AlarmFailure> failures;
+  final DateTime scheduleWindowStart;
+  final DateTime scheduleWindowEnd;
+  final DateTime alarmCoverageStart;
+  final DateTime alarmCoverageEnd;
+
+  const AlarmReconciliationResult({
+    required this.status,
+    required this.nativeAlarmProvider,
+    required this.fallbackProvider,
+    required this.armedScheduleIds,
+    required this.skippedScheduleCount,
+    required this.failures,
+    required this.scheduleWindowStart,
+    required this.scheduleWindowEnd,
+    required this.alarmCoverageStart,
+    required this.alarmCoverageEnd,
+    this.permissionIssue,
+  });
+
+  int get armedScheduleCount => armedScheduleIds.length;
+
+  @override
+  List<Object?> get props => [
+        status,
+        permissionIssue,
+        nativeAlarmProvider,
+        fallbackProvider,
+        armedScheduleIds,
+        skippedScheduleCount,
+        failures,
+        scheduleWindowStart,
+        scheduleWindowEnd,
+        alarmCoverageStart,
+        alarmCoverageEnd,
+      ];
+}
+
+class AlarmStatusReport extends Equatable {
+  final String deviceId;
+  final DateTime reconciledAt;
+  final DateTime scheduleWindowStart;
+  final DateTime scheduleWindowEnd;
+  final DateTime alarmCoverageStart;
+  final DateTime alarmCoverageEnd;
+  final AlarmReconciliationStatus status;
+  final AlarmPermissionIssue? permissionIssue;
+  final AlarmProvider nativeAlarmProvider;
+  final AlarmProvider fallbackProvider;
+  final int armedScheduleCount;
+  final List<String> armedScheduleIds;
+  final int skippedScheduleCount;
+  final List<AlarmFailure> failures;
+
+  const AlarmStatusReport({
+    required this.deviceId,
+    required this.reconciledAt,
+    required this.scheduleWindowStart,
+    required this.scheduleWindowEnd,
+    required this.alarmCoverageStart,
+    required this.alarmCoverageEnd,
+    required this.status,
+    required this.nativeAlarmProvider,
+    required this.fallbackProvider,
+    required this.armedScheduleCount,
+    required this.armedScheduleIds,
+    required this.skippedScheduleCount,
+    required this.failures,
+    this.permissionIssue,
+  });
+
+  @override
+  List<Object?> get props => [
+        deviceId,
+        reconciledAt,
+        scheduleWindowStart,
+        scheduleWindowEnd,
+        alarmCoverageStart,
+        alarmCoverageEnd,
+        status,
+        permissionIssue,
+        nativeAlarmProvider,
+        fallbackProvider,
+        armedScheduleCount,
+        armedScheduleIds,
+        skippedScheduleCount,
+        failures,
+      ];
+}
+
+bool isAlarmEligibleSchedule(ScheduleWithPreparationEntity schedule) {
+  return schedule.doneStatus == ScheduleDoneStatus.notEnded;
+}
+
+DateTime computeAlarmTime(
+  ScheduleWithPreparationEntity schedule, {
+  Duration offset = alarmDefaultOffset,
+}) {
+  return schedule.preparationStartTime.subtract(offset);
+}
+
+String buildAlarmScheduleFingerprint(ScheduleWithPreparationEntity schedule) {
+  return schedule.cacheFingerprint;
+}
+
+int stableAlarmId(String scheduleId) {
+  const offsetBasis = 0x811c9dc5;
+  const prime = 0x01000193;
+  var hash = offsetBasis;
+  for (final unit in scheduleId.codeUnits) {
+    hash ^= unit;
+    hash = (hash * prime) & 0x7fffffff;
+  }
+  return hash == 0 ? 1 : hash;
+}
+
+ScheduledAlarmRecord buildScheduledAlarmRecord(
+  ScheduleWithPreparationEntity schedule, {
+  required Duration alarmOffset,
+  required AlarmProvider provider,
+}) {
+  final alarmTime = computeAlarmTime(schedule, offset: alarmOffset);
+  final id = stableAlarmId(schedule.id);
+  final preparationStartTime = schedule.preparationStartTime;
+  return ScheduledAlarmRecord(
+    scheduleId: schedule.id,
+    alarmTime: alarmTime,
+    preparationStartTime: preparationStartTime,
+    scheduleFingerprint: buildAlarmScheduleFingerprint(schedule),
+    nativeAlarmId: id,
+    fallbackNotificationId: id,
+    provider: provider,
+    scheduleTitle: schedule.scheduleName,
+    payload: {
+      'type': 'schedule_alarm',
+      'scheduleId': schedule.id,
+      'alarmTime': alarmTime.toIso8601String(),
+      'preparationStartTime': preparationStartTime.toIso8601String(),
+      'scheduleFingerprint': buildAlarmScheduleFingerprint(schedule),
+      'promptVariant': 'alarm',
+    },
+  );
+}

--- a/lib/domain/entities/alarm_entities.dart
+++ b/lib/domain/entities/alarm_entities.dart
@@ -3,7 +3,7 @@ import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
 
 const alarmDefaultOffset = Duration(minutes: 5);
-const alarmLaunchPayloadVersion = '2';
+const alarmLaunchPayloadVersion = '3';
 
 enum AlarmProvider {
   androidAlarmManager,

--- a/lib/domain/entities/alarm_entities.dart
+++ b/lib/domain/entities/alarm_entities.dart
@@ -3,6 +3,7 @@ import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
 
 const alarmDefaultOffset = Duration(minutes: 5);
+const alarmLaunchPayloadVersion = '2';
 
 enum AlarmProvider {
   androidAlarmManager,
@@ -488,6 +489,7 @@ ScheduledAlarmRecord buildScheduledAlarmRecord(
     scheduleTitle: schedule.scheduleName,
     payload: {
       'type': 'schedule_alarm',
+      'alarmLaunchPayloadVersion': alarmLaunchPayloadVersion,
       'scheduleId': schedule.id,
       'alarmTime': alarmTime.toIso8601String(),
       'preparationStartTime': preparationStartTime.toIso8601String(),

--- a/lib/domain/entities/place_entity.dart
+++ b/lib/domain/entities/place_entity.dart
@@ -6,7 +6,7 @@ class PlaceEntity extends Equatable {
   final String id;
   final String placeName;
 
-  PlaceEntity({
+  const PlaceEntity({
     required this.id,
     required this.placeName,
   });

--- a/lib/domain/entities/schedule_with_preparation_entity.dart
+++ b/lib/domain/entities/schedule_with_preparation_entity.dart
@@ -14,6 +14,8 @@ class ScheduleWithPreparationEntity extends ScheduleEntity {
     required super.isStarted,
     required super.scheduleSpareTime,
     required super.scheduleNote,
+    super.latenessTime,
+    super.doneStatus,
     required this.preparation,
   });
 
@@ -86,6 +88,8 @@ class ScheduleWithPreparationEntity extends ScheduleEntity {
       isStarted: schedule.isStarted,
       scheduleSpareTime: schedule.scheduleSpareTime,
       scheduleNote: schedule.scheduleNote,
+      latenessTime: schedule.latenessTime,
+      doneStatus: schedule.doneStatus,
       preparation: preparation,
     );
   }

--- a/lib/domain/repositories/alarm_registry_repository.dart
+++ b/lib/domain/repositories/alarm_registry_repository.dart
@@ -1,0 +1,13 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+abstract interface class AlarmRegistryRepository {
+  Future<List<ScheduledAlarmRecord>> loadAll();
+
+  Future<void> upsert(ScheduledAlarmRecord record);
+
+  Future<void> deleteByScheduleId(String scheduleId);
+
+  Future<void> deleteAll();
+
+  Future<void> replaceAll(List<ScheduledAlarmRecord> records);
+}

--- a/lib/domain/repositories/alarm_repository.dart
+++ b/lib/domain/repositories/alarm_repository.dart
@@ -1,0 +1,23 @@
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+
+abstract interface class AlarmRepository {
+  Future<String> getDeviceId();
+
+  Future<AlarmDeviceInfo> buildCurrentDeviceInfo();
+
+  Future<AlarmSettings> getAlarmSettings();
+
+  Future<AlarmSettings> updateAlarmSettings({required bool alarmsEnabled});
+
+  Future<void> registerCurrentDevice(AlarmDeviceInfo deviceInfo);
+
+  Future<void> unregisterCurrentDevice(String deviceId);
+
+  Future<List<ScheduleWithPreparationEntity>> getAlarmWindow(
+    DateTime startDate,
+    DateTime endDate,
+  );
+
+  Future<void> postAlarmStatus(AlarmStatusReport report);
+}

--- a/lib/domain/use-cases/cancel_all_alarms_use_case.dart
+++ b/lib/domain/use-cases/cancel_all_alarms_use_case.dart
@@ -1,0 +1,56 @@
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
+
+@Injectable()
+class CancelAllAlarmsUseCase {
+  final AlarmRepository _alarmRepository;
+  final AlarmRegistryRepository _registryRepository;
+  final AlarmSchedulerService _schedulerService;
+  final FallbackAlarmNotificationService _fallbackNotificationService;
+
+  CancelAllAlarmsUseCase(
+    this._alarmRepository,
+    this._registryRepository,
+    this._schedulerService,
+    this._fallbackNotificationService,
+  );
+
+  Future<void> call({bool unregisterDevice = false}) async {
+    final records = await _registryRepository.loadAll();
+    await cancelRecords(records);
+    await _registryRepository.deleteAll();
+
+    if (unregisterDevice) {
+      try {
+        await _alarmRepository.unregisterCurrentDevice(
+          await _alarmRepository.getDeviceId(),
+        );
+      } catch (_) {
+        // Logout/session cleanup must still complete when the backend is gone.
+      }
+    }
+  }
+
+  Future<void> cancelRecords(List<ScheduledAlarmRecord> records) async {
+    for (final record in records) {
+      await _cancelRecord(record);
+    }
+  }
+
+  Future<void> _cancelRecord(ScheduledAlarmRecord record) async {
+    try {
+      if (record.provider == AlarmProvider.localNotification) {
+        await _fallbackNotificationService.cancelFallbackAlarm(record);
+      } else if (record.provider != AlarmProvider.none) {
+        await _schedulerService.cancelNativeAlarm(record);
+      }
+    } catch (_) {
+      // Best-effort cancellation: stale registry cleanup should not be blocked
+      // by a platform channel or notification plugin failure.
+    }
+  }
+}

--- a/lib/domain/use-cases/cancel_schedule_alarm_use_case.dart
+++ b/lib/domain/use-cases/cancel_schedule_alarm_use_case.dart
@@ -1,0 +1,39 @@
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+
+@Injectable()
+class CancelScheduleAlarmUseCase {
+  final AlarmRegistryRepository _registryRepository;
+  final AlarmSchedulerService _schedulerService;
+  final FallbackAlarmNotificationService _fallbackNotificationService;
+
+  CancelScheduleAlarmUseCase(
+    this._registryRepository,
+    this._schedulerService,
+    this._fallbackNotificationService,
+  );
+
+  Future<void> call(String scheduleId) async {
+    final records = await _registryRepository.loadAll();
+    final matchingRecords = records
+        .where((record) => record.scheduleId == scheduleId)
+        .toList(growable: false);
+
+    for (final record in matchingRecords) {
+      try {
+        if (record.provider == AlarmProvider.localNotification) {
+          await _fallbackNotificationService.cancelFallbackAlarm(record);
+        } else if (record.provider != AlarmProvider.none) {
+          await _schedulerService.cancelNativeAlarm(record);
+        }
+      } catch (_) {
+        // Keep cleanup idempotent when the platform has already removed it.
+      }
+    }
+
+    await _registryRepository.deleteByScheduleId(scheduleId);
+  }
+}

--- a/lib/domain/use-cases/create_schedule_with_place_use_case.dart
+++ b/lib/domain/use-cases/create_schedule_with_place_use_case.dart
@@ -1,14 +1,22 @@
+import 'dart:async';
+
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 
 @Injectable()
 class CreateScheduleWithPlaceUseCase {
   final ScheduleRepository _scheduleRepository;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
 
-  CreateScheduleWithPlaceUseCase(this._scheduleRepository);
+  CreateScheduleWithPlaceUseCase(
+    this._scheduleRepository,
+    this._reconcileAlarmsUseCase,
+  );
 
   Future<void> call(ScheduleEntity schedule) async {
     await _scheduleRepository.createSchedule(schedule);
+    unawaited(_reconcileAlarmsUseCase());
   }
 }

--- a/lib/domain/use-cases/delete_schedule_use_case.dart
+++ b/lib/domain/use-cases/delete_schedule_use_case.dart
@@ -1,14 +1,26 @@
+import 'dart:async';
+
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
+import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 
 @Injectable()
 class DeleteScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
+  final CancelScheduleAlarmUseCase _cancelScheduleAlarmUseCase;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
 
-  DeleteScheduleUseCase(this._scheduleRepository);
+  DeleteScheduleUseCase(
+    this._scheduleRepository,
+    this._cancelScheduleAlarmUseCase,
+    this._reconcileAlarmsUseCase,
+  );
 
   Future<void> call(ScheduleEntity schedule) async {
-    return _scheduleRepository.deleteSchedule(schedule);
+    await _scheduleRepository.deleteSchedule(schedule);
+    await _cancelScheduleAlarmUseCase(schedule.id);
+    unawaited(_reconcileAlarmsUseCase());
   }
 }

--- a/lib/domain/use-cases/finish_schedule_use_case.dart
+++ b/lib/domain/use-cases/finish_schedule_use_case.dart
@@ -1,13 +1,25 @@
+import 'dart:async';
+
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
+import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 
 @Injectable()
 class FinishScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
+  final CancelScheduleAlarmUseCase _cancelScheduleAlarmUseCase;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
 
-  FinishScheduleUseCase(this._scheduleRepository);
+  FinishScheduleUseCase(
+    this._scheduleRepository,
+    this._cancelScheduleAlarmUseCase,
+    this._reconcileAlarmsUseCase,
+  );
 
   Future<void> call(String scheduleId, int latenessTime) async {
     await _scheduleRepository.finishSchedule(scheduleId, latenessTime);
+    await _cancelScheduleAlarmUseCase(scheduleId);
+    unawaited(_reconcileAlarmsUseCase());
   }
 }

--- a/lib/domain/use-cases/get_nearest_upcoming_schedule_use_case.dart
+++ b/lib/domain/use-cases/get_nearest_upcoming_schedule_use_case.dart
@@ -25,7 +25,7 @@ class GetNearestUpcomingScheduleUseCase {
   Stream<ScheduleWithPreparationEntity?> call() async* {
     final DateTime now = DateTime.now();
 
-    _loadSchedulesForWeekUseCase(now);
+    unawaited(_loadSchedulesForWeekUseCase(now).catchError((_) {}));
 
     final upcomingScheduleStream =
         _getScheduleByDateUseCase(now, now.add(const Duration(days: 2)));

--- a/lib/domain/use-cases/reconcile_alarms_use_case.dart
+++ b/lib/domain/use-cases/reconcile_alarms_use_case.dart
@@ -378,6 +378,8 @@ class ReconcileAlarmsUseCase {
     ScheduledAlarmRecord desired,
   ) {
     return existing.scheduleFingerprint == desired.scheduleFingerprint &&
+        existing.payload['alarmLaunchPayloadVersion'] ==
+            desired.payload['alarmLaunchPayloadVersion'] &&
         existing.alarmTime.isAtSameMomentAs(desired.alarmTime) &&
         existing.preparationStartTime
             .isAtSameMomentAs(desired.preparationStartTime);

--- a/lib/domain/use-cases/reconcile_alarms_use_case.dart
+++ b/lib/domain/use-cases/reconcile_alarms_use_case.dart
@@ -354,21 +354,23 @@ class ReconcileAlarmsUseCase {
     AlarmSchedulerCapabilities capabilities,
     List<ScheduledAlarmRecord> records,
   ) {
+    var nativeProvider = AlarmProvider.none;
+    for (final record in records) {
+      if (record.provider != AlarmProvider.none &&
+          record.provider != AlarmProvider.localNotification) {
+        nativeProvider = record.provider;
+        break;
+      }
+    }
     final usesFallback = records.any(
       (record) => record.provider == AlarmProvider.localNotification,
     );
-    if (usesFallback) {
-      return AlarmSchedulerCapabilities(
-        supportsNativeAlarm: capabilities.supportsNativeAlarm,
-        nativeAlarmProvider: records.any(
-          (record) => record.provider == capabilities.nativeAlarmProvider,
-        )
-            ? capabilities.nativeAlarmProvider
-            : AlarmProvider.none,
-        fallbackProvider: AlarmProvider.localNotification,
-      );
-    }
-    return capabilities;
+    return AlarmSchedulerCapabilities(
+      supportsNativeAlarm: capabilities.supportsNativeAlarm,
+      nativeAlarmProvider: nativeProvider,
+      fallbackProvider:
+          usesFallback ? AlarmProvider.localNotification : AlarmProvider.none,
+    );
   }
 
   bool _recordMatches(

--- a/lib/domain/use-cases/reconcile_alarms_use_case.dart
+++ b/lib/domain/use-cases/reconcile_alarms_use_case.dart
@@ -1,0 +1,454 @@
+import 'package:flutter/foundation.dart';
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
+import 'package:on_time_front/domain/repositories/user_repository.dart';
+
+typedef AlarmNowProvider = DateTime Function();
+
+@Injectable()
+class ReconcileAlarmsUseCase {
+  final AlarmRepository _alarmRepository;
+  final AlarmRegistryRepository _registryRepository;
+  final AlarmSchedulerService _schedulerService;
+  final FallbackAlarmNotificationService _fallbackNotificationService;
+  final UserRepository? _userRepository;
+  final AlarmNowProvider _nowProvider;
+
+  ReconcileAlarmsUseCase(
+    this._alarmRepository,
+    this._registryRepository,
+    this._schedulerService,
+    this._fallbackNotificationService,
+    UserRepository userRepository,
+  )   : _userRepository = userRepository,
+        _nowProvider = DateTime.now;
+
+  @visibleForTesting
+  ReconcileAlarmsUseCase.test(
+    this._alarmRepository,
+    this._registryRepository,
+    this._schedulerService,
+    this._fallbackNotificationService, {
+    required AlarmNowProvider nowProvider,
+    UserRepository? userRepository,
+  })  : _userRepository = userRepository,
+        _nowProvider = nowProvider;
+
+  Future<AlarmReconciliationResult> call() async {
+    final now = _nowProvider();
+    final scheduleWindowStart = now;
+    final scheduleWindowEnd = now.add(const Duration(days: 8));
+    final alarmCoverageStart = now;
+    final alarmCoverageEnd = now.add(const Duration(days: 7));
+    final deviceId = await _alarmRepository.getDeviceId();
+    final capabilities = await _schedulerService.getCapabilities();
+
+    AlarmSettings settings;
+    try {
+      settings = await _alarmRepository.getAlarmSettings();
+    } catch (_) {
+      final result = _result(
+        status: AlarmReconciliationStatus.settingsUnavailable,
+        capabilities: capabilities,
+        scheduleWindowStart: scheduleWindowStart,
+        scheduleWindowEnd: scheduleWindowEnd,
+        alarmCoverageStart: alarmCoverageStart,
+        alarmCoverageEnd: alarmCoverageEnd,
+      );
+      await _postStatusBestEffort(deviceId, result);
+      return result;
+    }
+
+    if (!settings.alarmsEnabled) {
+      final records = await _registryRepository.loadAll();
+      await _cancelRecords(records);
+      await _registryRepository.deleteAll();
+      final result = _result(
+        status: AlarmReconciliationStatus.disabled,
+        capabilities: capabilities,
+        scheduleWindowStart: scheduleWindowStart,
+        scheduleWindowEnd: scheduleWindowEnd,
+        alarmCoverageStart: alarmCoverageStart,
+        alarmCoverageEnd: alarmCoverageEnd,
+      );
+      await _postStatusBestEffort(deviceId, result);
+      return result;
+    }
+
+    try {
+      await _alarmRepository.registerCurrentDevice(
+        await _alarmRepository.buildCurrentDeviceInfo(),
+      );
+    } catch (_) {
+      // Device registration is diagnostic. Local scheduling can still proceed.
+    }
+
+    final schedules = await _alarmRepository.getAlarmWindow(
+      scheduleWindowStart,
+      scheduleWindowEnd,
+    );
+    final desiredRecords = _desiredRecords(
+      schedules: schedules,
+      now: now,
+      alarmCoverageEnd: alarmCoverageEnd,
+      alarmOffset: settings.alarmOffset,
+    );
+    final skippedScheduleCount = schedules
+        .where((schedule) =>
+            !_isDesired(schedule, now, alarmCoverageEnd, settings.alarmOffset))
+        .length;
+
+    final existingRecords = await _registryRepository.loadAll();
+    final existingByScheduleId = {
+      for (final record in existingRecords) record.scheduleId: record,
+    };
+    final desiredByScheduleId = {
+      for (final record in desiredRecords) record.scheduleId: record,
+    };
+
+    final staleRecords = existingRecords.where((record) {
+      final desired = desiredByScheduleId[record.scheduleId];
+      return desired == null || !_recordMatches(record, desired);
+    }).toList();
+    await _cancelRecords(staleRecords);
+
+    final nativePermission = await _checkNativePermission(capabilities);
+    final fallbackPermission = await _fallbackNotificationService
+        .checkPermission()
+        .catchError((_) => AlarmPermissionState.denied);
+
+    final finalRecords = <ScheduledAlarmRecord>[];
+    final failures = <AlarmFailure>[];
+    AlarmPermissionIssue? permissionIssue;
+
+    for (final desired in desiredRecords) {
+      final existing = existingByScheduleId[desired.scheduleId];
+      if (existing != null && _recordMatches(existing, desired)) {
+        finalRecords.add(existing);
+        continue;
+      }
+
+      final scheduled = await _scheduleRecord(
+        desired,
+        capabilities: capabilities,
+        nativePermission: nativePermission,
+        fallbackPermission: fallbackPermission,
+      );
+
+      if (scheduled.record != null) {
+        finalRecords.add(scheduled.record!);
+      } else if (scheduled.permissionIssue != null) {
+        permissionIssue ??= scheduled.permissionIssue;
+      } else {
+        failures.add(
+          AlarmFailure(
+            scheduleId: desired.scheduleId,
+            reason: scheduled.failureReason ?? AlarmFailureReason.unknown,
+            message: scheduled.message,
+          ),
+        );
+      }
+    }
+
+    await _registryRepository.replaceAll(finalRecords);
+
+    final status = _statusFor(
+      desiredCount: desiredRecords.length,
+      armedCount: finalRecords.length,
+      failures: failures,
+      permissionIssue: permissionIssue,
+      capabilities: capabilities,
+      fallbackPermission: fallbackPermission,
+    );
+
+    final result = _result(
+      status: status,
+      permissionIssue: permissionIssue,
+      capabilities: _effectiveCapabilities(capabilities, finalRecords),
+      armedScheduleIds:
+          finalRecords.map((record) => record.scheduleId).toList(),
+      skippedScheduleCount: skippedScheduleCount,
+      failures: failures,
+      scheduleWindowStart: scheduleWindowStart,
+      scheduleWindowEnd: scheduleWindowEnd,
+      alarmCoverageStart: alarmCoverageStart,
+      alarmCoverageEnd: alarmCoverageEnd,
+    );
+
+    await _postStatusBestEffort(deviceId, result);
+    return result;
+  }
+
+  List<ScheduledAlarmRecord> _desiredRecords({
+    required List<ScheduleWithPreparationEntity> schedules,
+    required DateTime now,
+    required DateTime alarmCoverageEnd,
+    required Duration alarmOffset,
+  }) {
+    return schedules
+        .where((schedule) =>
+            _isDesired(schedule, now, alarmCoverageEnd, alarmOffset))
+        .map(
+          (schedule) => buildScheduledAlarmRecord(
+            schedule,
+            alarmOffset: alarmOffset,
+            provider: AlarmProvider.none,
+          ),
+        )
+        .toList();
+  }
+
+  bool _isDesired(
+    ScheduleWithPreparationEntity schedule,
+    DateTime now,
+    DateTime alarmCoverageEnd,
+    Duration alarmOffset,
+  ) {
+    if (!isAlarmEligibleSchedule(schedule)) return false;
+    if (schedule.id.isEmpty) return false;
+    final alarmTime = computeAlarmTime(schedule, offset: alarmOffset);
+    return alarmTime.isAfter(now) &&
+        (alarmTime.isBefore(alarmCoverageEnd) ||
+            alarmTime.isAtSameMomentAs(alarmCoverageEnd));
+  }
+
+  Future<AlarmPermissionState> _checkNativePermission(
+    AlarmSchedulerCapabilities capabilities,
+  ) async {
+    if (!capabilities.supportsNativeAlarm ||
+        capabilities.nativeAlarmProvider == AlarmProvider.none) {
+      return AlarmPermissionState.unsupported;
+    }
+    return _schedulerService
+        .checkPermission()
+        .catchError((_) => AlarmPermissionState.unsupported);
+  }
+
+  Future<_ScheduleAttempt> _scheduleRecord(
+    ScheduledAlarmRecord desired, {
+    required AlarmSchedulerCapabilities capabilities,
+    required AlarmPermissionState nativePermission,
+    required AlarmPermissionState fallbackPermission,
+  }) async {
+    if (capabilities.supportsNativeAlarm &&
+        capabilities.nativeAlarmProvider != AlarmProvider.none &&
+        nativePermission == AlarmPermissionState.granted) {
+      final nativeRecord = desired.copyWith(
+        provider: capabilities.nativeAlarmProvider,
+      );
+      try {
+        await _schedulerService.scheduleNativeAlarm(nativeRecord);
+        return _ScheduleAttempt(record: nativeRecord);
+      } on AlarmSchedulingException catch (error) {
+        if (error.permissionIssue == null &&
+            fallbackPermission != AlarmPermissionState.granted) {
+          return _ScheduleAttempt(
+            failureReason: error.reason,
+            message: error.message,
+          );
+        }
+      } catch (error) {
+        if (fallbackPermission != AlarmPermissionState.granted) {
+          return _ScheduleAttempt(
+            failureReason: AlarmFailureReason.platformError,
+            message: error.toString(),
+          );
+        }
+      }
+    }
+
+    if (fallbackPermission == AlarmPermissionState.granted) {
+      final fallbackRecord = desired.copyWith(
+        provider: AlarmProvider.localNotification,
+      );
+      try {
+        await _fallbackNotificationService.scheduleFallbackAlarm(
+          fallbackRecord,
+        );
+        return _ScheduleAttempt(record: fallbackRecord);
+      } on AlarmSchedulingException catch (error) {
+        if (error.permissionIssue != null) {
+          return _ScheduleAttempt(permissionIssue: error.permissionIssue);
+        }
+        return _ScheduleAttempt(
+          failureReason: error.reason,
+          message: error.message,
+        );
+      } catch (error) {
+        return _ScheduleAttempt(
+          failureReason: AlarmFailureReason.platformError,
+          message: error.toString(),
+        );
+      }
+    }
+
+    if (nativePermission == AlarmPermissionState.denied ||
+        nativePermission == AlarmPermissionState.notDetermined) {
+      return const _ScheduleAttempt(
+        permissionIssue: AlarmPermissionIssue.nativePermissionDenied,
+      );
+    }
+    if (fallbackPermission == AlarmPermissionState.denied ||
+        fallbackPermission == AlarmPermissionState.notDetermined) {
+      return const _ScheduleAttempt(
+        permissionIssue: AlarmPermissionIssue.notificationPermissionDenied,
+      );
+    }
+
+    return const _ScheduleAttempt(
+      failureReason: AlarmFailureReason.platformError,
+      message: 'No alarm delivery provider is available',
+    );
+  }
+
+  AlarmReconciliationStatus _statusFor({
+    required int desiredCount,
+    required int armedCount,
+    required List<AlarmFailure> failures,
+    required AlarmPermissionIssue? permissionIssue,
+    required AlarmSchedulerCapabilities capabilities,
+    required AlarmPermissionState fallbackPermission,
+  }) {
+    final hasAnyProvider = capabilities.supportsNativeAlarm ||
+        fallbackPermission == AlarmPermissionState.granted;
+    if (!hasAnyProvider) {
+      if (permissionIssue != null) {
+        return AlarmReconciliationStatus.permissionNeeded;
+      }
+      return AlarmReconciliationStatus.unsupported;
+    }
+    if (desiredCount > armedCount || failures.isNotEmpty) {
+      return armedCount == 0 && permissionIssue != null
+          ? AlarmReconciliationStatus.permissionNeeded
+          : AlarmReconciliationStatus.partial;
+    }
+    if (permissionIssue != null && armedCount == 0) {
+      return AlarmReconciliationStatus.permissionNeeded;
+    }
+    return AlarmReconciliationStatus.armed;
+  }
+
+  AlarmSchedulerCapabilities _effectiveCapabilities(
+    AlarmSchedulerCapabilities capabilities,
+    List<ScheduledAlarmRecord> records,
+  ) {
+    final usesFallback = records.any(
+      (record) => record.provider == AlarmProvider.localNotification,
+    );
+    if (usesFallback) {
+      return AlarmSchedulerCapabilities(
+        supportsNativeAlarm: capabilities.supportsNativeAlarm,
+        nativeAlarmProvider: records.any(
+          (record) => record.provider == capabilities.nativeAlarmProvider,
+        )
+            ? capabilities.nativeAlarmProvider
+            : AlarmProvider.none,
+        fallbackProvider: AlarmProvider.localNotification,
+      );
+    }
+    return capabilities;
+  }
+
+  bool _recordMatches(
+    ScheduledAlarmRecord existing,
+    ScheduledAlarmRecord desired,
+  ) {
+    return existing.scheduleFingerprint == desired.scheduleFingerprint &&
+        existing.alarmTime.isAtSameMomentAs(desired.alarmTime) &&
+        existing.preparationStartTime
+            .isAtSameMomentAs(desired.preparationStartTime);
+  }
+
+  Future<void> _cancelRecords(List<ScheduledAlarmRecord> records) async {
+    for (final record in records) {
+      try {
+        if (record.provider == AlarmProvider.localNotification) {
+          await _fallbackNotificationService.cancelFallbackAlarm(record);
+        } else if (record.provider != AlarmProvider.none) {
+          await _schedulerService.cancelNativeAlarm(record);
+        }
+      } catch (_) {
+        // Keep reconciliation moving; registry replacement is authoritative.
+      }
+    }
+  }
+
+  AlarmReconciliationResult _result({
+    required AlarmReconciliationStatus status,
+    required AlarmSchedulerCapabilities capabilities,
+    required DateTime scheduleWindowStart,
+    required DateTime scheduleWindowEnd,
+    required DateTime alarmCoverageStart,
+    required DateTime alarmCoverageEnd,
+    AlarmPermissionIssue? permissionIssue,
+    List<String> armedScheduleIds = const [],
+    int skippedScheduleCount = 0,
+    List<AlarmFailure> failures = const [],
+  }) {
+    return AlarmReconciliationResult(
+      status: status,
+      permissionIssue: permissionIssue,
+      nativeAlarmProvider: capabilities.nativeAlarmProvider,
+      fallbackProvider: capabilities.fallbackProvider,
+      armedScheduleIds: armedScheduleIds,
+      skippedScheduleCount: skippedScheduleCount,
+      failures: failures,
+      scheduleWindowStart: scheduleWindowStart,
+      scheduleWindowEnd: scheduleWindowEnd,
+      alarmCoverageStart: alarmCoverageStart,
+      alarmCoverageEnd: alarmCoverageEnd,
+    );
+  }
+
+  Future<void> _postStatusBestEffort(
+    String deviceId,
+    AlarmReconciliationResult result,
+  ) async {
+    try {
+      await _alarmRepository.postAlarmStatus(
+        AlarmStatusReport(
+          deviceId: deviceId,
+          reconciledAt: _nowProvider(),
+          scheduleWindowStart: result.scheduleWindowStart,
+          scheduleWindowEnd: result.scheduleWindowEnd,
+          alarmCoverageStart: result.alarmCoverageStart,
+          alarmCoverageEnd: result.alarmCoverageEnd,
+          status: result.status,
+          permissionIssue: result.permissionIssue,
+          nativeAlarmProvider: result.nativeAlarmProvider,
+          fallbackProvider: result.fallbackProvider,
+          armedScheduleCount: result.armedScheduleCount,
+          armedScheduleIds: result.armedScheduleIds,
+          skippedScheduleCount: result.skippedScheduleCount,
+          failures: result.failures,
+        ),
+      );
+    } on DeviceSessionNotActiveException {
+      final records = await _registryRepository.loadAll();
+      await _cancelRecords(records);
+      await _registryRepository.deleteAll();
+      await _userRepository?.signOut();
+    } catch (_) {
+      // Status reports are diagnostic; scheduling result should still return.
+    }
+  }
+}
+
+class _ScheduleAttempt {
+  final ScheduledAlarmRecord? record;
+  final AlarmPermissionIssue? permissionIssue;
+  final AlarmFailureReason? failureReason;
+  final String? message;
+
+  const _ScheduleAttempt({
+    this.record,
+    this.permissionIssue,
+    this.failureReason,
+    this.message,
+  });
+}

--- a/lib/domain/use-cases/reconcile_alarms_use_case.dart
+++ b/lib/domain/use-cases/reconcile_alarms_use_case.dart
@@ -10,7 +10,7 @@ import 'package:on_time_front/domain/repositories/user_repository.dart';
 
 typedef AlarmNowProvider = DateTime Function();
 
-@Injectable()
+@Singleton()
 class ReconcileAlarmsUseCase {
   final AlarmRepository _alarmRepository;
   final AlarmRegistryRepository _registryRepository;
@@ -18,6 +18,7 @@ class ReconcileAlarmsUseCase {
   final FallbackAlarmNotificationService _fallbackNotificationService;
   final UserRepository? _userRepository;
   final AlarmNowProvider _nowProvider;
+  Future<AlarmReconciliationResult>? _inFlight;
 
   ReconcileAlarmsUseCase(
     this._alarmRepository,
@@ -39,7 +40,23 @@ class ReconcileAlarmsUseCase {
   })  : _userRepository = userRepository,
         _nowProvider = nowProvider;
 
-  Future<AlarmReconciliationResult> call() async {
+  Future<AlarmReconciliationResult> call() {
+    final running = _inFlight;
+    if (running != null) {
+      return running;
+    }
+
+    late final Future<AlarmReconciliationResult> pending;
+    pending = _run().whenComplete(() {
+      if (identical(_inFlight, pending)) {
+        _inFlight = null;
+      }
+    });
+    _inFlight = pending;
+    return pending;
+  }
+
+  Future<AlarmReconciliationResult> _run() async {
     final now = _nowProvider();
     final scheduleWindowStart = now;
     final scheduleWindowEnd = now.add(const Duration(days: 8));

--- a/lib/domain/use-cases/sign_out_use_case.dart
+++ b/lib/domain/use-cases/sign_out_use_case.dart
@@ -1,13 +1,16 @@
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
+import 'package:on_time_front/domain/use-cases/cancel_all_alarms_use_case.dart';
 
 @Injectable()
 class SignOutUseCase {
   final UserRepository _userRepository;
+  final CancelAllAlarmsUseCase _cancelAllAlarmsUseCase;
 
-  SignOutUseCase(this._userRepository);
+  SignOutUseCase(this._userRepository, this._cancelAllAlarmsUseCase);
 
   Future<void> call() async {
+    await _cancelAllAlarmsUseCase(unregisterDevice: true);
     return _userRepository.signOut();
   }
 }

--- a/lib/domain/use-cases/update_schedule_use_case.dart
+++ b/lib/domain/use-cases/update_schedule_use_case.dart
@@ -1,14 +1,22 @@
+import 'dart:async';
+
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 
 @Injectable()
 class UpdateScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
 
-  UpdateScheduleUseCase(this._scheduleRepository);
+  UpdateScheduleUseCase(
+    this._scheduleRepository,
+    this._reconcileAlarmsUseCase,
+  );
 
   Future<void> call(ScheduleEntity schedule) async {
     await _scheduleRepository.updateSchedule(schedule);
+    unawaited(_reconcileAlarmsUseCase());
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:on_time_front/core/constants/environment_variable.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
@@ -13,6 +14,7 @@ import 'package:on_time_front/presentation/app/screens/app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await HardwareKeyboard.instance.syncKeyboardState().catchError((_) {});
   await initializeDateFormatting();
   configureDependencies();
   debugPrint(EnvironmentVariable.restApiUrl);

--- a/lib/presentation/alarm/components/alarm_graph_animator.dart
+++ b/lib/presentation/alarm/components/alarm_graph_animator.dart
@@ -14,7 +14,7 @@ class AlarmGraphAnimator extends StatefulWidget {
   });
 
   @override
-  _AlarmGraphAnimatorState createState() => _AlarmGraphAnimatorState();
+  State<AlarmGraphAnimator> createState() => _AlarmGraphAnimatorState();
 }
 
 class _AlarmGraphAnimatorState extends State<AlarmGraphAnimator>

--- a/lib/presentation/alarm/screens/schedule_start_screen.dart
+++ b/lib/presentation/alarm/screens/schedule_start_screen.dart
@@ -14,6 +14,7 @@ import 'package:on_time_front/presentation/shared/utils/duration_format.dart';
 enum ScheduleStartPromptVariant {
   officialStart,
   earlyStart,
+  alarm,
 }
 
 ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteValue(
@@ -23,6 +24,8 @@ ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteValue(
     case 'earlyStart':
     case 'fiveMinutes':
       return ScheduleStartPromptVariant.earlyStart;
+    case 'alarm':
+      return ScheduleStartPromptVariant.alarm;
     default:
       return ScheduleStartPromptVariant.officialStart;
   }
@@ -102,6 +105,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
   ) {
     switch (variant) {
       case ScheduleStartPromptVariant.earlyStart:
+      case ScheduleStartPromptVariant.alarm:
         return _buildEarlyStartPromptMessage(context, schedule);
       case ScheduleStartPromptVariant.officialStart:
         return AppLocalizations.of(context)!.youWillBeLate;
@@ -131,7 +135,8 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
     BuildContext context,
     ScheduleStartPromptVariant variant,
   ) {
-    if (variant != ScheduleStartPromptVariant.officialStart) {
+    if (variant == ScheduleStartPromptVariant.earlyStart ||
+        variant == ScheduleStartPromptVariant.alarm) {
       context.read<ScheduleBloc>().add(const SchedulePreparationStarted());
     }
     context.go('/alarmScreen');
@@ -246,7 +251,8 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
               _onPrimaryActionPressed(context, variant);
             },
             child: Text(
-              variant == ScheduleStartPromptVariant.earlyStart
+              variant == ScheduleStartPromptVariant.earlyStart ||
+                      variant == ScheduleStartPromptVariant.alarm
                   ? l10n.startPreparingNow
                   : l10n.startPreparing,
             ),
@@ -262,6 +268,7 @@ class _ScheduleStartScreenState extends State<ScheduleStartScreen> {
   ) {
     switch (variant) {
       case ScheduleStartPromptVariant.earlyStart:
+      case ScheduleStartPromptVariant.alarm:
         return _buildTwoButtonLayout(context, variant);
       case ScheduleStartPromptVariant.officialStart:
         return _buildPrimaryButton(context, variant);

--- a/lib/presentation/app/bloc/auth/auth_bloc.dart
+++ b/lib/presentation/app/bloc/auth/auth_bloc.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/user_entity.dart';
 import 'package:on_time_front/domain/use-cases/load_user_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 import 'package:on_time_front/domain/use-cases/sign_out_use_case.dart';
 import 'package:on_time_front/domain/use-cases/stream_user_use_case.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
@@ -15,7 +16,7 @@ part 'auth_state.dart';
 @Injectable()
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   AuthBloc(this._streamUserUseCase, this._signOutUseCase, this._loadUserUseCase,
-      this._scheduleBloc)
+      this._scheduleBloc, this._reconcileAlarmsUseCase)
       : super(AuthState(user: const UserEntity.empty())) {
     on<AuthUserSubscriptionRequested>(_appUserSubscriptionRequested);
     on<AuthSignOutPressed>(_appLogoutPressed);
@@ -25,6 +26,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final LoadUserUseCase _loadUserUseCase;
   final SignOutUseCase _signOutUseCase;
   final ScheduleBloc _scheduleBloc;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
   Timer? _timer;
 
   Future<void> _appUserSubscriptionRequested(
@@ -49,6 +51,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         await Future.delayed(const Duration(milliseconds: 0));
         if (state.status == AuthStatus.authenticated) {
           _scheduleBloc.add(const ScheduleSubscriptionRequested());
+          unawaited(_reconcileAlarmsUseCase());
         }
       },
       onError: addError,

--- a/lib/presentation/app/bloc/schedule/schedule_bloc.dart
+++ b/lib/presentation/app/bloc/schedule/schedule_bloc.dart
@@ -172,6 +172,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       if (staleId != null) {
         await _clearPersistedState(staleId);
       }
+      _stopPreparationTimer();
       emit(const ScheduleState.notExists());
       _currentScheduleId = null;
       _activeEarlyStartScheduleId = null;
@@ -222,11 +223,13 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       debugPrint(
           'ongoingSchedule: $resolvedSchedule, currentStep: ${resolvedSchedule.preparation.currentStep}');
       _startPreparationTimer();
-    } else {
-      emit(ScheduleState.upcoming(resolvedSchedule));
-      debugPrint('upcomingSchedule: $resolvedSchedule');
-      _startScheduleTimer(resolvedSchedule);
+      return;
     }
+
+    _stopPreparationTimer();
+    emit(ScheduleState.upcoming(resolvedSchedule));
+    debugPrint('upcomingSchedule: $resolvedSchedule');
+    _startScheduleTimer(resolvedSchedule);
   }
 
   Future<void> _onScheduleStarted(
@@ -285,8 +288,10 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       _activeEarlyStartScheduleId = null;
       _scheduleStartTimer?.cancel();
       _scheduleStartTimer = null;
+      _stopPreparationTimer();
       _initializeNotificationTracking(scheduleWithPreparation);
       emit(ScheduleState.upcoming(scheduleWithPreparation));
+      _startScheduleTimer(scheduleWithPreparation);
     } catch (error) {
       debugPrint('alarm prompt validation failed: $error');
       await _cancelScheduleAlarmUseCase?.call(event.scheduleId);
@@ -352,7 +357,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     try {
       await _finishScheduleUseCase(scheduleId, event.latenessTime);
       // After finishing, clear timers and set state to notExists
-      _preparationTimer?.cancel();
+      _stopPreparationTimer();
       _scheduleStartTimer?.cancel();
       await _clearPersistedState(scheduleId);
       _currentScheduleId = null;
@@ -400,12 +405,17 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     });
   }
 
+  void _stopPreparationTimer() {
+    _preparationTimer?.cancel();
+    _preparationTimer = null;
+  }
+
   @override
   Future<void> close() {
     // ✅ Proper cleanup: Cancel subscription and timer before closing
     _upcomingScheduleSubscription?.cancel();
     _scheduleStartTimer?.cancel();
-    _preparationTimer?.cancel();
+    _stopPreparationTimer();
     return super.close();
   }
 

--- a/lib/presentation/app/bloc/schedule/schedule_bloc.dart
+++ b/lib/presentation/app/bloc/schedule/schedule_bloc.dart
@@ -6,12 +6,18 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/services/navigation_service.dart';
 import 'package:on_time_front/core/services/notification_service.dart';
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
 import 'package:on_time_front/domain/use-cases/clear_early_start_session_use_case.dart';
 import 'package:on_time_front/domain/use-cases/clear_timed_preparation_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_preparation_by_schedule_id_use_case.dart';
 import 'package:on_time_front/domain/use-cases/get_nearest_upcoming_schedule_use_case.dart';
 import 'package:on_time_front/domain/use-cases/get_early_start_session_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_schedule_by_id_use_case.dart';
 import 'package:on_time_front/domain/use-cases/get_timed_preparation_snapshot_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_preparation_by_schedule_id_use_case.dart';
 import 'package:on_time_front/domain/use-cases/mark_early_start_session_use_case.dart';
 import 'package:on_time_front/domain/use-cases/save_timed_preparation_use_case.dart';
 import 'package:on_time_front/domain/use-cases/finish_schedule_use_case.dart';
@@ -53,10 +59,21 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     required MarkEarlyStartSessionUseCase markEarlyStartSessionUseCase,
     required GetEarlyStartSessionUseCase getEarlyStartSessionUseCase,
     required ClearEarlyStartSessionUseCase clearEarlyStartSessionUseCase,
+    required CancelScheduleAlarmUseCase cancelScheduleAlarmUseCase,
+    required GetScheduleByIdUseCase getScheduleByIdUseCase,
+    required LoadPreparationByScheduleIdUseCase
+        loadPreparationByScheduleIdUseCase,
+    required GetPreparationByScheduleIdUseCase
+        getPreparationByScheduleIdUseCase,
   })  : _nowProvider = DateTime.now,
         _markEarlyStartSessionUseCase = markEarlyStartSessionUseCase,
         _getEarlyStartSessionUseCase = getEarlyStartSessionUseCase,
         _clearEarlyStartSessionUseCase = clearEarlyStartSessionUseCase,
+        _cancelScheduleAlarmUseCase = cancelScheduleAlarmUseCase,
+        _getScheduleByIdUseCase = getScheduleByIdUseCase,
+        _loadPreparationByScheduleIdUseCase =
+            loadPreparationByScheduleIdUseCase,
+        _getPreparationByScheduleIdUseCase = getPreparationByScheduleIdUseCase,
         _notifyPreparationStep = _defaultNotifyPreparationStep,
         super(const ScheduleState.initial()) {
     _registerHandlers();
@@ -73,12 +90,21 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     required MarkEarlyStartSessionUseCase markEarlyStartSessionUseCase,
     required GetEarlyStartSessionUseCase getEarlyStartSessionUseCase,
     required ClearEarlyStartSessionUseCase clearEarlyStartSessionUseCase,
+    CancelScheduleAlarmUseCase? cancelScheduleAlarmUseCase,
+    GetScheduleByIdUseCase? getScheduleByIdUseCase,
+    LoadPreparationByScheduleIdUseCase? loadPreparationByScheduleIdUseCase,
+    GetPreparationByScheduleIdUseCase? getPreparationByScheduleIdUseCase,
     NowProvider? nowProvider,
     NotifyPreparationStep? notifyPreparationStep,
   })  : _nowProvider = nowProvider ?? DateTime.now,
         _markEarlyStartSessionUseCase = markEarlyStartSessionUseCase,
         _getEarlyStartSessionUseCase = getEarlyStartSessionUseCase,
         _clearEarlyStartSessionUseCase = clearEarlyStartSessionUseCase,
+        _cancelScheduleAlarmUseCase = cancelScheduleAlarmUseCase,
+        _getScheduleByIdUseCase = getScheduleByIdUseCase,
+        _loadPreparationByScheduleIdUseCase =
+            loadPreparationByScheduleIdUseCase,
+        _getPreparationByScheduleIdUseCase = getPreparationByScheduleIdUseCase,
         _notifyPreparationStep =
             notifyPreparationStep ?? _defaultNotifyPreparationStep,
         super(const ScheduleState.initial()) {
@@ -88,6 +114,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
   void _registerHandlers() {
     on<ScheduleSubscriptionRequested>(_onSubscriptionRequested);
     on<ScheduleUpcomingReceived>(_onUpcomingReceived);
+    on<ScheduleAlarmPromptRequested>(_onAlarmPromptRequested);
     on<ScheduleStarted>(_onScheduleStarted);
     on<SchedulePreparationStarted>(_onPreparationStarted);
     on<ScheduleTick>(_onTick);
@@ -104,6 +131,10 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
   final MarkEarlyStartSessionUseCase _markEarlyStartSessionUseCase;
   final GetEarlyStartSessionUseCase _getEarlyStartSessionUseCase;
   final ClearEarlyStartSessionUseCase _clearEarlyStartSessionUseCase;
+  final CancelScheduleAlarmUseCase? _cancelScheduleAlarmUseCase;
+  final GetScheduleByIdUseCase? _getScheduleByIdUseCase;
+  final LoadPreparationByScheduleIdUseCase? _loadPreparationByScheduleIdUseCase;
+  final GetPreparationByScheduleIdUseCase? _getPreparationByScheduleIdUseCase;
   final NowProvider _nowProvider;
   final NotifyPreparationStep _notifyPreparationStep;
   StreamSubscription<ScheduleWithPreparationEntity?>?
@@ -210,6 +241,59 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
     }
   }
 
+  Future<void> _onAlarmPromptRequested(
+    ScheduleAlarmPromptRequested event,
+    Emitter<ScheduleState> emit,
+  ) async {
+    if (_getScheduleByIdUseCase == null ||
+        _loadPreparationByScheduleIdUseCase == null ||
+        _getPreparationByScheduleIdUseCase == null) {
+      return;
+    }
+    final getScheduleByIdUseCase = _getScheduleByIdUseCase;
+    final loadPreparationByScheduleIdUseCase =
+        _loadPreparationByScheduleIdUseCase;
+    final getPreparationByScheduleIdUseCase =
+        _getPreparationByScheduleIdUseCase;
+
+    try {
+      final schedule = await getScheduleByIdUseCase(event.scheduleId);
+      if (_isEnded(schedule.doneStatus)) {
+        await _cancelScheduleAlarmUseCase?.call(event.scheduleId);
+        _navigationService.go('/home');
+        return;
+      }
+
+      await loadPreparationByScheduleIdUseCase(event.scheduleId);
+      final preparation =
+          await getPreparationByScheduleIdUseCase(event.scheduleId);
+      final scheduleWithPreparation =
+          ScheduleWithPreparationEntity.fromScheduleAndPreparationEntity(
+        schedule,
+        PreparationWithTimeEntity.fromPreparation(preparation),
+      );
+
+      if (event.scheduleFingerprint != null &&
+          event.scheduleFingerprint !=
+              scheduleWithPreparation.cacheFingerprint) {
+        await _cancelScheduleAlarmUseCase?.call(event.scheduleId);
+        _navigationService.go('/home');
+        return;
+      }
+
+      _currentScheduleId = scheduleWithPreparation.id;
+      _activeEarlyStartScheduleId = null;
+      _scheduleStartTimer?.cancel();
+      _scheduleStartTimer = null;
+      _initializeNotificationTracking(scheduleWithPreparation);
+      emit(ScheduleState.upcoming(scheduleWithPreparation));
+    } catch (error) {
+      debugPrint('alarm prompt validation failed: $error');
+      await _cancelScheduleAlarmUseCase?.call(event.scheduleId);
+      _navigationService.go('/home');
+    }
+  }
+
   Future<void> _onPreparationStarted(
       SchedulePreparationStarted event, Emitter<ScheduleState> emit) async {
     final schedule = state.schedule;
@@ -225,6 +309,7 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
       scheduleId: schedule.id,
       startedAt: _nowProvider(),
     );
+    await _cancelScheduleAlarmUseCase?.call(schedule.id);
 
     emit(ScheduleState.started(schedule, isEarlyStarted: true));
     await _saveTimedPreparationSnapshot(schedule, force: true);
@@ -388,6 +473,12 @@ class ScheduleBloc extends Bloc<ScheduleEvent, ScheduleState> {
   ) {
     final start = schedule.preparationStartTime;
     return start.isBefore(now) && schedule.scheduleTime.isAfter(now);
+  }
+
+  bool _isEnded(ScheduleDoneStatus doneStatus) {
+    return doneStatus == ScheduleDoneStatus.normalEnd ||
+        doneStatus == ScheduleDoneStatus.lateEnd ||
+        doneStatus == ScheduleDoneStatus.abnormalEnd;
   }
 
   void _initializeNotificationTracking(ScheduleWithPreparationEntity schedule) {

--- a/lib/presentation/app/bloc/schedule/schedule_event.dart
+++ b/lib/presentation/app/bloc/schedule/schedule_event.dart
@@ -25,6 +25,19 @@ final class ScheduleUpcomingReceived extends ScheduleEvent {
   List<Object?> get props => [upcomingSchedule];
 }
 
+final class ScheduleAlarmPromptRequested extends ScheduleEvent {
+  final String scheduleId;
+  final String? scheduleFingerprint;
+
+  const ScheduleAlarmPromptRequested({
+    required this.scheduleId,
+    this.scheduleFingerprint,
+  });
+
+  @override
+  List<Object?> get props => [scheduleId, scheduleFingerprint];
+}
+
 final class ScheduleStarted extends ScheduleEvent {
   const ScheduleStarted();
 

--- a/lib/presentation/app/screens/app.dart
+++ b/lib/presentation/app/screens/app.dart
@@ -1,6 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/navigation_service.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/app/bloc/auth/auth_bloc.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
@@ -43,9 +48,39 @@ class _AppRouterView extends StatefulWidget {
   State<_AppRouterView> createState() => _AppRouterViewState();
 }
 
-class _AppRouterViewState extends State<_AppRouterView> {
+class _AppRouterViewState extends State<_AppRouterView>
+    with WidgetsBindingObserver {
   late final _router =
       goRouterConfig(context.read<AuthBloc>(), context.read<ScheduleBloc>());
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(
+        getIt.get<AlarmSchedulerService>().initializeLaunchHandling((payload) {
+          if (!mounted) return;
+          getIt.get<NavigationService>().push('/scheduleStart', extra: payload);
+        }),
+      );
+    });
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (context.read<AuthBloc>().state.status != AuthStatus.authenticated) {
+      return;
+    }
+    unawaited(getIt.get<ReconcileAlarmsUseCase>()());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/app/screens/app.dart
+++ b/lib/presentation/app/screens/app.dart
@@ -53,18 +53,21 @@ class _AppRouterViewState extends State<_AppRouterView>
     with WidgetsBindingObserver {
   late final _router =
       goRouterConfig(context.read<AuthBloc>(), context.read<ScheduleBloc>());
+  final _alarmLaunchPollTimers = <Timer>[];
+  Map<String, String>? _pendingAlarmLaunchPayload;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       unawaited(
-        getIt.get<AlarmSchedulerService>().initializeLaunchHandling((payload) {
-          if (!mounted) return;
-          getIt.get<NavigationService>().push('/scheduleStart', extra: payload);
-        }),
+        getIt
+            .get<AlarmSchedulerService>()
+            .initializeLaunchHandling(_handleAlarmLaunchPayload),
       );
+      _schedulePendingAlarmLaunchPolls();
     });
   }
 
@@ -75,25 +78,77 @@ class _AppRouterViewState extends State<_AppRouterView>
     unawaited(
       getIt.get<AlarmSchedulerService>().dispatchPendingLaunchPayload(),
     );
+    _schedulePendingAlarmLaunchPolls();
     if (context.read<AuthBloc>().state.status != AuthStatus.authenticated) {
       return;
     }
     unawaited(getIt.get<ReconcileAlarmsUseCase>()());
   }
 
+  void _handleAlarmLaunchPayload(Map<String, String> payload) {
+    if (!mounted) return;
+    _pendingAlarmLaunchPayload = payload;
+    _drainPendingAlarmLaunchPayload();
+  }
+
+  void _drainPendingAlarmLaunchPayload() {
+    final payload = _pendingAlarmLaunchPayload;
+    if (!mounted || payload == null) return;
+    if (context.read<AuthBloc>().state.status != AuthStatus.authenticated) {
+      return;
+    }
+    if (getIt.get<NavigationService>().navigatorKey.currentContext == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _drainPendingAlarmLaunchPayload();
+      });
+      return;
+    }
+
+    _pendingAlarmLaunchPayload = null;
+    getIt.get<NavigationService>().push('/scheduleStart', extra: payload);
+  }
+
+  void _schedulePendingAlarmLaunchPolls() {
+    for (final timer in _alarmLaunchPollTimers) {
+      timer.cancel();
+    }
+    _alarmLaunchPollTimers.clear();
+    const delays = [
+      Duration(milliseconds: 300),
+      Duration(seconds: 1),
+      Duration(seconds: 2),
+    ];
+    final alarmSchedulerService = getIt.get<AlarmSchedulerService>();
+    for (final delay in delays) {
+      _alarmLaunchPollTimers.add(
+        Timer(delay, () {
+          if (!mounted) return;
+          unawaited(alarmSchedulerService.dispatchPendingLaunchPayload());
+        }),
+      );
+    }
+  }
+
   @override
   void dispose() {
+    for (final timer in _alarmLaunchPollTimers) {
+      timer.cancel();
+    }
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      theme: themeData,
-      routerConfig: _router,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
+    return BlocListener<AuthBloc, AuthState>(
+      listenWhen: (previous, current) => previous.status != current.status,
+      listener: (context, state) => _drainPendingAlarmLaunchPayload(),
+      child: MaterialApp.router(
+        theme: themeData,
+        routerConfig: _router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
     );
   }
 }

--- a/lib/presentation/app/screens/app.dart
+++ b/lib/presentation/app/screens/app.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/services.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
 import 'package:on_time_front/core/services/navigation_service.dart';
@@ -70,6 +71,7 @@ class _AppRouterViewState extends State<_AppRouterView>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state != AppLifecycleState.resumed) return;
+    unawaited(HardwareKeyboard.instance.syncKeyboardState().catchError((_) {}));
     if (context.read<AuthBloc>().state.status != AuthStatus.authenticated) {
       return;
     }

--- a/lib/presentation/app/screens/app.dart
+++ b/lib/presentation/app/screens/app.dart
@@ -72,6 +72,9 @@ class _AppRouterViewState extends State<_AppRouterView>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state != AppLifecycleState.resumed) return;
     unawaited(HardwareKeyboard.instance.syncKeyboardState().catchError((_) {}));
+    unawaited(
+      getIt.get<AlarmSchedulerService>().dispatchPendingLaunchPayload(),
+    );
     if (context.read<AuthBloc>().state.status != AuthStatus.authenticated) {
       return;
     }

--- a/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
+++ b/lib/presentation/calendar/bloc/monthly_schedules_bloc.dart
@@ -65,7 +65,12 @@ class MonthlySchedulesBloc
   ) async {
     emit(state.copyWith(status: () => MonthlySchedulesStatus.loading));
 
-    await _loadSchedulesForMonthUseCase(event.date);
+    try {
+      await _loadSchedulesForMonthUseCase(event.date);
+    } catch (_) {
+      emit(state.copyWith(status: () => MonthlySchedulesStatus.error));
+      return;
+    }
 
     await emit.forEach(
       _getSchedulesByDateUseCase(event.startDate, event.endDate),
@@ -121,7 +126,12 @@ class MonthlySchedulesBloc
         endDate: () => endDate,
       ));
 
-      await _loadSchedulesForMonthUseCase(event.date);
+      try {
+        await _loadSchedulesForMonthUseCase(event.date);
+      } catch (_) {
+        emit(state.copyWith(status: () => MonthlySchedulesStatus.error));
+        return;
+      }
     }
 
     debugPrint('startDate: $startDate, endDate: $endDate');

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -25,6 +27,7 @@ class CalendarScreen extends StatefulWidget {
 
 class _CalendarScreenState extends State<CalendarScreen> {
   late DateTime _selectedDate;
+  late final MonthlySchedulesBloc _monthlySchedulesBloc;
 
   DateTime get _firstDay => DateTime(2024, 12, 1);
 
@@ -53,6 +56,21 @@ class _CalendarScreenState extends State<CalendarScreen> {
           );
 
     _selectedDate = _clampDay(initial, _firstDay, _lastDay);
+    _monthlySchedulesBloc = getIt.get<MonthlySchedulesBloc>()
+      ..add(
+        MonthlySchedulesSubscriptionRequested(
+          date: DateTime(
+            _selectedDate.year,
+            _selectedDate.month,
+            _selectedDate.day,
+          ),
+        ),
+      )
+      ..add(
+        MonthlySchedulesVisibleDateChanged(
+          date: _selectedDate,
+        ),
+      );
   }
 
   void _onLeftArrowTap() {
@@ -76,9 +94,15 @@ class _CalendarScreenState extends State<CalendarScreen> {
       return;
     }
 
-    context.read<MonthlySchedulesBloc>().add(
-          MonthlySchedulesRefreshRequested(date: _selectedDate),
-        );
+    _monthlySchedulesBloc.add(
+      MonthlySchedulesRefreshRequested(date: _selectedDate),
+    );
+  }
+
+  @override
+  void dispose() {
+    unawaited(_monthlySchedulesBloc.close());
+    super.dispose();
   }
 
   Future<void> _openCreateScheduleSheet(BuildContext context) async {
@@ -117,25 +141,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
     final colorScheme = theme.colorScheme;
     final calendarTheme = theme.extension<CalendarTheme>()!;
 
-    return BlocProvider(
-      create: (context) => getIt.get<MonthlySchedulesBloc>()
-        ..add(
-          MonthlySchedulesSubscriptionRequested(
-            date: DateTime(
-              _selectedDate.year,
-              _selectedDate.month,
-              _selectedDate.day,
-              0,
-              0,
-              0,
-            ),
-          ),
-        )
-        ..add(
-          MonthlySchedulesVisibleDateChanged(
-            date: _selectedDate,
-          ),
-        ),
+    return BlocProvider.value(
+      value: _monthlySchedulesBloc,
       child: Scaffold(
         backgroundColor: colorScheme.surfaceContainerLow,
         appBar: AppBar(
@@ -190,11 +197,11 @@ class _CalendarScreenState extends State<CalendarScreen> {
                             _selectedDate =
                                 _clampDay(selectedDay, _firstDay, _lastDay);
                           });
-                          context.read<MonthlySchedulesBloc>().add(
-                                MonthlySchedulesVisibleDateChanged(
-                                  date: _selectedDate,
-                                ),
-                              );
+                          _monthlySchedulesBloc.add(
+                            MonthlySchedulesVisibleDateChanged(
+                              date: _selectedDate,
+                            ),
+                          );
                         },
                         onPageChanged: (focusedDay) {
                           final clampedFocusedDay =
@@ -204,21 +211,21 @@ class _CalendarScreenState extends State<CalendarScreen> {
                             _selectedDate = clampedFocusedDay;
                           });
 
-                          context.read<MonthlySchedulesBloc>().add(
-                                MonthlySchedulesVisibleDateChanged(
-                                  date: _selectedDate,
-                                ),
-                              );
+                          _monthlySchedulesBloc.add(
+                            MonthlySchedulesVisibleDateChanged(
+                              date: _selectedDate,
+                            ),
+                          );
 
-                          context.read<MonthlySchedulesBloc>().add(
-                                MonthlySchedulesMonthAdded(
-                                  date: DateTime(
-                                    clampedFocusedDay.year,
-                                    clampedFocusedDay.month,
-                                    clampedFocusedDay.day,
-                                  ),
-                                ),
-                              );
+                          _monthlySchedulesBloc.add(
+                            MonthlySchedulesMonthAdded(
+                              date: DateTime(
+                                clampedFocusedDay.year,
+                                clampedFocusedDay.month,
+                                clampedFocusedDay.day,
+                              ),
+                            ),
+                          );
                         },
                         calendarBuilders: CalendarBuilders(
                           headerTitleBuilder: (context, date) {
@@ -383,11 +390,11 @@ class _CalendarScreenState extends State<CalendarScreen> {
                                           !context.mounted) {
                                         return;
                                       }
-                                      context.read<MonthlySchedulesBloc>().add(
-                                            MonthlySchedulesScheduleDeleted(
-                                              schedule: schedule,
-                                            ),
-                                          );
+                                      _monthlySchedulesBloc.add(
+                                        MonthlySchedulesScheduleDeleted(
+                                          schedule: schedule,
+                                        ),
+                                      );
                                     });
                                   },
                                 );

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -71,8 +71,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
     });
   }
 
-  Future<void> _refreshSchedulesIfSaved(
-      BuildContext context, bool? saved) async {
+  void _refreshSchedulesIfSaved(bool? saved) {
     if (saved != true || !mounted) {
       return;
     }
@@ -92,7 +91,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
       ),
     );
 
-    await _refreshSchedulesIfSaved(context, saved);
+    _refreshSchedulesIfSaved(saved);
   }
 
   Future<void> _openEditScheduleSheet(
@@ -108,7 +107,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
       ),
     );
 
-    await _refreshSchedulesIfSaved(context, saved);
+    _refreshSchedulesIfSaved(saved);
   }
 
   @override

--- a/lib/presentation/early_late/screens/early_late_screen.dart
+++ b/lib/presentation/early_late/screens/early_late_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/early_late/bloc/early_late_screen_bloc.dart';
-import 'package:on_time_front/presentation/early_late/components/check_list_box_widget.dart';
 import 'package:on_time_front/presentation/early_late/components/early_late_message_image_widget.dart';
 import 'package:on_time_front/presentation/shared/utils/time_format.dart';
 
@@ -133,33 +132,6 @@ class _EarlyLateText extends StatelessWidget {
         ],
       ),
       textAlign: TextAlign.center,
-    );
-  }
-}
-
-class _CheckListBoxSection extends StatelessWidget {
-  final double screenWidth;
-  final double screenHeight;
-  final List<String> checkList;
-  final List<bool> checkedStates;
-  final Function(int) onItemToggled;
-
-  const _CheckListBoxSection({
-    required this.screenWidth,
-    required this.screenHeight,
-    required this.checkList,
-    required this.checkedStates,
-    required this.onItemToggled,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return CheckListBoxWidget(
-      screenWidth: screenWidth,
-      screenHeight: screenHeight,
-      checkList: checkList,
-      checkedStates: checkedStates,
-      onItemToggled: onItemToggled,
     );
   }
 }

--- a/lib/presentation/home/bloc/weekly_schedules_bloc.dart
+++ b/lib/presentation/home/bloc/weekly_schedules_bloc.dart
@@ -20,7 +20,12 @@ class WeeklySchedulesBloc
       (event, emit) async {
         emit(state.copyWith(status: () => WeeklySchedulesStatus.loading));
 
-        await _loadSchedulesForWeekUseCase(event.date);
+        try {
+          await _loadSchedulesForWeekUseCase(event.date);
+        } catch (_) {
+          emit(state.copyWith(status: () => WeeklySchedulesStatus.error));
+          return;
+        }
 
         await emit.forEach(
           _getSchedulesByDateUseCase(event.startDate, event.endDate),

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -37,10 +37,12 @@ class _HomeScreenState extends State<HomeScreen> {
       create: (context) => getIt.get<WeeklySchedulesBloc>()
         ..add(WeeklySchedulesSubscriptionRequested(date: dateOfToday)),
       child: BlocListener<ScheduleBloc, ScheduleState>(
+        listenWhen: (previous, current) {
+          return previous.status != ScheduleStatus.started &&
+              current.status == ScheduleStatus.started;
+        },
         listener: (context, scheduleState) {
-          if (scheduleState.status == ScheduleStatus.started) {
-            context.go('/scheduleStart');
-          }
+          context.go('/scheduleStart');
         },
         child: BlocBuilder<WeeklySchedulesBloc, WeeklySchedulesState>(
           builder: (context, state) {

--- a/lib/presentation/home/screens/home_screen_tmp.dart
+++ b/lib/presentation/home/screens/home_screen_tmp.dart
@@ -54,10 +54,12 @@ class HomeScreenContent extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     return BlocListener<ScheduleBloc, ScheduleState>(
+      listenWhen: (previous, current) {
+        return previous.status != ScheduleStatus.started &&
+            current.status == ScheduleStatus.started;
+      },
       listener: (context, scheduleState) {
-        if (scheduleState.status == ScheduleStatus.started) {
-          context.go('/scheduleStart');
-        }
+        context.go('/scheduleStart');
       },
       child: LayoutBuilder(
         builder: (context, constraints) {

--- a/lib/presentation/login/components/google_sign_in_button/apple_sign_in_button_mobile.dart
+++ b/lib/presentation/login/components/google_sign_in_button/apple_sign_in_button_mobile.dart
@@ -33,7 +33,7 @@ class AppleSignInButton extends StatelessWidget {
 
               final identityToken = credential.identityToken;
               final authorizationCode = credential.authorizationCode;
-              if (identityToken == null || authorizationCode == null) {
+              if (identityToken == null) {
                 throw Exception('Apple Sign In Failed: Missing credentials');
               }
 

--- a/lib/presentation/moving/screens/moving_screen.dart
+++ b/lib/presentation/moving/screens/moving_screen.dart
@@ -6,8 +6,6 @@ class MovingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: Text(AppLocalizations.of(context)!.movingScreenTitle),
-    );
+    return Text(AppLocalizations.of(context)!.movingScreenTitle);
   }
 }

--- a/lib/presentation/my_page/my_page_screen.dart
+++ b/lib/presentation/my_page/my_page_screen.dart
@@ -2,8 +2,16 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
 import 'package:on_time_front/core/services/notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
+import 'package:on_time_front/domain/use-cases/cancel_all_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/app/bloc/auth/auth_bloc.dart';
 import 'package:on_time_front/presentation/my_page/my_page_modal/delete_user_modal.dart';
@@ -29,6 +37,10 @@ class MyPageScreen extends StatelessWidget {
           _FrameView(
               title: AppLocalizations.of(context)!.myAccount,
               child: _MyAccountView()),
+          const _FrameView(
+            title: '알람 설정',
+            child: _AlarmStatusView(),
+          ),
           _FrameView(
             title: AppLocalizations.of(context)!.accountSettings,
             child: Column(
@@ -75,6 +87,149 @@ class MyPageScreen extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _AlarmStatusView extends StatefulWidget {
+  const _AlarmStatusView();
+
+  @override
+  State<_AlarmStatusView> createState() => _AlarmStatusViewState();
+}
+
+class _AlarmStatusViewState extends State<_AlarmStatusView> {
+  bool _isLoading = true;
+  bool _isUpdating = false;
+  bool _alarmsEnabled = true;
+  String _statusLabel = '확인 중';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+    });
+    try {
+      final alarmRepository = getIt.get<AlarmRepository>();
+      final registryRepository = getIt.get<AlarmRegistryRepository>();
+      final schedulerService = getIt.get<AlarmSchedulerService>();
+      final fallbackService = getIt.get<FallbackAlarmNotificationService>();
+
+      final settings = await alarmRepository.getAlarmSettings();
+      final records = await registryRepository.loadAll();
+      final capabilities = await schedulerService.getCapabilities();
+      final nativePermission = await schedulerService.checkPermission();
+      final fallbackPermission = await fallbackService.checkPermission();
+
+      if (!mounted) return;
+      setState(() {
+        _alarmsEnabled = settings.alarmsEnabled;
+        _statusLabel = _buildStatusLabel(
+          settings: settings,
+          records: records,
+          capabilities: capabilities,
+          nativePermission: nativePermission,
+          fallbackPermission: fallbackPermission,
+        );
+        _isLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _statusLabel = '상태를 불러올 수 없음';
+        _isLoading = false;
+      });
+    }
+  }
+
+  String _buildStatusLabel({
+    required AlarmSettings settings,
+    required List<ScheduledAlarmRecord> records,
+    required AlarmSchedulerCapabilities capabilities,
+    required AlarmPermissionState nativePermission,
+    required AlarmPermissionState fallbackPermission,
+  }) {
+    if (!settings.alarmsEnabled) return '꺼짐';
+    if (records.any((record) =>
+        record.provider == AlarmProvider.androidAlarmManager ||
+        record.provider == AlarmProvider.iosAlarmKit)) {
+      return '네이티브 알람';
+    }
+    if (records
+        .any((record) => record.provider == AlarmProvider.localNotification)) {
+      return '알림 대체';
+    }
+    if (capabilities.supportsNativeAlarm &&
+        nativePermission != AlarmPermissionState.granted &&
+        fallbackPermission != AlarmPermissionState.granted) {
+      return '권한 필요';
+    }
+    if (!capabilities.supportsNativeAlarm &&
+        fallbackPermission != AlarmPermissionState.granted) {
+      return '지원 안 됨';
+    }
+    return '대기 중';
+  }
+
+  Future<void> _toggle(bool value) async {
+    setState(() {
+      _isUpdating = true;
+      _alarmsEnabled = value;
+    });
+    try {
+      final alarmRepository = getIt.get<AlarmRepository>();
+      await alarmRepository.updateAlarmSettings(alarmsEnabled: value);
+      if (value) {
+        final schedulerService = getIt.get<AlarmSchedulerService>();
+        final fallbackService = getIt.get<FallbackAlarmNotificationService>();
+        final nativePermission = await schedulerService.requestPermission();
+        if (nativePermission != AlarmPermissionState.granted) {
+          await fallbackService.requestPermission();
+        }
+        await getIt.get<ReconcileAlarmsUseCase>()();
+      } else {
+        await getIt.get<CancelAllAlarmsUseCase>()();
+      }
+      await _load();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdating = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('일정 알람', style: textTheme.bodyLarge),
+            const SizedBox(height: 4),
+            Text(
+              _isLoading ? '확인 중' : _statusLabel,
+              style: textTheme.bodySmall?.copyWith(
+                color: colorScheme.outline,
+              ),
+            ),
+          ],
+        ),
+        Switch(
+          value: _alarmsEnabled,
+          onChanged: _isUpdating ? null : _toggle,
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/schedule_create/bloc/schedule_form_bloc.dart
+++ b/lib/presentation/schedule_create/bloc/schedule_form_bloc.dart
@@ -135,7 +135,7 @@ class ScheduleFormBloc extends Bloc<ScheduleFormEvent, ScheduleFormState> {
         placeId: Uuid().v7(),
         placeName: null,
         scheduleName: null,
-        scheduleTime: null,
+        scheduleTime: initialScheduleTime,
         moveTime: null,
         isChanged: null,
         scheduleSpareTime: userSpareTime,

--- a/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_cubit.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_cubit.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:formz/formz.dart';

--- a/lib/presentation/shared/router/go_router.dart
+++ b/lib/presentation/shared/router/go_router.dart
@@ -19,6 +19,7 @@ import 'package:on_time_front/presentation/my_page/preparation_spare_time_edit/p
 import 'package:on_time_front/presentation/notification_allow/screens/notification_allow_screen.dart';
 import 'package:on_time_front/presentation/onboarding/screens/onboarding_screen.dart';
 import 'package:on_time_front/presentation/onboarding/screens/onboarding_start_screen.dart';
+import 'package:on_time_front/presentation/shared/components/loading_screen.dart';
 import 'package:on_time_front/presentation/schedule_create/schedule_spare_and_preparing_time/preparation_form/screens/preparation_edit_form.dart';
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_create_screen.dart';
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_edit_screen.dart';
@@ -120,17 +121,8 @@ GoRouter goRouterConfig(AuthBloc authBloc, ScheduleBloc scheduleBloc) {
         path: '/scheduleStart',
         name: 'scheduleStart',
         builder: (context, state) {
-          final scheduleState = context.read<ScheduleBloc>().state;
-          if (scheduleState.isEarlyStarted) {
-            return const AlarmScreen();
-          }
-          final schedule = context.read<ScheduleBloc>().state.schedule;
-          if (schedule == null) {
-            return const SizedBox.shrink();
-          }
           final extra = state.extra as Map<String, dynamic>?;
-          final promptVariant = scheduleStartPromptVariantFromRouteExtra(extra);
-          return ScheduleStartScreen(promptVariant: promptVariant);
+          return _ScheduleStartRouteGate(extra: extra);
         },
       ),
       GoRoute(
@@ -158,4 +150,61 @@ GoRouter goRouterConfig(AuthBloc authBloc, ScheduleBloc scheduleBloc) {
       ),
     ],
   );
+}
+
+class _ScheduleStartRouteGate extends StatefulWidget {
+  final Map<String, dynamic>? extra;
+
+  const _ScheduleStartRouteGate({required this.extra});
+
+  @override
+  State<_ScheduleStartRouteGate> createState() =>
+      _ScheduleStartRouteGateState();
+}
+
+class _ScheduleStartRouteGateState extends State<_ScheduleStartRouteGate> {
+  bool _requestedValidation = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_requestedValidation) return;
+    final scheduleId = widget.extra?['scheduleId']?.toString();
+    if (scheduleId == null || scheduleId.isEmpty) return;
+    _requestedValidation = true;
+    context.read<ScheduleBloc>().add(
+          ScheduleAlarmPromptRequested(
+            scheduleId: scheduleId,
+            scheduleFingerprint:
+                widget.extra?['scheduleFingerprint']?.toString(),
+          ),
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheduleState = context.watch<ScheduleBloc>().state;
+    if (scheduleState.isEarlyStarted) {
+      return const AlarmScreen();
+    }
+
+    final scheduleId = widget.extra?['scheduleId']?.toString();
+    final scheduleFingerprint =
+        widget.extra?['scheduleFingerprint']?.toString();
+    final schedule = scheduleState.schedule;
+    if (schedule == null) {
+      return const LoadingScreen();
+    }
+    if (scheduleId != null && schedule.id != scheduleId) {
+      return const LoadingScreen();
+    }
+    if (scheduleFingerprint != null &&
+        schedule.cacheFingerprint != scheduleFingerprint) {
+      return const LoadingScreen();
+    }
+
+    final promptVariant =
+        scheduleStartPromptVariantFromRouteExtra(widget.extra);
+    return ScheduleStartScreen(promptVariant: promptVariant);
+  }
 }

--- a/plans/backend_alarm_feature_spec.md
+++ b/plans/backend_alarm_feature_spec.md
@@ -1,0 +1,468 @@
+# Backend Specification: Native Alarm Feature
+
+## Goal
+
+Support account-owned schedules while allowing exactly one logged-in device to mirror upcoming schedules into local native alarms.
+
+The server remains the source of truth for schedules and preparation data. Native alarm scheduling remains device-local because Android AlarmManager, iOS AlarmKit, and local notification fallback are OS/device capabilities.
+
+## Product Decisions
+
+- Alarm trigger time is 5 minutes before `preparationStartTime`.
+- `preparationStartTime = scheduleTime - moveTime - scheduleSpareTime - totalPreparationTime`.
+- Device-local time is accepted for v1.
+- `scheduleTime`, `preparationStartTime`, and `defaultAlarmTime` represent the user's intended local wall-clock time in v1.
+- Only one device is logged in at a time.
+- The client reconciles all not-ended schedules in the next 7 days.
+- The client does not schedule past alarms.
+- Schedule create/update should succeed even if alarm setup is incomplete.
+- Global alarms setting ships first.
+- Future server-backed per-schedule alarm settings should be designed into the contract.
+
+## V1 Backend Scope
+
+Backend must keep schedule and preparation APIs as source of truth and add user alarm preference/device metadata APIs. Backend does not schedule native alarms.
+
+Required backend responsibilities:
+
+- Persist user-level alarm preference.
+- Persist current device identity for the authenticated user.
+- Enforce or support one active device session, if not already implemented.
+- Suppress legacy server push reminders only when latest current-device alarm status indicates local alarm coverage, to avoid duplicate alerts without leaving unarmed users silent.
+- Return enough schedule and preparation data for the client to compute alarm times.
+- Expose a required 7-day schedule/preparation alarm-window sync path efficient enough for alarm reconciliation.
+- Store the latest per-device alarm status as durable but non-authoritative diagnostics for settings UI and support.
+
+Out of scope for v1:
+
+- Server-sent alarm jobs.
+- Backend-triggered alarm fallback.
+- Per-schedule alarm settings enforcement.
+- Multi-device alarm arbitration.
+
+## Data Model Additions
+
+### User Alarm Settings
+
+Store one row/document per user.
+
+```json
+{
+  "userId": "string",
+  "alarmsEnabled": true,
+  "defaultAlarmOffsetMinutes": 5,
+  "updatedAt": "2026-05-05T09:00:00.000Z"
+}
+```
+
+Rules:
+
+- `alarmsEnabled` controls whether the client should mirror schedules into local alarms.
+- `defaultAlarmOffsetMinutes` defaults to `5`.
+- Backend stores `defaultAlarmOffsetMinutes` in v1, but the client UI keeps the offset fixed at 5 minutes.
+- For v1, this is global and applies to all schedules.
+- When `alarmsEnabled=false`, client cancels local alarms but server schedules remain unchanged.
+- When `alarmsEnabled=true`, backend should suppress legacy 5-minute-before push reminders only when the latest current-device alarm status indicates local coverage.
+- Suppression applies when latest status is `armed`, or `partial` with provider coverage and at least one armed schedule.
+- If status is `partial`, backend should suppress legacy push only for `armedScheduleIds` and may send legacy push for failed or missing eligible schedules.
+- Backend should suppress only for schedules inside the reported alarm coverage window and listed in `armedScheduleIds`.
+- Latest status is eligible for suppression only when `reconciledAt` is within the last 24 hours and belongs to the current active `deviceId`/session.
+- Backend may continue legacy push reminders when latest status is `permissionNeeded`, `unsupported`, `settingsUnavailable`, missing, or stale.
+- Client-reported `armedScheduleIds` are a best-effort suppression signal. If backend is uncertain, it should send the legacy push rather than risk silence.
+- When `alarmsEnabled=false`, backend may continue legacy push reminder behavior if the product wants backward compatibility.
+
+### Device Registration
+
+Store one active device per user.
+
+```json
+{
+  "deviceId": "uuid-or-installation-id",
+  "userId": "string",
+  "platform": "android|ios",
+  "appVersion": "string",
+  "osVersion": "string",
+  "supportsNativeAlarm": true,
+  "nativeAlarmProvider": "androidAlarmManager|iosAlarmKit|none",
+  "fallbackProvider": "localNotification|none",
+  "lastSeenAt": "2026-05-05T09:00:00.000Z"
+}
+```
+
+Rules:
+
+- On login, client registers or updates the current device.
+- `deviceId` is an opaque client-generated installation identifier.
+- Validate `deviceId` as a required bounded string, recommended length 16-128 with safe identifier characters such as letters, numbers, `.`, `_`, `:`, and `-`.
+- If the product guarantees one logged-in device, registering a new device may invalidate older device sessions/tokens.
+- Logout should unregister or mark the device inactive.
+- Device metadata is diagnostic and helps backend/customer support understand alarm availability.
+
+### Future Per-Schedule Alarm Settings
+
+Do not require this for v1, but reserve fields or prepare a table for later.
+
+```json
+{
+  "scheduleId": "string",
+  "userId": "string",
+  "alarmEnabled": true,
+  "alarmOffsetMinutes": 5,
+  "deliveryPreference": "nativeFirst|notificationOnly|off",
+  "updatedAt": "2026-05-05T09:00:00.000Z"
+}
+```
+
+Future rules:
+
+- Per-schedule settings override user defaults.
+- Global `alarmsEnabled=false` remains a device/user-level override that prevents local arming.
+- These settings must survive device changes.
+
+## API Contracts
+
+### Get Alarm Settings
+
+`GET /users/me/alarm-settings`
+
+Response:
+
+```json
+{
+  "data": {
+    "alarmsEnabled": true,
+    "defaultAlarmOffsetMinutes": 5,
+    "updatedAt": "2026-05-05T09:00:00.000Z"
+  }
+}
+```
+
+### Patch Alarm Settings
+
+`PATCH /users/me/alarm-settings`
+
+Request:
+
+```json
+{
+  "alarmsEnabled": true
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "alarmsEnabled": true,
+    "defaultAlarmOffsetMinutes": 5,
+    "updatedAt": "2026-05-05T09:00:00.000Z"
+  }
+}
+```
+
+Validation:
+
+- Request fields are optional, but at least one supported field must be present.
+- Unknown fields should be rejected with `400 Bad Request` and error code `ALARM_SETTINGS_INVALID_FIELD`.
+- `defaultAlarmOffsetMinutes` must be `>= 0`.
+- Recommended max is `1440`.
+
+### Register Current Device
+
+`PUT /users/me/devices/current`
+
+Request:
+
+```json
+{
+  "deviceId": "4f78cdd2-2d90-43b8-8bc5-53df8d9c5b12",
+  "platform": "ios",
+  "appVersion": "1.4.0",
+  "osVersion": "26.0",
+  "supportsNativeAlarm": true,
+  "nativeAlarmProvider": "iosAlarmKit",
+  "fallbackProvider": "localNotification"
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "deviceId": "4f78cdd2-2d90-43b8-8bc5-53df8d9c5b12",
+    "active": true,
+    "lastSeenAt": "2026-05-05T09:00:00.000Z"
+  }
+}
+```
+
+Server behavior:
+
+- Associate this device with the authenticated user.
+- Bind this device to the current authenticated access/refresh-token session.
+- If only one logged-in device is allowed, invalidate or deactivate previous devices for the same user.
+- This endpoint should be idempotent.
+- Validate `platform`, `nativeAlarmProvider`, and `fallbackProvider` as enums.
+- Reject impossible platform/provider combinations, such as `platform=ios` with `nativeAlarmProvider=androidAlarmManager`.
+- Backend cannot directly cancel OS alarms on an old disconnected device.
+- Old-device local alarms must be canceled by the old app when it receives logout/session-invalidated handling or next observes an auth failure.
+
+### Unregister Current Device
+
+`DELETE /users/me/devices/current`
+
+Request body optional:
+
+```json
+{
+  "deviceId": "4f78cdd2-2d90-43b8-8bc5-53df8d9c5b12"
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "active": false
+  }
+}
+```
+
+### Register FCM Token
+
+Existing endpoint: `POST /firebase-token`
+
+Update the request to include `deviceId` so push tokens can be associated with the current active device.
+
+Request:
+
+```json
+{
+  "firebaseToken": "string",
+  "deviceId": "4f78cdd2-2d90-43b8-8bc5-53df8d9c5b12"
+}
+```
+
+Rules:
+
+- `/users/me/devices/current` owns device/session metadata.
+- `/firebase-token` owns push token registration and links the FCM token to the current device.
+- Backend should consider a transition period if older clients still send only `firebaseToken`.
+
+### Alarm Window Sync
+
+`GET /schedules/alarm-window?startDate=2026-05-05T00:00:00.000Z&endDate=2026-05-12T00:00:00.000Z`
+
+Response:
+
+```json
+{
+  "data": [
+    {
+      "scheduleId": "string",
+      "scheduleName": "Dentist",
+      "place": {
+        "placeId": "string",
+        "placeName": "Gangnam Station"
+      },
+      "scheduleTime": "2026-05-06T10:00:00.000",
+      "moveTime": 30,
+      "scheduleSpareTime": 10,
+      "doneStatus": "NOT_ENDED",
+      "preparationStartTime": "2026-05-06T08:55:00.000",
+      "defaultAlarmTime": "2026-05-06T08:50:00.000",
+      "preparations": [
+        {
+          "preparationId": "string",
+          "preparationName": "Shower",
+          "preparationTime": 20,
+          "nextPreparationId": "string-or-null"
+        }
+      ],
+      "alarmSettings": null
+    }
+  ]
+}
+```
+
+Notes:
+
+- `startDate` and `endDate` use the same format and semantics as the existing `GET /schedules` date range API.
+- Backend interprets query bounds as local wall-clock schedule bounds for v1.
+- Endpoint is not paginated in v1.
+- Backend rejects ranges longer than 14 days.
+- Date range is inclusive start and exclusive end: include schedules where `scheduleTime >= startDate && scheduleTime < endDate`.
+- Client should request an 8-day padded schedule window for 7-day alarm coverage.
+- If the requested range is longer than 14 days, backend returns `400 Bad Request` with error code `ALARM_WINDOW_RANGE_TOO_LONG`.
+- `scheduleTime` remains device-local for v1, matching current client behavior.
+- `place` includes only minimal display data needed for local alarm text.
+- `moveTime`, `scheduleSpareTime`, and `preparationTime` are non-negative integer minutes.
+- `scheduleSpareTime` should be `0`, not `null`, when no spare time exists.
+- `preparations: []` is allowed when a schedule truly has no preparation steps; client treats total preparation time as zero.
+- Backend should not silently return `preparations: []` when preparation loading failed server-side.
+- `doneStatus` must be included so client filters `NOT_ENDED`.
+- `alarmSettings` is `null` for v1, reserved for future per-schedule settings.
+- Backend filters by `scheduleTime` range and `doneStatus=NOT_ENDED`.
+- Backend returns schedules sorted by `scheduleTime ASC, scheduleId ASC`.
+- Client should request a padded schedule window, such as `now` through `now + 8 days`, then arm only computed alarm times within `now` through `now + 7 days`.
+- `preparationStartTime` and `defaultAlarmTime` are optional convenience/debug fields.
+- Client remains responsible for computing final alarm time from raw schedule, preparation, and alarm settings data.
+- Time fields represent local wall-clock schedule time in v1. Do not silently convert them in a way that changes the user's intended appointment time.
+- Future timezone-stable behavior should add a `scheduleTimezone` field, such as `Asia/Seoul`.
+
+This endpoint is required for v1 because alarms default on and reconciliation runs on login, launch, resume, and schedule mutation boundaries.
+
+### Alarm Status Report
+
+`POST /users/me/alarm-status`
+
+Request:
+
+```json
+{
+  "deviceId": "4f78cdd2-2d90-43b8-8bc5-53df8d9c5b12",
+  "reconciledAt": "2026-05-05T09:00:00.000Z",
+  "scheduleWindowStart": "2026-05-05T00:00:00.000",
+  "scheduleWindowEnd": "2026-05-13T00:00:00.000",
+  "alarmCoverageStart": "2026-05-05T00:00:00.000",
+  "alarmCoverageEnd": "2026-05-12T00:00:00.000",
+  "status": "armed|partial|disabled|permissionNeeded|unsupported|settingsUnavailable",
+  "permissionIssue": "nativePermissionDenied|notificationPermissionDenied|null",
+  "nativeAlarmProvider": "androidAlarmManager|iosAlarmKit|none",
+  "fallbackProvider": "localNotification|none",
+  "armedScheduleCount": 4,
+  "armedScheduleIds": ["schedule-id-1", "schedule-id-2"],
+  "skippedScheduleCount": 2,
+  "failures": [
+    {
+      "scheduleId": "schedule-id-1",
+      "reason": "preparationLoadFailed"
+    }
+  ]
+}
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "received": true
+  }
+}
+```
+
+Server behavior:
+
+- Store only the latest status for the authenticated user's current device.
+- Reject reports from inactive or non-current devices with `409 Conflict` and error code `DEVICE_SESSION_NOT_ACTIVE`.
+- Treat status as diagnostic and non-authoritative.
+- Do not use this status to decide whether schedules are valid or guarantee whether local alarms will fire.
+- Backend may use latest current-device status as a best-effort duplicate-alert suppression signal for legacy push reminders.
+- Use it for My Page status display, support diagnostics, and debugging missed alarms.
+- `armedScheduleIds` means schedules covered by any accepted local delivery method, including native alarms and local notification fallback.
+- Do not add a custom `armedScheduleIds` count cap in v1 beyond normal API request body limits.
+- Status definitions:
+  - `armed`: no eligible schedule failed to arm; zero eligible schedules is still healthy.
+  - `partial`: at least one eligible schedule could not be armed.
+  - `disabled`: global alarms are disabled.
+  - `permissionNeeded`: required native alarm or fallback notification permission/setup is missing.
+  - `settingsUnavailable`: alarm settings could not be loaded.
+  - `unsupported`: no native alarm and no acceptable fallback are available.
+- `unsupported` is a top-level platform/provider state, not a per-schedule failure.
+- If local notification fallback is active, report `status=armed` or `status=partial` with `nativeAlarmProvider=none` and `fallbackProvider=localNotification`, not `unsupported`.
+- Failure reasons should be coarse and non-sensitive.
+- `permissionIssue` is a top-level device/provider issue and should not be repeated per schedule.
+- Supported failure reasons: `preparationLoadFailed`, `scheduleInvalid`, `platformError`, `unknown`.
+- Past alarm times are skipped by design and should be counted in `skippedScheduleCount`, not reported as failures.
+
+## Existing Schedule API Requirements
+
+The current schedule APIs must preserve these fields:
+
+- `scheduleId`
+- `scheduleName`
+- `scheduleTime`
+- `moveTime`
+- `scheduleSpareTime`
+- `doneStatus`
+
+The preparation API must preserve:
+
+- `preparationId`
+- `preparationName`
+- `preparationTime`
+- `nextPreparationId`
+
+Backend must ensure `doneStatus` is accurate after finish/delete/update operations so the client cancels stale alarms.
+
+`/schedules/alarm-window` should omit `scheduleNote` because alarm computation and local alarm display do not require private note content.
+
+## Client Reconciliation Contract
+
+Backend provides data. Client computes:
+
+```text
+totalPreparationTime = sum(preparation.preparationTime)
+preparationStartTime = scheduleTime - moveTime - scheduleSpareTime - totalPreparationTime
+alarmTime = preparationStartTime - defaultAlarmOffsetMinutes
+```
+
+Client schedules only when:
+
+- User is authenticated.
+- Global `alarmsEnabled=true`.
+- `doneStatus == NOT_ENDED`.
+- `now < alarmTime`.
+- `alarmTime <= now + 7 days`.
+- Preparation data loaded successfully.
+
+The client should request the alarm-window endpoint by `scheduleTime` with a padded range, then perform final eligibility filtering by computed `alarmTime`.
+
+Client cancels local alarms when:
+
+- Global alarms are disabled.
+- User logs out.
+- User session is invalidated by login on another device.
+- Backend returns `DEVICE_SESSION_NOT_ACTIVE`.
+- Schedule is deleted, finished, ended, or no longer in desired window.
+- Schedule/preparation fingerprint changes.
+- User starts preparation early.
+
+## Error Handling
+
+- Schedule create/update/delete/finish must not fail because local alarm setup fails.
+- If alarm settings API fails, client should keep schedule operations successful and retry alarm settings/reconciliation later.
+- If alarm settings cannot be loaded during reconciliation, client should not arm new alarms, should not immediately cancel existing registered alarms, should report `settingsUnavailable`, and should retry later.
+- If preparation data cannot be loaded, client skips that schedule alarm and reports partial status through the alarm status API.
+- If device registration fails, client can still use local alarms, but status reporting/device ownership may be degraded.
+
+## Security
+
+- All endpoints require authenticated user tokens.
+- Users can only access their own alarm settings, devices, schedules, and status reports.
+- Device IDs are client-generated installation identifiers, not hardware identifiers.
+- Do not store sensitive OS permission details beyond coarse support/status fields.
+
+## Migration
+
+Default values for existing and new users:
+
+```json
+{
+  "alarmsEnabled": true,
+  "defaultAlarmOffsetMinutes": 5
+}
+```
+
+Recommended rollout:
+
+1. Add alarm settings storage and APIs.
+2. Add device registration APIs.
+3. Add alarm-window aggregate endpoint.
+4. Confirm existing schedule and preparation APIs remain backward compatible.
+5. Add alarm status report endpoint.
+6. Later add per-schedule alarm settings.

--- a/plans/native_alarm_client_implementation_plan.md
+++ b/plans/native_alarm_client_implementation_plan.md
@@ -1,0 +1,197 @@
+# Native Alarm Client Implementation Plan
+
+## Goal
+
+Replace the legacy fixed push reminder behavior with a client-owned alarm mirror for upcoming schedules.
+
+The server remains the source of truth for schedules, preparation data, global alarm settings, current device registration, and diagnostic alarm status. The Flutter app owns local reconciliation, native alarm scheduling, fallback notification scheduling, local alarm registry persistence, permission UX, and launch routing.
+
+## Context
+
+- Backend contract is defined in `plans/backend_alarm_feature_spec.md`.
+- Existing notification code lives in `lib/core/services/notification_service.dart` and should remain focused on FCM, foreground/background push handling, local notification display, and fallback notification support.
+- Existing schedule state and timer behavior lives in `lib/presentation/app/bloc/schedule/schedule_bloc.dart`.
+- Existing schedule start route is `/scheduleStart` in `lib/presentation/shared/router/go_router.dart`.
+- Existing schedule entity computes `preparationStartTime` in `lib/domain/entities/schedule_with_preparation_entity.dart`.
+- Current schedule data is server-backed through `ScheduleRepositoryImpl`, `ScheduleRemoteDataSource`, and related use cases.
+- Root architecture follows clean layers: `core` for platform services, `data` for sources/models/repositories, `domain` for entities/repository contracts/use cases, and `presentation` for screens/blocs/widgets.
+
+## Decisions
+
+- Alarm fires 5 minutes before `preparationStartTime`.
+- `preparationStartTime = scheduleTime - moveTime - scheduleSpareTime - totalPreparationTime`.
+- Device-local wall-clock schedule time is accepted for v1.
+- Global alarms default to enabled on the backend.
+- The app keeps `alarmsEnabled=true` when permission is missing, reports `permissionNeeded`, and does not schedule until native or fallback permission is available.
+- Reconciliation targets all not-ended schedules whose computed alarm time is in the next 7 days.
+- The schedule query is padded: request schedules by `scheduleTime` for about 8 days, then filter by computed `alarmTime` for 7-day coverage.
+- Do not schedule past alarms.
+- Use true native alarms where available: Android `AlarmManager.setAlarmClock`, iOS 26+ AlarmKit.
+- Use local notification fallback elsewhere when notification permission exists.
+- Do not use Android inexact alarms if exact/native alarm permission is denied.
+- Alarm tap opens `/scheduleStart` with `scheduleId` and `promptVariant: alarm`.
+- Alarm firing/tapping does not start preparation automatically.
+- Validate the schedule before showing start UI; alarm payload is only a hint.
+- Introduce a separate alarm layer; keep `NotificationService` for FCM and fallback notifications.
+- Use MethodChannel/native platform code for native alarms unless a package cleanly supports the exact Android and iOS requirements.
+- Persist a local alarm registry keyed by `scheduleId`.
+- Trigger reconciliation from auth/app lifecycle and schedule mutation boundaries, not screens directly.
+- On logout or session invalidation, cancel native alarms, cancel fallback notifications, clear registry, and leave server schedules untouched.
+- Cancel the pending schedule alarm when the user starts preparation early.
+- Prioritize reconciliation unit tests before native platform tests.
+- Mention future server-backed per-schedule alarm settings, but do not build per-schedule toggles in v1.
+
+## Steps
+
+1. Add alarm domain entities and enums.
+   - Create entities for `AlarmSettings`, `AlarmDeviceInfo`, `ScheduledAlarmRecord`, `AlarmReconciliationResult`, `AlarmStatusReport`, `AlarmProvider`, `AlarmPermissionIssue`, and `AlarmFailureReason`.
+   - Keep computed fields deterministic: `preparationStartTime`, `alarmTime`, and `scheduleFingerprint`.
+   - Model provider states as `androidAlarmManager`, `iosAlarmKit`, `localNotification`, and `none`.
+
+2. Add backend API models and data sources.
+   - Add endpoints for:
+     - `GET /users/me/alarm-settings`
+     - `PATCH /users/me/alarm-settings`
+     - `PUT /users/me/devices/current`
+     - `DELETE /users/me/devices/current`
+     - `GET /schedules/alarm-window`
+     - `POST /users/me/alarm-status`
+   - Update FCM token registration request to include `deviceId`.
+   - Add JSON models for alarm settings, device registration, alarm-window schedules, preparation steps, status reports, and structured failures.
+   - Keep remote data sources in `lib/data/data_sources/`, models in `lib/data/models/`, and domain contracts in `lib/domain/repositories/`.
+
+3. Add local alarm registry persistence.
+   - Persist registry records keyed by `scheduleId`.
+   - Include `alarmTime`, `preparationStartTime`, `scheduleFingerprint`, native alarm id, fallback notification id, provider, schedule title, and minimal payload.
+   - Use an existing local persistence style where possible. SharedPreferences is acceptable for a small registry; Drift is better if the registry grows or needs queryability.
+   - Provide operations: load all, upsert, delete by schedule id, delete all, and replace after reconciliation.
+
+4. Add platform alarm service interface.
+   - Create `AlarmSchedulerService` in `lib/core/services/`.
+   - Expose methods:
+     - `getCapabilities()`
+     - `checkPermission()`
+     - `requestPermission()`
+     - `scheduleNativeAlarm(record)`
+     - `cancelNativeAlarm(record)`
+     - `cancelAllNativeAlarms(records)`
+   - Keep `NotificationService` available for fallback scheduled local notifications and tap routing.
+   - Convert platform exceptions into typed Dart failures for reconciliation.
+
+5. Add MethodChannel native alarm bridge.
+   - Use a stable channel name such as `on_time_front/native_alarm`.
+   - Dart-to-native calls should include `scheduleId`, `alarmTime`, `title`, `body`, and payload containing `type=schedule_alarm`, `scheduleId`, `alarmTime`, and `preparationStartTime`.
+   - Native-to-Dart or launch-intent payload handling should route into the existing navigation service after app startup is ready.
+
+6. Implement Android native alarm behavior.
+   - Use `AlarmManager.setAlarmClock` for true alarm behavior.
+   - Use stable request codes derived from persisted schedule ids or stored registry ids.
+   - Build a `PendingIntent` that opens the Flutter app with the alarm payload.
+   - Check exact/native alarm capability before scheduling.
+   - If exact/native capability is denied, return a typed permission/capability failure; Dart should use local notification fallback if available.
+   - Add boot restore support. After `BOOT_COMPLETED`, restore from local registry if possible and run full reconciliation on next app launch/resume.
+
+7. Implement iOS native alarm behavior.
+   - Use AlarmKit on iOS 26+ for native alarms.
+   - Guard calls with iOS version checks and return unsupported below iOS 26.
+   - Store native alarm identifiers so Dart registry can cancel/update.
+   - If AlarmKit is unsupported or not permitted, Dart should use local notification fallback if notification permission exists.
+
+8. Implement fallback scheduled local notifications.
+   - Extend `NotificationService` or add a small collaborator so fallback scheduling supports exact local notification ids, cancellation by id, and payload routing.
+   - Ensure fallback notifications use timezone-aware scheduling if required by `flutter_local_notifications`.
+   - Add only minimum needed dependency support, such as `timezone`, if current setup cannot schedule future local notifications correctly.
+   - Fallback tap opens `/scheduleStart` with `promptVariant: alarm`.
+
+9. Implement reconciliation use case.
+   - Add `ReconcileAlarmsUseCase`.
+   - Flow:
+     - Fetch alarm settings.
+     - If settings unavailable, do not arm new alarms, do not immediately cancel existing registered alarms, report `settingsUnavailable`, and retry later.
+     - If `alarmsEnabled=false`, cancel all local alarms/fallback notifications, clear registry, report `disabled`.
+     - Register or verify current device if needed.
+     - Fetch `/schedules/alarm-window` using padded schedule bounds.
+     - Compute desired alarm records.
+     - Skip `alarmTime <= now`.
+     - Compare desired records to registry by `scheduleId` and fingerprint.
+     - Cancel stale or changed records first.
+     - Schedule native alarm when supported/permitted.
+     - Use fallback local notification when native is unavailable/denied and notification permission exists.
+     - Save final registry.
+     - Post alarm status with `armedScheduleIds`, counts, coverage windows, provider info, and failures.
+
+10. Add trigger points.
+   - On successful auth/login: register current device, fetch settings, reconcile.
+   - On app launch/resume: reconcile.
+   - After schedule create/update/delete/finish succeeds: reconcile.
+   - On global alarm toggle on: request/check permission, reconcile.
+   - On global alarm toggle off: cancel all local alarms/fallback notifications, clear registry, patch backend setting.
+   - On logout: unregister current device if possible, cancel all, clear registry.
+   - On `DEVICE_SESSION_NOT_ACTIVE`: cancel all, clear registry, clear auth/session as appropriate, route to sign-in.
+   - On early preparation start: cancel that schedule's pending alarm record.
+
+11. Add route and launch validation.
+   - Alarm payload opens `/scheduleStart` with `scheduleId` and `promptVariant: alarm`.
+   - Before showing start UI, load/check latest schedule state.
+   - If schedule no longer exists, is ended, or fingerprint/time no longer matches, cancel stale record and route home.
+   - Do not start preparation until user confirms.
+
+12. Add My Page alarm status UI.
+   - Add a compact alarm status area in My Page/settings.
+   - Show global enabled state and active delivery method:
+     - Native alarm
+     - Notification fallback
+     - Permission needed
+     - Unsupported
+     - Some alarms could not be set
+     - Disabled
+   - Keep v1 offset fixed at 5 minutes; do not expose an offset picker yet.
+   - Provide permission/setup actions only when needed.
+
+13. Add tests.
+   - Prioritize `ReconcileAlarmsUseCase` unit tests.
+   - Cover:
+     - Schedules only not-ended schedules in 7-day alarm coverage.
+     - Requests padded schedule window.
+     - Skips `alarmTime <= now`.
+     - Cancels stale registry records.
+     - Cancel-then-reschedule on fingerprint change.
+     - Skips and reports partial when preparation data is invalid or scheduling fails.
+     - Cancels all on global toggle off/logout/session invalidation.
+     - Cancels schedule alarm on early preparation start.
+     - Uses fallback when native is unsupported or denied.
+     - Reports `settingsUnavailable` without canceling existing alarms.
+   - Add repository/data-source tests for JSON contract mapping.
+   - Add focused bloc/widget tests for My Page status UI and alarm-start routing where practical.
+
+14. Add platform QA checklist.
+   - Android native alarm fires when app is foreground, background, and terminated.
+   - Android exact/native permission denied uses notification fallback.
+   - Android reboot restore re-arms or reconciles.
+   - iOS 26+ AlarmKit alarm fires and routes correctly.
+   - iOS below 26 uses notification fallback or reports unsupported/permission needed.
+   - Notification fallback routes to `/scheduleStart`.
+   - Logout cancels local alarms.
+   - New-device login invalidates old device and old app cancels on session-invalidated response.
+
+15. Roll out safely.
+   - Ship backend APIs first.
+   - Ship client with reconciliation logging/status reports.
+   - Keep legacy push fallback active unless latest current-device status is fresh and schedule is listed in `armedScheduleIds`.
+   - Monitor `permissionNeeded`, `partial`, `settingsUnavailable`, and `platformError` rates.
+   - Later add server-backed per-schedule alarm settings with `alarmEnabled`, `alarmOffsetMinutes`, and `deliveryPreference`.
+
+## Validation
+
+- Run `flutter analyze`.
+- Run targeted reconciliation tests first, then `flutter test`.
+- Run `dart run build_runner build --delete-conflicting-outputs` after adding generated models or Injectable registrations.
+- Manually test Android native alarm, Android fallback, Android reboot restore, iOS 26 AlarmKit, and iOS fallback.
+- Verify alarm status reports match the backend spec and legacy push suppression receives `armedScheduleIds`.
+
+## Open Questions
+
+- Confirm the exact iOS deployment target and build environment for AlarmKit availability.
+- Confirm whether SharedPreferences or Drift should own the local alarm registry.
+- Confirm final MethodChannel method names during implementation.
+- Confirm backend error response envelope matches existing API conventions before coding data-source parsing.

--- a/plans/native_alarm_platform_qa_checklist.md
+++ b/plans/native_alarm_platform_qa_checklist.md
@@ -1,0 +1,33 @@
+# Native Alarm Platform QA Checklist
+
+Run this after backend alarm APIs are available and the app has valid Firebase
+configuration for Android/iOS builds.
+
+## Android
+
+- Native alarm fires while the app is foregrounded.
+- Native alarm fires while the app is backgrounded.
+- Native alarm opens `/scheduleStart` after app termination.
+- Alarm payload validation redirects home for deleted, ended, or fingerprint-changed schedules.
+- Notification fallback is used when native alarm scheduling is unavailable.
+- Notification fallback opens `/scheduleStart` with `promptVariant=alarm`.
+- Reboot after scheduling a native alarm restores future `androidAlarmManager` registry entries.
+- Logout cancels native alarms, cancels fallback notifications, clears registry, and unregisters the device.
+- Old-device `DEVICE_SESSION_NOT_ACTIVE` status response cancels local alarms, clears registry, and signs out.
+
+## iOS
+
+- iOS 26+ returns `iosAlarmKit` capabilities when built with an SDK that includes AlarmKit.
+- iOS 26+ requests AlarmKit authorization and maps authorized/denied/notDetermined to Dart permission states.
+- iOS 26+ AlarmKit alarm fires at the scheduled alarm time.
+- AlarmKit Open action stores the alarm payload and `/scheduleStart` validates before showing the prompt.
+- AlarmKit cancellation removes the scheduled alarm for changed, deleted, finished, or disabled schedules.
+- iOS below 26 returns unsupported native capability and uses notification fallback when notification permission is granted.
+- Notification fallback opens `/scheduleStart` with `promptVariant=alarm`.
+- Logout cancels fallback notifications, clears registry, and unregisters the device.
+
+## Backend Status
+
+- Fresh status reports include padded schedule window, 7-day alarm coverage, provider fields, counts, and `armedScheduleIds`.
+- Backend legacy push suppression keeps fixed push reminders only when current-device status is stale or missing the schedule id.
+- Monitor `permissionNeeded`, `partial`, `settingsUnavailable`, `platformError`, and `DEVICE_SESSION_NOT_ACTIVE` rates during rollout.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -749,7 +749,7 @@ packages:
     source: hosted
     version: "1.0.5"
   js:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
@@ -1362,7 +1362,7 @@ packages:
     source: hosted
     version: "0.7.4"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
       sha256: ffc9d5f4d1193534ef051f9254063fa53d588609418c84299956c3db9383587d

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,11 +78,13 @@ dependencies:
   firebase_messaging: ^15.2.4
   firebase_core: ^3.12.1
   flutter_local_notifications: ^18.0.1
+  timezone: ^0.10.0
   google_sign_in_web: ^0.12.4+4
   google_sign_in_platform_interface: ^2.5.0
   widgetbook: ^3.11.0
   widgetbook_annotation: ^3.3.0
   intl: ^0.20.2
+  js: ^0.6.7
 
   sign_in_with_apple: ^7.0.1
   permission_handler: ^12.0.1

--- a/test/core/services/alarm_scheduler_service_test.dart
+++ b/test/core/services/alarm_scheduler_service_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('on_time_front/native_alarm');
+  Map<String, dynamic>? pendingPayload;
+
+  setUp(() {
+    pendingPayload = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getLaunchPayload') {
+        final payload = pendingPayload;
+        pendingPayload = null;
+        return payload;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('initializeLaunchHandling dispatches cold-start alarm payload',
+      () async {
+    pendingPayload = {
+      'type': 'schedule_alarm',
+      'scheduleId': 'schedule-1',
+    };
+    final receivedPayloads = <Map<String, String>>[];
+
+    await AlarmSchedulerService().initializeLaunchHandling(
+      receivedPayloads.add,
+    );
+
+    expect(receivedPayloads, [
+      {
+        'type': 'schedule_alarm',
+        'scheduleId': 'schedule-1',
+      },
+    ]);
+  });
+
+  test('dispatchPendingLaunchPayload dispatches resumed alarm payload',
+      () async {
+    final receivedPayloads = <Map<String, String>>[];
+    final service = AlarmSchedulerService();
+    await service.initializeLaunchHandling(receivedPayloads.add);
+
+    pendingPayload = {
+      'type': 'schedule_alarm',
+      'scheduleId': 'schedule-2',
+    };
+    await service.dispatchPendingLaunchPayload();
+
+    expect(receivedPayloads, [
+      {
+        'type': 'schedule_alarm',
+        'scheduleId': 'schedule-2',
+      },
+    ]);
+  });
+}

--- a/test/data/data_sources/alarm_remote_data_source_test.dart
+++ b/test/data/data_sources/alarm_remote_data_source_test.dart
@@ -17,7 +17,8 @@ void main() {
   });
 
   group('postAlarmStatus', () {
-    test('posts backend enum format without retry on success', () async {
+    test('posts lower-camel backend contract without retry on success',
+        () async {
       when(
         dio.post<dynamic>(
           Endpoint.alarmStatus,
@@ -46,12 +47,13 @@ void main() {
       expect(options.validateStatus!(400), isTrue);
       expect(data.containsKey('permissionIssue'), isFalse);
       expect(data['reconciledAt'], '2026-05-05T09:00:00.000Z');
-      expect(data['status'], 'ARMED');
-      expect(data['nativeAlarmProvider'], 'IOS_ALARM_KIT');
-      expect(data['fallbackProvider'], 'LOCAL_NOTIFICATION');
+      expect(data['status'], 'armed');
+      expect(data['nativeAlarmProvider'], 'iosAlarmKit');
+      expect(data['fallbackProvider'], 'localNotification');
     });
 
-    test('falls back to lower-camel format after bad request', () async {
+    test('falls back to backend enum format after generic bad request',
+        () async {
       var callCount = 0;
       when(
         dio.post<dynamic>(
@@ -92,12 +94,12 @@ void main() {
       expect(firstOptions.validateStatus!(400), isTrue);
       expect(secondOptions.validateStatus!(400), isTrue);
       expect(firstData.containsKey('permissionIssue'), isFalse);
-      expect(firstData['status'], 'ARMED');
-      expect(firstData['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+      expect(firstData['status'], 'armed');
+      expect(firstData['nativeAlarmProvider'], 'iosAlarmKit');
       expect(secondData.containsKey('permissionIssue'), isFalse);
-      expect(secondData['status'], 'armed');
-      expect(secondData['nativeAlarmProvider'], 'iosAlarmKit');
-      expect(secondData['fallbackProvider'], 'localNotification');
+      expect(secondData['status'], 'ARMED');
+      expect(secondData['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+      expect(secondData['fallbackProvider'], 'LOCAL_NOTIFICATION');
     });
 
     test('does not retry semantic validation errors', () async {

--- a/test/data/data_sources/alarm_remote_data_source_test.dart
+++ b/test/data/data_sources/alarm_remote_data_source_test.dart
@@ -17,7 +17,41 @@ void main() {
   });
 
   group('postAlarmStatus', () {
-    test('retries with backend enum format after bad request', () async {
+    test('posts backend enum format without retry on success', () async {
+      when(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).thenAnswer(
+        (_) async => Response(
+          statusCode: 200,
+          requestOptions: RequestOptions(path: Endpoint.alarmStatus),
+        ),
+      );
+
+      await remoteDataSource.postAlarmStatus(_statusReport());
+
+      final verification = verify(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: captureAnyNamed('data'),
+          options: captureAnyNamed('options'),
+        ),
+      )..called(1);
+      final data = verification.captured[0] as Map<String, dynamic>;
+      final options = verification.captured[1] as Options;
+
+      expect(options.validateStatus!(400), isTrue);
+      expect(data.containsKey('permissionIssue'), isFalse);
+      expect(data['reconciledAt'], '2026-05-05T09:00:00.000Z');
+      expect(data['status'], 'ARMED');
+      expect(data['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+      expect(data['fallbackProvider'], 'LOCAL_NOTIFICATION');
+    });
+
+    test('falls back to lower-camel format after bad request', () async {
       var callCount = 0;
       when(
         dio.post<dynamic>(
@@ -58,12 +92,12 @@ void main() {
       expect(firstOptions.validateStatus!(400), isTrue);
       expect(secondOptions.validateStatus!(400), isTrue);
       expect(firstData.containsKey('permissionIssue'), isFalse);
-      expect(firstData['status'], 'armed');
-      expect(firstData['nativeAlarmProvider'], 'iosAlarmKit');
+      expect(firstData['status'], 'ARMED');
+      expect(firstData['nativeAlarmProvider'], 'IOS_ALARM_KIT');
       expect(secondData.containsKey('permissionIssue'), isFalse);
-      expect(secondData['status'], 'ARMED');
-      expect(secondData['nativeAlarmProvider'], 'IOS_ALARM_KIT');
-      expect(secondData['fallbackProvider'], 'LOCAL_NOTIFICATION');
+      expect(secondData['status'], 'armed');
+      expect(secondData['nativeAlarmProvider'], 'iosAlarmKit');
+      expect(secondData['fallbackProvider'], 'localNotification');
     });
 
     test('throws device session exception for inactive session', () async {
@@ -98,7 +132,7 @@ void main() {
 }
 
 AlarmStatusReport _statusReport() {
-  final now = DateTime(2026, 5, 5, 9);
+  final now = DateTime.utc(2026, 5, 5, 9);
   return AlarmStatusReport(
     deviceId: 'device-1',
     reconciledAt: now,

--- a/test/data/data_sources/alarm_remote_data_source_test.dart
+++ b/test/data/data_sources/alarm_remote_data_source_test.dart
@@ -100,6 +100,40 @@ void main() {
       expect(secondData['fallbackProvider'], 'localNotification');
     });
 
+    test('does not retry semantic validation errors', () async {
+      when(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).thenAnswer(
+        (_) async => Response(
+          statusCode: 400,
+          data: {
+            'status': 'error',
+            'code': 1002,
+            'message': 'invalid input',
+            'data': null,
+          },
+          requestOptions: RequestOptions(path: Endpoint.alarmStatus),
+        ),
+      );
+
+      expect(
+        () => remoteDataSource.postAlarmStatus(_statusReport()),
+        throwsException,
+      );
+
+      verify(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).called(1);
+    });
+
     test('throws device session exception for inactive session', () async {
       when(
         dio.post<dynamic>(

--- a/test/data/data_sources/alarm_remote_data_source_test.dart
+++ b/test/data/data_sources/alarm_remote_data_source_test.dart
@@ -1,0 +1,117 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:on_time_front/core/constants/endpoint.dart';
+import 'package:on_time_front/data/data_sources/alarm_remote_data_source.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+
+import '../../helpers/mock.mocks.dart';
+
+void main() {
+  late Dio dio;
+  late AlarmRemoteDataSourceImpl remoteDataSource;
+
+  setUp(() {
+    dio = MockAppDio();
+    remoteDataSource = AlarmRemoteDataSourceImpl(dio);
+  });
+
+  group('postAlarmStatus', () {
+    test('retries with backend enum format after bad request', () async {
+      var callCount = 0;
+      when(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).thenAnswer((_) async {
+        callCount += 1;
+        return Response(
+          statusCode: callCount == 1 ? 400 : 200,
+          data: callCount == 1
+              ? {
+                  'status': 'error',
+                  'code': 400,
+                  'message': 'bad request',
+                  'data': null,
+                }
+              : null,
+          requestOptions: RequestOptions(path: Endpoint.alarmStatus),
+        );
+      });
+
+      await remoteDataSource.postAlarmStatus(_statusReport());
+
+      final verification = verify(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: captureAnyNamed('data'),
+          options: captureAnyNamed('options'),
+        ),
+      )..called(2);
+      final firstData = verification.captured[0] as Map<String, dynamic>;
+      final firstOptions = verification.captured[1] as Options;
+      final secondData = verification.captured[2] as Map<String, dynamic>;
+      final secondOptions = verification.captured[3] as Options;
+
+      expect(firstOptions.validateStatus!(400), isTrue);
+      expect(secondOptions.validateStatus!(400), isTrue);
+      expect(firstData.containsKey('permissionIssue'), isFalse);
+      expect(firstData['status'], 'armed');
+      expect(firstData['nativeAlarmProvider'], 'iosAlarmKit');
+      expect(secondData.containsKey('permissionIssue'), isFalse);
+      expect(secondData['status'], 'ARMED');
+      expect(secondData['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+      expect(secondData['fallbackProvider'], 'LOCAL_NOTIFICATION');
+    });
+
+    test('throws device session exception for inactive session', () async {
+      when(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).thenAnswer(
+        (_) async => Response(
+          statusCode: 409,
+          data: {'code': 'DEVICE_SESSION_NOT_ACTIVE'},
+          requestOptions: RequestOptions(path: Endpoint.alarmStatus),
+        ),
+      );
+
+      expect(
+        () => remoteDataSource.postAlarmStatus(_statusReport()),
+        throwsA(isA<DeviceSessionNotActiveException>()),
+      );
+
+      verify(
+        dio.post<dynamic>(
+          Endpoint.alarmStatus,
+          data: anyNamed('data'),
+          options: anyNamed('options'),
+        ),
+      ).called(1);
+    });
+  });
+}
+
+AlarmStatusReport _statusReport() {
+  final now = DateTime(2026, 5, 5, 9);
+  return AlarmStatusReport(
+    deviceId: 'device-1',
+    reconciledAt: now,
+    scheduleWindowStart: now,
+    scheduleWindowEnd: now.add(const Duration(days: 8)),
+    alarmCoverageStart: now,
+    alarmCoverageEnd: now.add(const Duration(days: 7)),
+    status: AlarmReconciliationStatus.armed,
+    nativeAlarmProvider: AlarmProvider.iosAlarmKit,
+    fallbackProvider: AlarmProvider.localNotification,
+    armedScheduleCount: 1,
+    armedScheduleIds: const ['schedule-1'],
+    skippedScheduleCount: 0,
+    failures: const [],
+  );
+}

--- a/test/data/data_sources/schedule_remote_data_source_test.dart
+++ b/test/data/data_sources/schedule_remote_data_source_test.dart
@@ -4,7 +4,6 @@ import 'package:mockito/mockito.dart';
 import 'package:on_time_front/core/constants/endpoint.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
 import 'package:on_time_front/data/models/create_schedule_request_model.dart';
-import 'package:on_time_front/data/models/update_schedule_request_model.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:uuid/uuid.dart';
@@ -37,9 +36,6 @@ void main() {
 
   final tCreateScheduleModel =
       CreateScheduleRequestModel.fromEntity(tScheduleEntity);
-
-  final tUpdateScheduleModel =
-      UpdateScheduleRequestModel.fromEntity(tScheduleEntity);
 
   setUp(() {
     dio = MockAppDio();

--- a/test/data/models/alarm_models_test.dart
+++ b/test/data/models/alarm_models_test.dart
@@ -70,7 +70,7 @@ void main() {
 
   test('status report and registry record serialize alarm contract payloads',
       () {
-    final now = DateTime(2026, 5, 5, 9);
+    final now = DateTime(2026, 5, 5, 9, 0, 0, 123, 456);
     final statusJson = AlarmStatusReportModel(
       AlarmStatusReport(
         deviceId: 'device-1',
@@ -98,6 +98,7 @@ void main() {
 
     expect(statusJson['status'], 'partial');
     expect(statusJson['permissionIssue'], 'notificationPermissionDenied');
+    expect(statusJson['reconciledAt'], '2026-05-05T09:00:00.123');
     expect(statusJson['armedScheduleIds'], ['schedule-1']);
     expect((statusJson['failures'] as List).single['reason'], 'platformError');
 
@@ -122,5 +123,40 @@ void main() {
     expect(decoded.provider, AlarmProvider.localNotification);
     expect(decoded.payload['type'], 'schedule_alarm');
     expect(decoded.scheduleFingerprint, 'fingerprint');
+  });
+
+  test('status report omits null permission issue and supports backend enums',
+      () {
+    final now = DateTime(2026, 5, 5, 9);
+    final model = AlarmStatusReportModel(
+      AlarmStatusReport(
+        deviceId: 'device-1',
+        reconciledAt: now,
+        scheduleWindowStart: now,
+        scheduleWindowEnd: now.add(const Duration(days: 8)),
+        alarmCoverageStart: now,
+        alarmCoverageEnd: now.add(const Duration(days: 7)),
+        status: AlarmReconciliationStatus.armed,
+        nativeAlarmProvider: AlarmProvider.iosAlarmKit,
+        fallbackProvider: AlarmProvider.localNotification,
+        armedScheduleCount: 1,
+        armedScheduleIds: const ['schedule-1'],
+        skippedScheduleCount: 0,
+        failures: const [],
+      ),
+    );
+
+    final json = model.toJson();
+    expect(json.containsKey('permissionIssue'), isFalse);
+    expect(json['status'], 'armed');
+    expect(json['nativeAlarmProvider'], 'iosAlarmKit');
+
+    final backendJson = model.toJson(
+      wireFormat: AlarmStatusReportWireFormat.upperSnake,
+    );
+    expect(backendJson.containsKey('permissionIssue'), isFalse);
+    expect(backendJson['status'], 'ARMED');
+    expect(backendJson['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+    expect(backendJson['fallbackProvider'], 'LOCAL_NOTIFICATION');
   });
 }

--- a/test/data/models/alarm_models_test.dart
+++ b/test/data/models/alarm_models_test.dart
@@ -96,13 +96,13 @@ void main() {
       ),
     ).toJson();
 
-    expect(statusJson['status'], 'PARTIAL');
-    expect(statusJson['permissionIssue'], 'NOTIFICATION_PERMISSION_DENIED');
+    expect(statusJson['status'], 'partial');
+    expect(statusJson['permissionIssue'], 'notificationPermissionDenied');
     expect(statusJson['reconciledAt'], '2026-05-05T09:00:00.123Z');
     expect(statusJson['armedScheduleIds'], ['schedule-1']);
     expect(
       (statusJson['failures'] as List).single['reason'],
-      'PLATFORM_ERROR',
+      'platformError',
     );
 
     final recordJson = ScheduledAlarmRecordModel(
@@ -128,7 +128,7 @@ void main() {
     expect(decoded.scheduleFingerprint, 'fingerprint');
   });
 
-  test('status report defaults to backend enums and supports lower-camel', () {
+  test('status report defaults to lower-camel and supports backend enums', () {
     final now = DateTime.utc(2026, 5, 5, 9);
     final model = AlarmStatusReportModel(
       AlarmStatusReport(
@@ -151,15 +151,15 @@ void main() {
     final json = model.toJson();
     expect(json.containsKey('permissionIssue'), isFalse);
     expect(json['reconciledAt'], '2026-05-05T09:00:00.000Z');
-    expect(json['status'], 'ARMED');
-    expect(json['nativeAlarmProvider'], 'IOS_ALARM_KIT');
-    expect(json['fallbackProvider'], 'LOCAL_NOTIFICATION');
+    expect(json['status'], 'armed');
+    expect(json['nativeAlarmProvider'], 'iosAlarmKit');
+    expect(json['fallbackProvider'], 'localNotification');
 
-    final fallbackJson = model.toJson(
-      wireFormat: AlarmStatusReportWireFormat.lowerCamel,
+    final backendJson = model.toJson(
+      wireFormat: AlarmStatusReportWireFormat.upperSnake,
     );
-    expect(fallbackJson.containsKey('permissionIssue'), isFalse);
-    expect(fallbackJson['status'], 'armed');
-    expect(fallbackJson['nativeAlarmProvider'], 'iosAlarmKit');
+    expect(backendJson.containsKey('permissionIssue'), isFalse);
+    expect(backendJson['status'], 'ARMED');
+    expect(backendJson['nativeAlarmProvider'], 'IOS_ALARM_KIT');
   });
 }

--- a/test/data/models/alarm_models_test.dart
+++ b/test/data/models/alarm_models_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/data/models/alarm_device_model.dart';
+import 'package:on_time_front/data/models/alarm_settings_model.dart';
+import 'package:on_time_front/data/models/alarm_status_report_model.dart';
+import 'package:on_time_front/data/models/alarm_window_schedule_model.dart';
+import 'package:on_time_front/data/models/scheduled_alarm_record_model.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+
+void main() {
+  test('alarm settings maps backend defaults and update request JSON', () {
+    final model = AlarmSettingsModel.fromJson({
+      'alarmsEnabled': false,
+      'updatedAt': '2026-05-05T09:00:00.000',
+    });
+
+    expect(model.toEntity().alarmsEnabled, isFalse);
+    expect(model.toEntity().defaultAlarmOffsetMinutes, 5);
+    expect(const UpdateAlarmSettingsRequestModel(alarmsEnabled: true).toJson(),
+        {'alarmsEnabled': true});
+  });
+
+  test('device info serializes provider wire values', () {
+    final json = AlarmDeviceInfoModel.fromEntity(
+      const AlarmDeviceInfo(
+        deviceId: 'device-1',
+        platform: 'android',
+        appVersion: '1.0.0',
+        osVersion: 'android-35',
+        supportsNativeAlarm: true,
+        nativeAlarmProvider: AlarmProvider.androidAlarmManager,
+        fallbackProvider: AlarmProvider.localNotification,
+      ),
+    ).toJson();
+
+    expect(json['deviceId'], 'device-1');
+    expect(json['nativeAlarmProvider'], 'androidAlarmManager');
+    expect(json['fallbackProvider'], 'localNotification');
+  });
+
+  test('alarm window schedule maps backend schedule and preparation JSON', () {
+    final entity = AlarmWindowScheduleModel.fromJson({
+      'scheduleId': 'schedule-1',
+      'scheduleName': 'Morning meeting',
+      'place': {
+        'placeId': 'place-1',
+        'placeName': 'Office',
+      },
+      'scheduleTime': '2026-05-05T10:00:00.000',
+      'moveTime': 20,
+      'scheduleSpareTime': 10,
+      'doneStatus': 'NOT_ENDED',
+      'preparations': [
+        {
+          'preparationId': 'prep-1',
+          'preparationName': 'Shower',
+          'preparationTime': 15,
+          'nextPreparationId': 'prep-2',
+        },
+      ],
+    }).toEntity();
+
+    expect(entity.id, 'schedule-1');
+    expect(entity.place.placeName, 'Office');
+    expect(entity.doneStatus, ScheduleDoneStatus.notEnded);
+    expect(entity.moveTime, const Duration(minutes: 20));
+    expect(entity.preparation.preparationStepList.single.nextPreparationId,
+        'prep-2');
+  });
+
+  test('status report and registry record serialize alarm contract payloads',
+      () {
+    final now = DateTime(2026, 5, 5, 9);
+    final statusJson = AlarmStatusReportModel(
+      AlarmStatusReport(
+        deviceId: 'device-1',
+        reconciledAt: now,
+        scheduleWindowStart: now,
+        scheduleWindowEnd: now.add(const Duration(days: 8)),
+        alarmCoverageStart: now,
+        alarmCoverageEnd: now.add(const Duration(days: 7)),
+        status: AlarmReconciliationStatus.partial,
+        permissionIssue: AlarmPermissionIssue.notificationPermissionDenied,
+        nativeAlarmProvider: AlarmProvider.none,
+        fallbackProvider: AlarmProvider.localNotification,
+        armedScheduleCount: 1,
+        armedScheduleIds: const ['schedule-1'],
+        skippedScheduleCount: 2,
+        failures: const [
+          AlarmFailure(
+            scheduleId: 'schedule-2',
+            reason: AlarmFailureReason.platformError,
+            message: 'failed',
+          ),
+        ],
+      ),
+    ).toJson();
+
+    expect(statusJson['status'], 'partial');
+    expect(statusJson['permissionIssue'], 'notificationPermissionDenied');
+    expect(statusJson['armedScheduleIds'], ['schedule-1']);
+    expect((statusJson['failures'] as List).single['reason'], 'platformError');
+
+    final recordJson = ScheduledAlarmRecordModel(
+      ScheduledAlarmRecord(
+        scheduleId: 'schedule-1',
+        alarmTime: now,
+        preparationStartTime: now.add(const Duration(minutes: 5)),
+        scheduleFingerprint: 'fingerprint',
+        nativeAlarmId: 123,
+        fallbackNotificationId: 123,
+        provider: AlarmProvider.localNotification,
+        scheduleTitle: 'Morning meeting',
+        payload: const {
+          'type': 'schedule_alarm',
+          'scheduleId': 'schedule-1',
+        },
+      ),
+    ).toJson();
+
+    final decoded = ScheduledAlarmRecordModel.fromJson(recordJson).record;
+    expect(decoded.provider, AlarmProvider.localNotification);
+    expect(decoded.payload['type'], 'schedule_alarm');
+    expect(decoded.scheduleFingerprint, 'fingerprint');
+  });
+}

--- a/test/data/models/alarm_models_test.dart
+++ b/test/data/models/alarm_models_test.dart
@@ -70,7 +70,7 @@ void main() {
 
   test('status report and registry record serialize alarm contract payloads',
       () {
-    final now = DateTime(2026, 5, 5, 9, 0, 0, 123, 456);
+    final now = DateTime.utc(2026, 5, 5, 9, 0, 0, 123, 456);
     final statusJson = AlarmStatusReportModel(
       AlarmStatusReport(
         deviceId: 'device-1',
@@ -96,11 +96,14 @@ void main() {
       ),
     ).toJson();
 
-    expect(statusJson['status'], 'partial');
-    expect(statusJson['permissionIssue'], 'notificationPermissionDenied');
-    expect(statusJson['reconciledAt'], '2026-05-05T09:00:00.123');
+    expect(statusJson['status'], 'PARTIAL');
+    expect(statusJson['permissionIssue'], 'NOTIFICATION_PERMISSION_DENIED');
+    expect(statusJson['reconciledAt'], '2026-05-05T09:00:00.123Z');
     expect(statusJson['armedScheduleIds'], ['schedule-1']);
-    expect((statusJson['failures'] as List).single['reason'], 'platformError');
+    expect(
+      (statusJson['failures'] as List).single['reason'],
+      'PLATFORM_ERROR',
+    );
 
     final recordJson = ScheduledAlarmRecordModel(
       ScheduledAlarmRecord(
@@ -125,9 +128,8 @@ void main() {
     expect(decoded.scheduleFingerprint, 'fingerprint');
   });
 
-  test('status report omits null permission issue and supports backend enums',
-      () {
-    final now = DateTime(2026, 5, 5, 9);
+  test('status report defaults to backend enums and supports lower-camel', () {
+    final now = DateTime.utc(2026, 5, 5, 9);
     final model = AlarmStatusReportModel(
       AlarmStatusReport(
         deviceId: 'device-1',
@@ -148,15 +150,16 @@ void main() {
 
     final json = model.toJson();
     expect(json.containsKey('permissionIssue'), isFalse);
-    expect(json['status'], 'armed');
-    expect(json['nativeAlarmProvider'], 'iosAlarmKit');
+    expect(json['reconciledAt'], '2026-05-05T09:00:00.000Z');
+    expect(json['status'], 'ARMED');
+    expect(json['nativeAlarmProvider'], 'IOS_ALARM_KIT');
+    expect(json['fallbackProvider'], 'LOCAL_NOTIFICATION');
 
-    final backendJson = model.toJson(
-      wireFormat: AlarmStatusReportWireFormat.upperSnake,
+    final fallbackJson = model.toJson(
+      wireFormat: AlarmStatusReportWireFormat.lowerCamel,
     );
-    expect(backendJson.containsKey('permissionIssue'), isFalse);
-    expect(backendJson['status'], 'ARMED');
-    expect(backendJson['nativeAlarmProvider'], 'IOS_ALARM_KIT');
-    expect(backendJson['fallbackProvider'], 'LOCAL_NOTIFICATION');
+    expect(fallbackJson.containsKey('permissionIssue'), isFalse);
+    expect(fallbackJson['status'], 'armed');
+    expect(fallbackJson['nativeAlarmProvider'], 'iosAlarmKit');
   });
 }

--- a/test/data/repositories/preparation_repository_impl_test.dart
+++ b/test/data/repositories/preparation_repository_impl_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:on_time_front/data/models/create_defualt_preparation_request_model.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
 import 'package:uuid/uuid.dart';
@@ -15,9 +14,6 @@ void main() {
   late MockPreparationLocalDataSource mockPreparationLocalDataSource;
 
   final uuid = Uuid();
-
-  final scheduleEntityId = uuid.v7();
-  final preparationStepEntityId = uuid.v7();
 
   final tPreparationStepList = [
     PreparationStepEntity(
@@ -41,28 +37,6 @@ void main() {
     nextPreparationId: tPreparationStepList[1].id,
   );
 
-  final tLocalPreparationStepList = [
-    PreparationStepEntity(
-      id: uuid.v7(),
-      preparationName: 'Meeting A Friend Local',
-      preparationTime: Duration(minutes: 10),
-      nextPreparationId: null, // 이후에 설정
-    ),
-    PreparationStepEntity(
-      id: uuid.v7(),
-      preparationName: 'Museum Tour Local',
-      preparationTime: Duration(minutes: 30),
-      nextPreparationId: null, // 이후에 설정
-    ),
-  ];
-
-  tLocalPreparationStepList[0] = PreparationStepEntity(
-    id: tLocalPreparationStepList[0].id,
-    preparationName: tLocalPreparationStepList[0].preparationName,
-    preparationTime: tLocalPreparationStepList[0].preparationTime,
-    nextPreparationId: tLocalPreparationStepList[1].id,
-  );
-
   final tPreparationStep = PreparationStepEntity(
     id: uuid.v7(),
     preparationName: 'Dress Up',
@@ -70,25 +44,8 @@ void main() {
     nextPreparationId: null,
   );
 
-  final tLocalPreparationStep = PreparationStepEntity(
-    id: uuid.v7(),
-    preparationName: 'Dress Up Local',
-    preparationTime: Duration(minutes: 15),
-    nextPreparationId: null,
-  );
-
   final tPreparationEntity =
       PreparationEntity(preparationStepList: [tPreparationStep]);
-
-  final tLocalPreparationEntity =
-      PreparationEntity(preparationStepList: [tLocalPreparationStep]);
-
-  final tCreateDefaultPreparationRequestModel =
-      CreateDefaultPreparationRequestModel.fromEntity(
-    preparationEntity: tPreparationEntity,
-    spareTime: Duration(minutes: 10),
-    note: 'Note',
-  );
 
   setUp(() {
     mockPreparationRemoteDataSource = MockPreparationRemoteDataSource();

--- a/test/domain/use-cases/get_nearest_upcoming_schedule_use_case_test.dart
+++ b/test/domain/use-cases/get_nearest_upcoming_schedule_use_case_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/use-cases/get_nearest_upcoming_schedule_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_schedules_by_date_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_schedules_for_week_use_case.dart';
+
+class StubGetSchedulesByDateUseCase implements GetSchedulesByDateUseCase {
+  StubGetSchedulesByDateUseCase(this.handler);
+  final Stream<List<ScheduleEntity>> Function(DateTime, DateTime) handler;
+
+  @override
+  Stream<List<ScheduleEntity>> call(DateTime startDate, DateTime endDate) {
+    return handler(startDate, endDate);
+  }
+}
+
+class StubLoadPreparationByScheduleIdUseCase
+    implements LoadPreparationByScheduleIdUseCase {
+  @override
+  Future<void> call(String scheduleId) async {}
+}
+
+class StubGetPreparationByScheduleIdUseCase
+    implements GetPreparationByScheduleIdUseCase {
+  @override
+  Future<PreparationEntity> call(String scheduleId) async {
+    return const PreparationEntity(preparationStepList: []);
+  }
+}
+
+class StubLoadSchedulesForWeekUseCase implements LoadSchedulesForWeekUseCase {
+  StubLoadSchedulesForWeekUseCase(this.handler);
+  final Future<void> Function(DateTime date) handler;
+
+  @override
+  Future<void> call(DateTime date) {
+    return handler(date);
+  }
+}
+
+void main() {
+  test('swallows background week load failures before streaming cache',
+      () async {
+    final useCase = GetNearestUpcomingScheduleUseCase(
+      StubGetSchedulesByDateUseCase(
+        (_, __) => Stream.value(const <ScheduleEntity>[]),
+      ),
+      StubLoadPreparationByScheduleIdUseCase(),
+      StubGetPreparationByScheduleIdUseCase(),
+      StubLoadSchedulesForWeekUseCase(
+        (_) async => throw Exception('unauthorized'),
+      ),
+    );
+
+    await expectLater(useCase(), emitsInOrder([null, emitsDone]));
+  });
+}

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -1,0 +1,514 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
+import 'package:on_time_front/domain/entities/user_entity.dart';
+import 'package:on_time_front/domain/repositories/alarm_registry_repository.dart';
+import 'package:on_time_front/domain/repositories/alarm_repository.dart';
+import 'package:on_time_front/domain/repositories/user_repository.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+
+class FakeAlarmRepository implements AlarmRepository {
+  AlarmSettings settings = const AlarmSettings(alarmsEnabled: true);
+  bool throwSettings = false;
+  List<ScheduleWithPreparationEntity> schedules = [];
+  DateTime? requestedWindowStart;
+  DateTime? requestedWindowEnd;
+  final statusReports = <AlarmStatusReport>[];
+  final registeredDevices = <AlarmDeviceInfo>[];
+  final updatedSettings = <bool>[];
+  bool throwDeviceSessionNotActiveOnStatus = false;
+
+  @override
+  Future<String> getDeviceId() async => 'device-1';
+
+  @override
+  Future<AlarmDeviceInfo> buildCurrentDeviceInfo() async {
+    return const AlarmDeviceInfo(
+      deviceId: 'device-1',
+      platform: 'android',
+      appVersion: '1.0.0',
+      osVersion: 'android',
+      supportsNativeAlarm: true,
+      nativeAlarmProvider: AlarmProvider.androidAlarmManager,
+      fallbackProvider: AlarmProvider.localNotification,
+    );
+  }
+
+  @override
+  Future<AlarmSettings> getAlarmSettings() async {
+    if (throwSettings) {
+      throw Exception('settings unavailable');
+    }
+    return settings;
+  }
+
+  @override
+  Future<AlarmSettings> updateAlarmSettings({
+    required bool alarmsEnabled,
+  }) async {
+    updatedSettings.add(alarmsEnabled);
+    settings = AlarmSettings(alarmsEnabled: alarmsEnabled);
+    return settings;
+  }
+
+  @override
+  Future<void> registerCurrentDevice(AlarmDeviceInfo deviceInfo) async {
+    registeredDevices.add(deviceInfo);
+  }
+
+  @override
+  Future<void> unregisterCurrentDevice(String deviceId) async {}
+
+  @override
+  Future<List<ScheduleWithPreparationEntity>> getAlarmWindow(
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
+    requestedWindowStart = startDate;
+    requestedWindowEnd = endDate;
+    return schedules;
+  }
+
+  @override
+  Future<void> postAlarmStatus(AlarmStatusReport report) async {
+    if (throwDeviceSessionNotActiveOnStatus) {
+      throw const DeviceSessionNotActiveException();
+    }
+    statusReports.add(report);
+  }
+}
+
+class FakeAlarmRegistryRepository implements AlarmRegistryRepository {
+  List<ScheduledAlarmRecord> records = [];
+
+  @override
+  Future<List<ScheduledAlarmRecord>> loadAll() async => List.of(records);
+
+  @override
+  Future<void> upsert(ScheduledAlarmRecord record) async {
+    records = records
+        .where((existing) => existing.scheduleId != record.scheduleId)
+        .toList()
+      ..add(record);
+  }
+
+  @override
+  Future<void> deleteByScheduleId(String scheduleId) async {
+    records =
+        records.where((record) => record.scheduleId != scheduleId).toList();
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    records = [];
+  }
+
+  @override
+  Future<void> replaceAll(List<ScheduledAlarmRecord> records) async {
+    this.records = List.of(records);
+  }
+}
+
+class FakeAlarmSchedulerService implements AlarmSchedulerService {
+  AlarmSchedulerCapabilities capabilities = const AlarmSchedulerCapabilities(
+    supportsNativeAlarm: true,
+    nativeAlarmProvider: AlarmProvider.androidAlarmManager,
+  );
+  AlarmPermissionState nativePermission = AlarmPermissionState.granted;
+  final scheduledNative = <ScheduledAlarmRecord>[];
+  final canceledNative = <ScheduledAlarmRecord>[];
+  final throwOnScheduleIds = <String>{};
+
+  @override
+  Future<AlarmSchedulerCapabilities> getCapabilities() async => capabilities;
+
+  @override
+  Future<AlarmPermissionState> checkPermission() async => nativePermission;
+
+  @override
+  Future<AlarmPermissionState> requestPermission() async => nativePermission;
+
+  @override
+  Future<void> scheduleNativeAlarm(ScheduledAlarmRecord record) async {
+    if (throwOnScheduleIds.contains(record.scheduleId)) {
+      throw const AlarmSchedulingException(
+        reason: AlarmFailureReason.platformError,
+        message: 'native failure',
+      );
+    }
+    scheduledNative.add(record);
+  }
+
+  @override
+  Future<void> cancelNativeAlarm(ScheduledAlarmRecord record) async {
+    canceledNative.add(record);
+  }
+
+  @override
+  Future<void> cancelAllNativeAlarms(
+    List<ScheduledAlarmRecord> records,
+  ) async {
+    canceledNative.addAll(records);
+  }
+
+  @override
+  Future<void> initializeLaunchHandling(
+    AlarmLaunchPayloadHandler onPayload,
+  ) async {}
+}
+
+class FakeFallbackAlarmNotificationService
+    implements FallbackAlarmNotificationService {
+  AlarmPermissionState permission = AlarmPermissionState.denied;
+  final scheduledFallback = <ScheduledAlarmRecord>[];
+  final canceledFallback = <ScheduledAlarmRecord>[];
+
+  @override
+  Future<AlarmPermissionState> checkPermission() async => permission;
+
+  @override
+  Future<AlarmPermissionState> requestPermission() async => permission;
+
+  @override
+  Future<void> scheduleFallbackAlarm(ScheduledAlarmRecord record) async {
+    scheduledFallback.add(record);
+  }
+
+  @override
+  Future<void> cancelFallbackAlarm(ScheduledAlarmRecord record) async {
+    canceledFallback.add(record);
+  }
+}
+
+class FakeUserRepository implements UserRepository {
+  bool signedOut = false;
+
+  @override
+  Stream<UserEntity> get userStream => const Stream.empty();
+
+  @override
+  GoogleSignIn get googleSignIn => throw UnimplementedError();
+
+  @override
+  Future<void> signOut() async {
+    signedOut = true;
+  }
+
+  @override
+  Future<void> deleteAppleUser() => throw UnimplementedError();
+
+  @override
+  Future<void> deleteGoogleUser() => throw UnimplementedError();
+
+  @override
+  Future<void> deleteUser() => throw UnimplementedError();
+
+  @override
+  Future<void> disconnectGoogleSignIn() => throw UnimplementedError();
+
+  @override
+  Future<void> getUser() => throw UnimplementedError();
+
+  @override
+  Future<String?> getUserSocialType() => throw UnimplementedError();
+
+  @override
+  Future<void> postFeedback(String message) => throw UnimplementedError();
+
+  @override
+  Future<void> signIn({
+    required String email,
+    required String password,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signInWithApple({
+    required String idToken,
+    required String authCode,
+    required String fullName,
+    String? email,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signInWithGoogle(GoogleSignInAccount account) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signUp({
+    required String email,
+    required String password,
+    required String name,
+  }) =>
+      throw UnimplementedError();
+}
+
+void main() {
+  late DateTime now;
+  late FakeAlarmRepository alarmRepository;
+  late FakeAlarmRegistryRepository registryRepository;
+  late FakeAlarmSchedulerService schedulerService;
+  late FakeFallbackAlarmNotificationService fallbackService;
+  late FakeUserRepository userRepository;
+  late ReconcileAlarmsUseCase useCase;
+
+  setUp(() {
+    now = DateTime(2026, 5, 5, 9, 0);
+    alarmRepository = FakeAlarmRepository();
+    registryRepository = FakeAlarmRegistryRepository();
+    schedulerService = FakeAlarmSchedulerService();
+    fallbackService = FakeFallbackAlarmNotificationService();
+    userRepository = FakeUserRepository();
+    useCase = ReconcileAlarmsUseCase.test(
+      alarmRepository,
+      registryRepository,
+      schedulerService,
+      fallbackService,
+      nowProvider: () => now,
+      userRepository: userRepository,
+    );
+  });
+
+  test('requests padded window and schedules only eligible 7-day alarms',
+      () async {
+    final eligible = scheduleWithAlarmAt(
+      id: 'eligible',
+      alarmTime: now.add(const Duration(hours: 1)),
+    );
+    final past = scheduleWithAlarmAt(
+      id: 'past',
+      alarmTime: now.subtract(const Duration(minutes: 1)),
+    );
+    final outsideCoverage = scheduleWithAlarmAt(
+      id: 'outside',
+      alarmTime: now.add(const Duration(days: 7, minutes: 1)),
+    );
+    final ended = scheduleWithAlarmAt(
+      id: 'ended',
+      alarmTime: now.add(const Duration(hours: 2)),
+      doneStatus: ScheduleDoneStatus.normalEnd,
+    );
+    alarmRepository.schedules = [
+      eligible,
+      past,
+      outsideCoverage,
+      ended,
+    ];
+
+    final result = await useCase();
+
+    expect(alarmRepository.requestedWindowStart, now);
+    expect(
+      alarmRepository.requestedWindowEnd,
+      now.add(const Duration(days: 8)),
+    );
+    expect(
+      schedulerService.scheduledNative.map((record) => record.scheduleId),
+      ['eligible'],
+    );
+    expect(result.armedScheduleIds, ['eligible']);
+    expect(result.skippedScheduleCount, 3);
+    expect(result.alarmCoverageEnd, now.add(const Duration(days: 7)));
+    expect(registryRepository.records.single.scheduleId, 'eligible');
+  });
+
+  test('cancels stale record before rescheduling changed fingerprint',
+      () async {
+    final changed = scheduleWithAlarmAt(
+      id: 'changed',
+      alarmTime: now.add(const Duration(hours: 1)),
+      preparationName: 'Updated',
+    );
+    final desiredRecord = buildScheduledAlarmRecord(
+      changed,
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.androidAlarmManager,
+    );
+    final staleRecord = ScheduledAlarmRecord(
+      scheduleId: desiredRecord.scheduleId,
+      alarmTime: desiredRecord.alarmTime,
+      preparationStartTime: desiredRecord.preparationStartTime,
+      scheduleFingerprint: 'old-fingerprint',
+      nativeAlarmId: desiredRecord.nativeAlarmId,
+      fallbackNotificationId: desiredRecord.fallbackNotificationId,
+      provider: AlarmProvider.androidAlarmManager,
+      scheduleTitle: desiredRecord.scheduleTitle,
+      payload: desiredRecord.payload,
+    );
+    registryRepository.records = [staleRecord];
+    alarmRepository.schedules = [changed];
+
+    await useCase();
+
+    expect(schedulerService.canceledNative.single.scheduleId, 'changed');
+    expect(schedulerService.scheduledNative.single.scheduleId, 'changed');
+    expect(
+      registryRepository.records.single.scheduleFingerprint,
+      desiredRecord.scheduleFingerprint,
+    );
+  });
+
+  test('uses local notification fallback when native alarms are unsupported',
+      () async {
+    schedulerService.capabilities = const AlarmSchedulerCapabilities(
+      supportsNativeAlarm: false,
+      nativeAlarmProvider: AlarmProvider.none,
+      fallbackProvider: AlarmProvider.localNotification,
+    );
+    schedulerService.nativePermission = AlarmPermissionState.unsupported;
+    fallbackService.permission = AlarmPermissionState.granted;
+    alarmRepository.schedules = [
+      scheduleWithAlarmAt(
+        id: 'fallback',
+        alarmTime: now.add(const Duration(hours: 1)),
+      ),
+    ];
+
+    final result = await useCase();
+
+    expect(schedulerService.scheduledNative, isEmpty);
+    expect(fallbackService.scheduledFallback.single.scheduleId, 'fallback');
+    expect(
+      registryRepository.records.single.provider,
+      AlarmProvider.localNotification,
+    );
+    expect(result.status, AlarmReconciliationStatus.armed);
+    expect(result.fallbackProvider, AlarmProvider.localNotification);
+  });
+
+  test('settingsUnavailable reports without canceling existing registry',
+      () async {
+    alarmRepository.throwSettings = true;
+    final existing = buildScheduledAlarmRecord(
+      scheduleWithAlarmAt(
+        id: 'existing',
+        alarmTime: now.add(const Duration(hours: 1)),
+      ),
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.androidAlarmManager,
+    );
+    registryRepository.records = [existing];
+
+    final result = await useCase();
+
+    expect(result.status, AlarmReconciliationStatus.settingsUnavailable);
+    expect(schedulerService.canceledNative, isEmpty);
+    expect(registryRepository.records, [existing]);
+    expect(alarmRepository.statusReports.single.status,
+        AlarmReconciliationStatus.settingsUnavailable);
+  });
+
+  test('global disabled cancels all local alarms and clears registry',
+      () async {
+    alarmRepository.settings = const AlarmSettings(alarmsEnabled: false);
+    final native = buildScheduledAlarmRecord(
+      scheduleWithAlarmAt(
+        id: 'native',
+        alarmTime: now.add(const Duration(hours: 1)),
+      ),
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.androidAlarmManager,
+    );
+    final fallback = buildScheduledAlarmRecord(
+      scheduleWithAlarmAt(
+        id: 'fallback',
+        alarmTime: now.add(const Duration(hours: 2)),
+      ),
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.localNotification,
+    );
+    registryRepository.records = [native, fallback];
+
+    final result = await useCase();
+
+    expect(result.status, AlarmReconciliationStatus.disabled);
+    expect(schedulerService.canceledNative, [native]);
+    expect(fallbackService.canceledFallback, [fallback]);
+    expect(registryRepository.records, isEmpty);
+  });
+
+  test('reports partial when scheduling a desired alarm fails', () async {
+    final failing = scheduleWithAlarmAt(
+      id: 'failing',
+      alarmTime: now.add(const Duration(hours: 1)),
+    );
+    alarmRepository.schedules = [failing];
+    schedulerService.throwOnScheduleIds.add('failing');
+    fallbackService.permission = AlarmPermissionState.denied;
+
+    final result = await useCase();
+
+    expect(result.status, AlarmReconciliationStatus.partial);
+    expect(result.failures.single.scheduleId, 'failing');
+    expect(result.failures.single.reason, AlarmFailureReason.platformError);
+    expect(registryRepository.records, isEmpty);
+  });
+
+  test('session invalidation cancels alarms, clears registry, and signs out',
+      () async {
+    final existing = buildScheduledAlarmRecord(
+      scheduleWithAlarmAt(
+        id: 'old-device',
+        alarmTime: now.add(const Duration(hours: 1)),
+      ),
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.androidAlarmManager,
+    );
+    registryRepository.records = [existing];
+    alarmRepository.throwDeviceSessionNotActiveOnStatus = true;
+
+    await useCase();
+
+    expect(schedulerService.canceledNative, [existing]);
+    expect(registryRepository.records, isEmpty);
+    expect(userRepository.signedOut, isTrue);
+  });
+}
+
+ScheduleWithPreparationEntity scheduleWithAlarmAt({
+  required String id,
+  required DateTime alarmTime,
+  ScheduleDoneStatus doneStatus = ScheduleDoneStatus.notEnded,
+  String preparationName = 'Shower',
+}) {
+  const offset = Duration(minutes: 5);
+  const moveTime = Duration(minutes: 10);
+  const spareTime = Duration(minutes: 5);
+  const preparationTime = Duration(minutes: 30);
+  final preparationStartTime = alarmTime.add(offset);
+  final scheduleTime = preparationStartTime.add(
+    moveTime + spareTime + preparationTime,
+  );
+  return ScheduleWithPreparationEntity(
+    id: id,
+    place: const PlaceEntity(id: 'place-1', placeName: 'Office'),
+    scheduleName: 'Schedule $id',
+    scheduleTime: scheduleTime,
+    moveTime: moveTime,
+    isChanged: false,
+    isStarted: false,
+    scheduleSpareTime: spareTime,
+    scheduleNote: '',
+    doneStatus: doneStatus,
+    preparation: PreparationWithTimeEntity.fromPreparation(
+      PreparationEntity(
+        preparationStepList: [
+          PreparationStepEntity(
+            id: 'step-$id',
+            preparationName: preparationName,
+            preparationTime: preparationTime,
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -385,6 +385,43 @@ void main() {
     );
   });
 
+  test('reschedules stale record with old alarm launch payload version',
+      () async {
+    final schedule = scheduleWithAlarmAt(
+      id: 'old-payload',
+      alarmTime: now.add(const Duration(hours: 1)),
+    );
+    final desiredRecord = buildScheduledAlarmRecord(
+      schedule,
+      alarmOffset: const Duration(minutes: 5),
+      provider: AlarmProvider.androidAlarmManager,
+    );
+    final stalePayload = Map<String, String>.from(desiredRecord.payload)
+      ..remove('alarmLaunchPayloadVersion');
+    final staleRecord = ScheduledAlarmRecord(
+      scheduleId: desiredRecord.scheduleId,
+      alarmTime: desiredRecord.alarmTime,
+      preparationStartTime: desiredRecord.preparationStartTime,
+      scheduleFingerprint: desiredRecord.scheduleFingerprint,
+      nativeAlarmId: desiredRecord.nativeAlarmId,
+      fallbackNotificationId: desiredRecord.fallbackNotificationId,
+      provider: AlarmProvider.androidAlarmManager,
+      scheduleTitle: desiredRecord.scheduleTitle,
+      payload: stalePayload,
+    );
+    registryRepository.records = [staleRecord];
+    alarmRepository.schedules = [schedule];
+
+    await useCase();
+
+    expect(schedulerService.canceledNative.single.scheduleId, 'old-payload');
+    expect(schedulerService.scheduledNative.single.scheduleId, 'old-payload');
+    expect(
+      registryRepository.records.single.payload['alarmLaunchPayloadVersion'],
+      alarmLaunchPayloadVersion,
+    );
+  });
+
   test('uses local notification fallback when native alarms are unsupported',
       () async {
     schedulerService.capabilities = const AlarmSchedulerCapabilities(

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -318,6 +318,12 @@ void main() {
       ['eligible'],
     );
     expect(result.armedScheduleIds, ['eligible']);
+    expect(result.nativeAlarmProvider, AlarmProvider.androidAlarmManager);
+    expect(result.fallbackProvider, AlarmProvider.none);
+    expect(alarmRepository.statusReports.single.nativeAlarmProvider,
+        AlarmProvider.androidAlarmManager);
+    expect(alarmRepository.statusReports.single.fallbackProvider,
+        AlarmProvider.none);
     expect(result.skippedScheduleCount, 3);
     expect(result.alarmCoverageEnd, now.add(const Duration(days: 7)));
     expect(registryRepository.records.single.scheduleId, 'eligible');

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -25,6 +25,7 @@ class FakeAlarmRepository implements AlarmRepository {
   final registeredDevices = <AlarmDeviceInfo>[];
   final updatedSettings = <bool>[];
   bool throwDeviceSessionNotActiveOnStatus = false;
+  int alarmWindowRequestCount = 0;
 
   @override
   Future<String> getDeviceId() async => 'device-1';
@@ -72,6 +73,7 @@ class FakeAlarmRepository implements AlarmRepository {
     DateTime startDate,
     DateTime endDate,
   ) async {
+    alarmWindowRequestCount += 1;
     requestedWindowStart = startDate;
     requestedWindowEnd = endDate;
     return schedules;
@@ -319,6 +321,23 @@ void main() {
     expect(result.skippedScheduleCount, 3);
     expect(result.alarmCoverageEnd, now.add(const Duration(days: 7)));
     expect(registryRepository.records.single.scheduleId, 'eligible');
+  });
+
+  test('coalesces overlapping reconciliation requests', () async {
+    alarmRepository.schedules = [
+      scheduleWithAlarmAt(
+        id: 'eligible',
+        alarmTime: now.add(const Duration(hours: 1)),
+      ),
+    ];
+
+    final results = await Future.wait([useCase(), useCase()]);
+
+    expect(results[0], results[1]);
+    expect(alarmRepository.alarmWindowRequestCount, 1);
+    expect(alarmRepository.registeredDevices.length, 1);
+    expect(alarmRepository.statusReports.length, 1);
+    expect(schedulerService.scheduledNative.length, 1);
   });
 
   test('cancels stale record before rescheduling changed fingerprint',

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -165,6 +165,9 @@ class FakeAlarmSchedulerService implements AlarmSchedulerService {
   Future<void> initializeLaunchHandling(
     AlarmLaunchPayloadHandler onPayload,
   ) async {}
+
+  @override
+  Future<void> dispatchPendingLaunchPayload() async {}
 }
 
 class FakeFallbackAlarmNotificationService

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -1027,20 +1027,20 @@ void main() {
       );
 
       expect(
-        continuingTheme.colorScheme.primary.value,
-        const Color(0xFF5C79FB).value,
+        continuingTheme.colorScheme.primary.toARGB32(),
+        const Color(0xFF5C79FB).toARGB32(),
       );
       expect(
-        continuingTheme.colorScheme.primaryContainer.value,
-        const Color(0xFFDCE3FF).value,
+        continuingTheme.colorScheme.primaryContainer.toARGB32(),
+        const Color(0xFFDCE3FF).toARGB32(),
       );
       expect(
-        continuingTheme.colorScheme.onPrimaryContainer.value,
-        const Color(0xFF212F6F).value,
+        continuingTheme.colorScheme.onPrimaryContainer.toARGB32(),
+        const Color(0xFF212F6F).toARGB32(),
       );
       expect(
-        continuingScaffold.backgroundColor!.value,
-        const Color(0xFF5C79FB).value,
+        continuingScaffold.backgroundColor!.toARGB32(),
+        const Color(0xFF5C79FB).toARGB32(),
       );
       expect(find.text('EARLYLATE'), findsNothing);
       expect(find.text('Ready to go'), findsOneWidget);
@@ -1202,20 +1202,20 @@ void main() {
       );
 
       expect(
-        lateTheme.colorScheme.primary.value,
-        const Color(0xFFFF6953).value,
+        lateTheme.colorScheme.primary.toARGB32(),
+        const Color(0xFFFF6953).toARGB32(),
       );
       expect(
-        lateTheme.colorScheme.primaryContainer.value,
-        const Color(0xFFFFEAE7).value,
+        lateTheme.colorScheme.primaryContainer.toARGB32(),
+        const Color(0xFFFFEAE7).toARGB32(),
       );
       expect(
-        lateTheme.colorScheme.onPrimaryContainer.value,
-        const Color(0xFFFF6953).value,
+        lateTheme.colorScheme.onPrimaryContainer.toARGB32(),
+        const Color(0xFFFF6953).toARGB32(),
       );
       expect(
-        lateScaffold.backgroundColor!.value,
-        const Color(0xFFFF6953).value,
+        lateScaffold.backgroundColor!.toARGB32(),
+        const Color(0xFFFF6953).toARGB32(),
       );
       expect(
         tester
@@ -1227,15 +1227,15 @@ void main() {
         tester
             .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
             .backgroundColor
-            .value,
-        const Color(0xFFFFEAE7).value,
+            .toARGB32(),
+        const Color(0xFFFFEAE7).toARGB32(),
       );
       expect(
         tester
             .widget<AlarmGraphAnimator>(find.byType(AlarmGraphAnimator))
             .progressColor
-            .value,
-        const Color(0xFFFFEAE7).value,
+            .toARGB32(),
+        const Color(0xFFFFEAE7).toARGB32(),
       );
       expect(find.text('준비시간을 1분 초과했어요'), findsOneWidget);
       expect(find.text('지각이에요'), findsOneWidget);

--- a/test/presentation/app/bloc/schedule/schedule_bloc_test.dart
+++ b/test/presentation/app/bloc/schedule/schedule_bloc_test.dart
@@ -633,6 +633,51 @@ void main() {
           markEarlySessionUseCase.sessions.containsKey('early-start'), isTrue);
     });
 
+    test('future upcoming schedule stops active preparation timer', () async {
+      final active = buildSchedule(
+        id: 'active',
+        scheduleTime: now.add(const Duration(hours: 1)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'a',
+            preparationName: 'a',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+      final future = buildSchedule(
+        id: 'future',
+        scheduleTime: now.add(const Duration(hours: 2)),
+        steps: const [
+          PreparationStepWithTimeEntity(
+            id: 'b',
+            preparationName: 'b',
+            preparationTime: Duration(minutes: 10),
+            nextPreparationId: null,
+          ),
+        ],
+      );
+
+      bloc.add(ScheduleUpcomingReceived(active));
+      await Future<void>.delayed(Duration.zero);
+      bloc.add(const SchedulePreparationStarted());
+      await Future<void>.delayed(Duration.zero);
+      expect(bloc.state.status, ScheduleStatus.started);
+
+      bloc.add(ScheduleUpcomingReceived(future));
+      await Future<void>.delayed(Duration.zero);
+      expect(bloc.state.status, ScheduleStatus.upcoming);
+      expect(bloc.state.schedule?.id, 'future');
+      final elapsedBeforeWait = bloc.state.schedule!.preparation.elapsedTime;
+
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+
+      expect(bloc.state.status, ScheduleStatus.upcoming);
+      expect(bloc.state.schedule?.id, 'future');
+      expect(bloc.state.schedule!.preparation.elapsedTime, elapsedBeforeWait);
+    });
+
     test(
         'official start timer does not push scheduleStart when already early-started',
         () async {

--- a/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
+++ b/test/presentation/calendar/bloc/monthly_schedules_bloc_test.dart
@@ -387,4 +387,21 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 20));
     expect(loadedDate, DateTime(2026, 3, 20));
   });
+
+  test('initial load failure emits error state instead of throwing', () async {
+    loadSchedulesForMonthUseCase = StubLoadSchedulesForMonthUseCase(
+      (_) async => throw Exception('unauthorized'),
+    );
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    bloc.add(MonthlySchedulesSubscriptionRequested(date: selectedDate));
+
+    final errorState = await bloc.stream.firstWhere(
+      (state) => state.status == MonthlySchedulesStatus.error,
+    );
+
+    expect(errorState.status, MonthlySchedulesStatus.error);
+  });
 }

--- a/test/presentation/calendar/component/schedule_detail_test.dart
+++ b/test/presentation/calendar/component/schedule_detail_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_swipe_action_cell/core/cell.dart';

--- a/test/presentation/home/bloc/weekly_schedules_bloc_test.dart
+++ b/test/presentation/home/bloc/weekly_schedules_bloc_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/use-cases/get_schedules_by_date_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_schedules_for_week_use_case.dart';
+import 'package:on_time_front/presentation/home/bloc/weekly_schedules_bloc.dart';
+
+class StubLoadSchedulesForWeekUseCase implements LoadSchedulesForWeekUseCase {
+  StubLoadSchedulesForWeekUseCase(this.handler);
+  final Future<void> Function(DateTime date) handler;
+
+  @override
+  Future<void> call(DateTime date) => handler(date);
+}
+
+class StubGetSchedulesByDateUseCase implements GetSchedulesByDateUseCase {
+  @override
+  Stream<List<ScheduleEntity>> call(DateTime startDate, DateTime endDate) {
+    return const Stream.empty();
+  }
+}
+
+void main() {
+  test('load failure emits error state instead of throwing', () async {
+    final bloc = WeeklySchedulesBloc(
+      StubLoadSchedulesForWeekUseCase(
+        (_) async => throw Exception('unauthorized'),
+      ),
+      StubGetSchedulesByDateUseCase(),
+    );
+    addTearDown(bloc.close);
+
+    bloc.add(
+      WeeklySchedulesSubscriptionRequested(date: DateTime(2026, 5, 5)),
+    );
+
+    await expectLater(
+      bloc.stream,
+      emitsThrough(
+        isA<WeeklySchedulesState>().having(
+          (state) => state.status,
+          'status',
+          WeeklySchedulesStatus.error,
+        ),
+      ),
+    );
+  });
+}

--- a/test/presentation/home/screens/home_screen_tmp_test.dart
+++ b/test/presentation/home/screens/home_screen_tmp_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mockito/mockito.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_step_with_time_entity.dart';
@@ -45,6 +46,32 @@ class StubScheduleBloc extends Mock implements ScheduleBloc {
 
   @override
   bool get isClosed => false;
+}
+
+class StreamingScheduleBloc extends Mock implements ScheduleBloc {
+  StreamingScheduleBloc(this._state);
+
+  ScheduleState _state;
+  final _controller = StreamController<ScheduleState>.broadcast();
+
+  void emitState(ScheduleState state) {
+    _state = state;
+    _controller.add(state);
+  }
+
+  @override
+  ScheduleState get state => _state;
+
+  @override
+  Stream<ScheduleState> get stream => _controller.stream;
+
+  @override
+  bool get isClosed => false;
+
+  @override
+  Future<void> close() async {
+    await _controller.close();
+  }
 }
 
 void main() {
@@ -229,6 +256,98 @@ void main() {
     expect(titleText.overflow, TextOverflow.ellipsis);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('does not reopen schedule start on started-state ticks',
+      (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(360, 640);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final scheduleBloc =
+        StreamingScheduleBloc(ScheduleState.started(_scheduleWithLongName()));
+    addTearDown(scheduleBloc.close);
+
+    await tester.pumpWidget(
+      _buildRoutedSubject(
+        size: const Size(360, 640),
+        scheduleBloc: scheduleBloc,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('today_schedule_card')), findsOneWidget);
+    expect(find.text('Schedule Start'), findsNothing);
+
+    scheduleBloc.emitState(ScheduleState.started(_scheduleWithLongName()));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('today_schedule_card')), findsOneWidget);
+    expect(find.text('Schedule Start'), findsNothing);
+  });
+}
+
+Widget _buildRoutedSubject({
+  required Size size,
+  required StreamingScheduleBloc scheduleBloc,
+}) {
+  final authBloc = StubAuthBloc(
+    AuthState(
+      user: UserEntity(
+        id: 'user-1',
+        name: 'Test User',
+        email: 'test@example.com',
+        spareTime: Duration.zero,
+        note: '',
+        score: 80,
+        isOnboardingCompleted: true,
+      ),
+    ),
+  );
+
+  final router = GoRouter(
+    initialLocation: '/home',
+    routes: [
+      GoRoute(
+        path: '/home',
+        builder: (context, state) {
+          return MediaQuery(
+            data: MediaQueryData(size: size),
+            child: SizedBox(
+              width: size.width,
+              height: size.height,
+              child: HomeScreenContent(
+                state: const MonthlySchedulesState(
+                  status: MonthlySchedulesStatus.success,
+                ),
+                userScore: 80,
+              ),
+            ),
+          );
+        },
+      ),
+      GoRoute(
+        path: '/scheduleStart',
+        builder: (context, state) {
+          return const Scaffold(body: Text('Schedule Start'));
+        },
+      ),
+    ],
+  );
+
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<AuthBloc>.value(value: authBloc),
+      BlocProvider<ScheduleBloc>.value(value: scheduleBloc),
+    ],
+    child: MaterialApp.router(
+      theme: themeData,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
 }
 
 double _verticalGap(

--- a/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
+++ b/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
@@ -216,7 +216,7 @@ void main() {
     );
   }
 
-  Future<void> _primeEditState(ScheduleFormBloc bloc) async {
+  Future<void> primeEditState(ScheduleFormBloc bloc) async {
     final loaded = bloc.stream.firstWhere(
       (state) => state.status == ScheduleFormStatus.success,
     );
@@ -224,7 +224,7 @@ void main() {
     await loaded;
   }
 
-  Future<void> _pumpSheet(WidgetTester tester, ScheduleFormBloc bloc) async {
+  Future<void> pumpSheet(WidgetTester tester, ScheduleFormBloc bloc) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -259,7 +259,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  Future<void> _goToFinalStepAndSubmit(WidgetTester tester) async {
+  Future<void> goToFinalStepAndSubmit(WidgetTester tester) async {
     Finder nextButton() => find.descendant(
           of: find.byType(TopBar),
           matching: find.byType(TextButton),
@@ -350,10 +350,10 @@ void main() {
     final bloc = buildBloc();
     addTearDown(bloc.close);
 
-    await _primeEditState(bloc);
-    await _pumpSheet(tester, bloc);
+    await primeEditState(bloc);
+    await pumpSheet(tester, bloc);
 
-    await _goToFinalStepAndSubmit(tester);
+    await goToFinalStepAndSubmit(tester);
 
     expect(find.byType(ScheduleMultiPageForm), findsOneWidget);
 
@@ -365,10 +365,10 @@ void main() {
     final bloc = buildBloc();
     addTearDown(bloc.close);
 
-    await _primeEditState(bloc);
-    await _pumpSheet(tester, bloc);
+    await primeEditState(bloc);
+    await pumpSheet(tester, bloc);
 
-    await _goToFinalStepAndSubmit(tester);
+    await goToFinalStepAndSubmit(tester);
     await tester.pumpAndSettle();
 
     expect(find.byType(ScheduleMultiPageForm), findsNothing);
@@ -381,10 +381,10 @@ void main() {
     final bloc = buildBloc();
     addTearDown(bloc.close);
 
-    await _primeEditState(bloc);
-    await _pumpSheet(tester, bloc);
+    await primeEditState(bloc);
+    await pumpSheet(tester, bloc);
 
-    await _goToFinalStepAndSubmit(tester);
+    await goToFinalStepAndSubmit(tester);
     await tester.pumpAndSettle();
 
     expect(find.byType(ScheduleMultiPageForm), findsOneWidget);
@@ -401,8 +401,8 @@ void main() {
     final bloc = buildBloc();
     addTearDown(bloc.close);
 
-    await _primeEditState(bloc);
-    await _pumpSheet(tester, bloc);
+    await primeEditState(bloc);
+    await pumpSheet(tester, bloc);
 
     Finder nextButton() => find.descendant(
           of: find.byType(TopBar),


### PR DESCRIPTION
## Summary

Adds the native alarm client flow for OnTime schedules, including backend API contracts, local alarm reconciliation, native Android/iOS alarm bridges, fallback notifications, lifecycle trigger points, alarm status UI, and test coverage.

## What changed

- Added alarm planning/spec docs:
  - `plans/backend_alarm_feature_spec.md`
  - `plans/native_alarm_client_implementation_plan.md`
  - `plans/native_alarm_platform_qa_checklist.md`
- Added backend alarm contract integration:
  - alarm settings, current device registration, alarm-window schedules, alarm status reporting, and FCM token `deviceId` support
  - new alarm endpoints in `Endpoint`
  - alarm remote data source, models, repository contracts, and repository implementations
- Added local alarm reconciliation:
  - `ReconcileAlarmsUseCase` computes `preparationStartTime - 5 minutes`, requests the padded alarm window, skips past alarms, cancels stale records, schedules desired records, and reports backend-compatible status
  - local alarm registry persistence keyed by `scheduleId`
  - cancel-all and cancel-schedule use cases for logout, schedule mutation, early start, and session invalidation
- Added platform alarm scheduling services:
  - Dart `AlarmSchedulerService`
  - fallback local notification service
  - Android `AlarmManager.setAlarmClock` bridge and boot receiver
  - iOS AppDelegate alarm channel / URL-intent handling and alarm launch dispatching
- Updated app lifecycle and schedule flows:
  - reconciles alarms from app/auth lifecycle and schedule mutation boundaries
  - cancels alarms on logout/session invalidation and early preparation start
  - dispatches cold-start/resumed alarm launch payloads into `/scheduleStart`
  - avoids reopening preparation start from repeated home ticks
- Updated schedule and calendar behavior around alarm-aware state:
  - schedule create/update/delete/finish flows trigger alarm reconciliation
  - monthly/weekly/home schedule state handles refreshed data and errors more safely
  - schedule stream and preparation fetching behavior adjusted for alarm-window consistency
- Added My Page alarm status/control surface:
  - shows native alarm/fallback/permission/partial/disabled states
  - supports global alarm enablement semantics while keeping offset fixed for v1
- Added and updated tests:
  - alarm scheduler launch handling
  - alarm remote data source backend wire compatibility
  - alarm models serialization
  - alarm reconciliation scenarios, including padded windows, stale cancellation, fallback, partial reports, settings unavailable, disabled state, and session invalidation
  - schedule bloc alarm/preparation state behavior
  - home, calendar, schedule form, and preparation flow regression coverage

## Why

Schedules remain server-owned, but native alarms are device-local OS state. This PR adds the client-side mirror that reconciles upcoming server schedules into local native alarms or notification fallback, while reporting enough status back to the backend to avoid duplicate legacy pushes when local alarm coverage is fresh.

## User/developer impact

- Users can be alerted 5 minutes before preparation should start, using true native alarms where supported and local notification fallback elsewhere.
- Backend receives a concrete contract for alarm settings, device ownership, alarm-window sync, status diagnostics, and legacy push suppression.
- Developers get dedicated alarm domain/repository/use-case layers instead of mixing native alarms into the existing FCM notification service.

## Validation

- `flutter analyze` passed.
- `flutter test` passed.

## Notes

- PR is opened as draft because platform alarm behavior still needs device QA on Android exact alarms, Android reboot restore, iOS AlarmKit-capable devices, and fallback notification paths.
- Branch contains 78 changed files relative to `main`.
