### PR TITLE
[codex] Fix preparation step order

### DIFF
--- a/lib/data/models/get_preparation_step_response_model.dart
+++ b/lib/data/models/get_preparation_step_response_model.dart
@@ -48,7 +48,38 @@ class GetPreparationStepResponseModel {
 extension PreparationResponseModelListExtension
     on List<GetPreparationStepResponseModel> {
   PreparationEntity toPreparationEntity() {
-    final steps = map((model) => model.toEntity()).toList();
+    if (isEmpty) {
+      return PreparationEntity(preparationStepList: []);
+    }
+
+    final modelsById = {
+      for (final model in this) model.id: model,
+    };
+    final referencedIds = {
+      for (final model in this)
+        if (model.nextPreparationId != null) model.nextPreparationId!,
+    };
+    final firstModel = firstWhere(
+      (model) => !referencedIds.contains(model.id),
+      orElse: () => first,
+    );
+
+    final orderedModels = <GetPreparationStepResponseModel>[];
+    final visitedIds = <String>{};
+    GetPreparationStepResponseModel? currentModel = firstModel;
+    while (currentModel != null && visitedIds.add(currentModel.id)) {
+      orderedModels.add(currentModel);
+      final nextId = currentModel.nextPreparationId;
+      currentModel = nextId == null ? null : modelsById[nextId];
+    }
+
+    for (final model in this) {
+      if (visitedIds.add(model.id)) {
+        orderedModels.add(model);
+      }
+    }
+
+    final steps = orderedModels.map((model) => model.toEntity()).toList();
     return PreparationEntity(preparationStepList: steps);
   }
 }

--- a/test/data/models/get_preparation_step_response_model_test.dart
+++ b/test/data/models/get_preparation_step_response_model_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/data/models/get_preparation_step_response_model.dart';
+
+void main() {
+  group('PreparationResponseModelListExtension', () {
+    test('orders preparation steps by nextPreparationId chain', () {
+      final models = [
+        GetPreparationStepResponseModel(
+          id: 'third',
+          preparationName: 'Put on shoes',
+          preparationTime: 3,
+          nextPreparationId: null,
+        ),
+        GetPreparationStepResponseModel(
+          id: 'first',
+          preparationName: 'Shower',
+          preparationTime: 10,
+          nextPreparationId: 'second',
+        ),
+        GetPreparationStepResponseModel(
+          id: 'second',
+          preparationName: 'Get dressed',
+          preparationTime: 5,
+          nextPreparationId: 'third',
+        ),
+      ];
+
+      final preparation = models.toPreparationEntity();
+
+      expect(
+        preparation.preparationStepList.map((step) => step.id),
+        ['first', 'second', 'third'],
+      );
+    });
+
+    test('keeps unlinked steps instead of dropping them', () {
+      final models = [
+        GetPreparationStepResponseModel(
+          id: 'first',
+          preparationName: 'Shower',
+          preparationTime: 10,
+          nextPreparationId: 'second',
+        ),
+        GetPreparationStepResponseModel(
+          id: 'second',
+          preparationName: 'Get dressed',
+          preparationTime: 5,
+          nextPreparationId: null,
+        ),
+        GetPreparationStepResponseModel(
+          id: 'unlinked',
+          preparationName: 'Pack bag',
+          preparationTime: 2,
+          nextPreparationId: null,
+        ),
+      ];
+
+      final preparation = models.toPreparationEntity();
+
+      expect(
+        preparation.preparationStepList.map((step) => step.id),
+        ['first', 'second', 'unlinked'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Normalize preparation step API responses by following the `nextPreparationId` chain.
- Add model tests for reversed response order and unlinked-step fallback behavior.

## Root Cause

The app trusted the raw array order returned by the preparation API. When the backend returned steps in reverse or otherwise unordered form, the preparation screen displayed that reversed order directly.

## Validation

- `flutter test test/data/models/get_preparation_step_response_model_test.dart`
- `flutter analyze lib/data/models/get_preparation_step_response_model.dart test/data/models/get_preparation_step_response_model_test.dart`
