### PR TITLE
[codex] Disable schedule editing after preparation starts

### DIFF
--- a/lib/presentation/calendar/component/schedule_detail.dart
+++ b/lib/presentation/calendar/component/schedule_detail.dart
@@ -56,11 +56,13 @@ class ScheduleDetail extends StatefulWidget {
       {super.key,
       required this.schedule,
       this.preparationTime,
+      this.isEarlyStarted = false,
       this.onDeleted,
       this.onEdit});
 
   final ScheduleEntity schedule;
   final Duration? preparationTime;
+  final bool isEarlyStarted;
   final VoidCallback? onEdit;
   final VoidCallback? onDeleted;
 
@@ -103,8 +105,10 @@ class _ScheduleDetailState extends State<ScheduleDetail> {
 
   List<SwipeAction> _buildSwipeActions(BuildContext context) {
     final theme = Theme.of(context);
+    final now = DateTime.now();
     final canEdit = widget.schedule.doneStatus == ScheduleDoneStatus.notEnded &&
-        !widget.schedule.scheduleTime.isBefore(DateTime.now());
+        !_hasPreparationStarted(now) &&
+        !widget.schedule.scheduleTime.isBefore(now);
     return [
       SwipeAction(
         widthSpace: _actionWidth,
@@ -134,6 +138,24 @@ class _ScheduleDetailState extends State<ScheduleDetail> {
           ),
         ),
     ];
+  }
+
+  bool _hasPreparationStarted(DateTime now) {
+    if (widget.schedule.isStarted || widget.isEarlyStarted) {
+      return true;
+    }
+
+    final preparationTime = widget.preparationTime;
+    if (preparationTime == null) {
+      return false;
+    }
+
+    final preparationStartTime = widget.schedule.scheduleTime.subtract(
+      widget.schedule.moveTime +
+          preparationTime +
+          (widget.schedule.scheduleSpareTime ?? Duration.zero),
+    );
+    return !now.isBefore(preparationStartTime);
   }
 
   Widget _buildScheduleContent(BuildContext context) {

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
 import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
 import 'package:on_time_front/presentation/calendar/component/schedule_detail.dart';
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_create_screen.dart';
@@ -357,39 +358,54 @@ class _CalendarScreenState extends State<CalendarScreen> {
                                 final schedule =
                                     state.schedules[_selectedDate]![index];
 
-                                return ScheduleDetail(
-                                  schedule: schedule,
-                                  preparationTime:
-                                      state.preparationDurationByScheduleId[
-                                          schedule.id],
-                                  onEdit: () {
-                                    _openEditScheduleSheet(
-                                      context,
-                                      scheduleId: schedule.id,
+                                return BlocBuilder<ScheduleBloc, ScheduleState>(
+                                  builder: (context, scheduleState) {
+                                    final isEarlyStarted =
+                                        scheduleState.isEarlyStarted &&
+                                            scheduleState.schedule?.id ==
+                                                schedule.id;
+
+                                    return ScheduleDetail(
+                                      schedule: schedule,
+                                      preparationTime:
+                                          state.preparationDurationByScheduleId[
+                                              schedule.id],
+                                      isEarlyStarted: isEarlyStarted,
+                                      onEdit: () {
+                                        _openEditScheduleSheet(
+                                          context,
+                                          scheduleId: schedule.id,
+                                        );
+                                      },
+                                      onDeleted: () {
+                                        showTwoButtonDeleteDialog(
+                                          context,
+                                          title: AppLocalizations.of(context)!
+                                              .scheduleDeleteConfirmTitle,
+                                          description: AppLocalizations.of(
+                                                  context)!
+                                              .scheduleDeleteConfirmDescription,
+                                          cancelText:
+                                              AppLocalizations.of(context)!
+                                                  .cancel,
+                                          confirmText:
+                                              AppLocalizations.of(context)!
+                                                  .deleteScheduleConfirmAction,
+                                        ).then((confirmed) {
+                                          if (confirmed != true ||
+                                              !context.mounted) {
+                                            return;
+                                          }
+                                          context
+                                              .read<MonthlySchedulesBloc>()
+                                              .add(
+                                                MonthlySchedulesScheduleDeleted(
+                                                  schedule: schedule,
+                                                ),
+                                              );
+                                        });
+                                      },
                                     );
-                                  },
-                                  onDeleted: () {
-                                    showTwoButtonDeleteDialog(
-                                      context,
-                                      title: AppLocalizations.of(context)!
-                                          .scheduleDeleteConfirmTitle,
-                                      description: AppLocalizations.of(context)!
-                                          .scheduleDeleteConfirmDescription,
-                                      cancelText:
-                                          AppLocalizations.of(context)!.cancel,
-                                      confirmText: AppLocalizations.of(context)!
-                                          .deleteScheduleConfirmAction,
-                                    ).then((confirmed) {
-                                      if (confirmed != true ||
-                                          !context.mounted) {
-                                        return;
-                                      }
-                                      context.read<MonthlySchedulesBloc>().add(
-                                            MonthlySchedulesScheduleDeleted(
-                                              schedule: schedule,
-                                            ),
-                                          );
-                                    });
                                   },
                                 );
                               },

--- a/test/presentation/calendar/component/schedule_detail_test.dart
+++ b/test/presentation/calendar/component/schedule_detail_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_swipe_action_cell/core/cell.dart';
@@ -38,6 +37,7 @@ void main() {
     WidgetTester tester, {
     ScheduleEntity? customSchedule,
     Duration? preparationTime,
+    bool isEarlyStarted = false,
   }) async {
     final targetSchedule = customSchedule ?? schedule;
     await tester.pumpWidget(
@@ -51,6 +51,7 @@ void main() {
             body: ScheduleDetail(
               schedule: targetSchedule,
               preparationTime: preparationTime,
+              isEarlyStarted: isEarlyStarted,
             ),
           ),
         ),
@@ -86,6 +87,25 @@ void main() {
         .evaluate()
         .map((element) => (element.renderObject! as RenderBox).size.height)
         .reduce((a, b) => a > b ? a : b);
+  }
+
+  int getActionButtonCount(WidgetTester tester) {
+    final actionContainers = find.byWidgetPredicate((widget) {
+      if (widget is! Container) {
+        return false;
+      }
+      final decoration = widget.decoration;
+      if (decoration is! BoxDecoration) {
+        return false;
+      }
+      final radius = decoration.borderRadius;
+      if (radius is! BorderRadius) {
+        return false;
+      }
+      return radius.topLeft.x == 12 && decoration.color != null;
+    });
+
+    return actionContainers.evaluate().length;
   }
 
   testWidgets('expanded tile shows travel, preparation, spare in order',
@@ -175,5 +195,81 @@ void main() {
     expect(find.text('Design Review'), findsNothing);
     expect(find.text('Office'), findsNothing);
     expect(find.text('09:00'), findsNothing);
+  });
+
+  testWidgets('edit action is available before preparation starts',
+      (tester) async {
+    final futureSchedule = ScheduleEntity(
+      id: 'schedule-2',
+      place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+      scheduleName: 'Planning',
+      scheduleTime: DateTime.now().add(const Duration(hours: 3)),
+      moveTime: const Duration(minutes: 30),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 10),
+      scheduleNote: '',
+    );
+
+    await pumpScheduleDetail(
+      tester,
+      customSchedule: futureSchedule,
+      preparationTime: const Duration(minutes: 20),
+    );
+
+    await openTrailingActions(tester);
+
+    expect(getActionButtonCount(tester), 2);
+  });
+
+  testWidgets('edit action is hidden after preparation start time',
+      (tester) async {
+    final scheduleInPreparation = ScheduleEntity(
+      id: 'schedule-3',
+      place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+      scheduleName: 'Planning',
+      scheduleTime: DateTime.now().add(const Duration(minutes: 30)),
+      moveTime: const Duration(minutes: 30),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 10),
+      scheduleNote: '',
+    );
+
+    await pumpScheduleDetail(
+      tester,
+      customSchedule: scheduleInPreparation,
+      preparationTime: const Duration(minutes: 20),
+    );
+
+    await openTrailingActions(tester);
+
+    expect(getActionButtonCount(tester), 1);
+  });
+
+  testWidgets('edit action is hidden for early-started schedule',
+      (tester) async {
+    final futureSchedule = ScheduleEntity(
+      id: 'schedule-4',
+      place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+      scheduleName: 'Planning',
+      scheduleTime: DateTime.now().add(const Duration(hours: 3)),
+      moveTime: const Duration(minutes: 30),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 10),
+      scheduleNote: '',
+    );
+
+    await pumpScheduleDetail(
+      tester,
+      customSchedule: futureSchedule,
+      preparationTime: const Duration(minutes: 20),
+      isEarlyStarted: true,
+    );
+
+    await openTrailingActions(tester);
+
+    expect(getActionButtonCount(tester), 1);
   });
 }


### PR DESCRIPTION
## Summary

- Hide the calendar schedule edit swipe action after a schedule's preparation window has started.
- Include early-started schedules in the edit lock by passing the active `ScheduleBloc` early-start state into schedule detail rows.
- Add widget coverage for edit visibility before preparation, after calculated preparation start, and during early start.

## Impact

Users can no longer modify a schedule once preparation is already underway, which prevents changing timing data while active preparation progress may exist.

## Validation

- `flutter test test/presentation/calendar/component/schedule_detail_test.dart`
- `git diff --check`

`flutter analyze` was attempted but is currently blocked by existing repository issues in Widgetbook generated/helper files, including missing `widgetbook/lib/main.directories.g.dart` and `package:widgetbook_workspace/dialog_story_helpers.dart`.
