### PR TITLE
fix: align Android app id with iOS and update sign-in deps

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,11 +9,12 @@ plugins {
 }
 
 android {
-    namespace = "com.example.ontime"
+    namespace = "club.devkor.ontime"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        coreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -24,7 +25,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.on_time_front"
+        applicationId = "club.devkor.ontime"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -32,6 +33,7 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
         manifestPlaceholders = [
+            applicationName: "android.app.Application",
             appAuthRedirectScheme: applicationId
         ]
     }
@@ -47,4 +49,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.4"
 }

--- a/android/app/src/main/kotlin/club/devkor/ontime/MainActivity.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.on_time_front
+package club.devkor.ontime
 
 import android.app.AlarmManager
 import android.app.PendingIntent
@@ -86,6 +86,10 @@ class MainActivity : FlutterActivity() {
         }
 
         val pendingIntent = pendingIntentFor(args, PendingIntent.FLAG_UPDATE_CURRENT)
+        if (pendingIntent == null) {
+            result.error("scheduleFailed", "Failed to create alarm PendingIntent", null)
+            return
+        }
         val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerAtMillis, pendingIntent)
         alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
         result.success(null)

--- a/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmBootReceiver.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmBootReceiver.kt
@@ -1,4 +1,4 @@
-package com.example.on_time_front
+package club.devkor.ontime
 
 import android.app.AlarmManager
 import android.app.PendingIntent

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.3.0" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,6 @@ import firebase_messaging
 import flutter_appauth
 import flutter_local_notifications
 import flutter_secure_storage_macos
-import flutter_web_auth
 import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
@@ -25,7 +24,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterAppauthPlugin.register(with: registry.registrar(forPlugin: "FlutterAppauthPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
-  FlutterWebAuthPlugin.register(with: registry.registrar(forPlugin: "FlutterWebAuthPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -551,14 +551,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_auth:
-    dependency: "direct main"
-    description:
-      name: flutter_web_auth
-      sha256: "95e4856e24fb6ac1678f5ff334743b63f782d839ab324543d29ccbd295176209"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,6 @@ dependencies:
   http: ^1.2.2
   url_launcher: ^6.3.1
   shared_preferences: ^2.3.3
-  flutter_web_auth: ^0.6.0
   kakao_flutter_sdk: ^1.9.6
   flutter_appauth: ^8.0.1
   go_router: ^14.6.2


### PR DESCRIPTION
## Summary
- align the Android namespace and application id with 
- remove the unused  dependency and regenerate plugin registrants
- update Android build settings for current Flutter and alarm scheduling code

## Verification
- Analyzing OnTime-front...                                       
No issues found! (ran in 2.9s)
- Running Gradle task 'assembleDebug'...                             29.0s
✓ Built build/app/outputs/flutter-apk/app-debug.apk

## Notes
- Android Google Sign-In still requires Firebase to include the debug SHA fingerprints for the new Android package name .