### PR TITLE
[codex] Support account deletion feedback

### DIFF
--- a/lib/data/data_sources/authentication_remote_data_source.dart
+++ b/lib/data/data_sources/authentication_remote_data_source.dart
@@ -23,13 +23,13 @@ abstract interface class AuthenticationRemoteDataSource {
 
   Future<UserEntity> getUser();
 
-  Future<void> deleteGoogleMe();
+  Future<void> deleteGoogleMe({String? feedbackMessage});
 
-  Future<void> deleteAppleMe();
+  Future<void> deleteAppleMe({String? feedbackMessage});
 
   Future<void> postFeedback(String message);
 
-  Future<void> deleteUser();
+  Future<void> deleteUser({String? feedbackMessage});
 
   Future<String?> getUserSocialType();
 }
@@ -143,9 +143,12 @@ class AuthenticationRemoteDataSourceImpl
   }
 
   @override
-  Future<void> deleteGoogleMe() async {
+  Future<void> deleteGoogleMe({String? feedbackMessage}) async {
     try {
-      final result = await dio.delete(Endpoint.deleteGoogleMe);
+      final result = await dio.delete(
+        Endpoint.deleteGoogleMe,
+        data: _buildDeleteFeedbackData(feedbackMessage),
+      );
       if (result.statusCode == 200) {
         return;
       } else {
@@ -157,9 +160,12 @@ class AuthenticationRemoteDataSourceImpl
   }
 
   @override
-  Future<void> deleteAppleMe() async {
+  Future<void> deleteAppleMe({String? feedbackMessage}) async {
     try {
-      final result = await dio.delete(Endpoint.deleteAppleMe);
+      final result = await dio.delete(
+        Endpoint.deleteAppleMe,
+        data: _buildDeleteFeedbackData(feedbackMessage),
+      );
       if (result.statusCode == 200) {
         return;
       } else {
@@ -189,9 +195,12 @@ class AuthenticationRemoteDataSourceImpl
   }
 
   @override
-  Future<void> deleteUser() async {
+  Future<void> deleteUser({String? feedbackMessage}) async {
     try {
-      final result = await dio.delete(Endpoint.deleteUser);
+      final result = await dio.delete(
+        Endpoint.deleteUser,
+        data: _buildDeleteFeedbackData(feedbackMessage),
+      );
       if (result.statusCode == 200) {
         return;
       } else {
@@ -215,5 +224,17 @@ class AuthenticationRemoteDataSourceImpl
     } catch (e) {
       rethrow;
     }
+  }
+
+  Map<String, dynamic> _buildDeleteFeedbackData(String? feedbackMessage) {
+    final trimmedMessage = feedbackMessage?.trim();
+    if (trimmedMessage == null || trimmedMessage.isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    return <String, dynamic>{
+      'feedbackId': const Uuid().v4(),
+      'message': trimmedMessage,
+    };
   }
 }

--- a/lib/data/repositories/user_repository_impl.dart
+++ b/lib/data/repositories/user_repository_impl.dart
@@ -132,27 +132,33 @@ class UserRepositoryImpl implements UserRepository {
   }
 
   @override
-  Future<void> deleteUser() async {
+  Future<void> deleteUser({String? feedbackMessage}) async {
     try {
-      await _authenticationRemoteDataSource.deleteUser();
+      await _authenticationRemoteDataSource.deleteUser(
+        feedbackMessage: feedbackMessage,
+      );
     } catch (e) {
       rethrow;
     }
   }
 
   @override
-  Future<void> deleteGoogleUser() async {
+  Future<void> deleteGoogleUser({String? feedbackMessage}) async {
     try {
-      await _authenticationRemoteDataSource.deleteGoogleMe();
+      await _authenticationRemoteDataSource.deleteGoogleMe(
+        feedbackMessage: feedbackMessage,
+      );
     } catch (e) {
       rethrow;
     }
   }
 
   @override
-  Future<void> deleteAppleUser() async {
+  Future<void> deleteAppleUser({String? feedbackMessage}) async {
     try {
-      await _authenticationRemoteDataSource.deleteAppleMe();
+      await _authenticationRemoteDataSource.deleteAppleMe(
+        feedbackMessage: feedbackMessage,
+      );
     } catch (e) {
       rethrow;
     }

--- a/lib/domain/repositories/user_repository.dart
+++ b/lib/domain/repositories/user_repository.dart
@@ -24,11 +24,11 @@ abstract interface class UserRepository {
 
   Future<void> getUser();
 
-  Future<void> deleteUser();
+  Future<void> deleteUser({String? feedbackMessage});
 
-  Future<void> deleteGoogleUser();
+  Future<void> deleteGoogleUser({String? feedbackMessage});
 
-  Future<void> deleteAppleUser();
+  Future<void> deleteAppleUser({String? feedbackMessage});
 
   Future<void> postFeedback(String message);
 

--- a/lib/domain/use-cases/delete_user_use_case.dart
+++ b/lib/domain/use-cases/delete_user_use_case.dart
@@ -9,20 +9,16 @@ class DeleteUserUseCase {
   DeleteUserUseCase(this._userRepository);
 
   Future<void> call(String feedbackMessage) async {
-    try {
-      await _userRepository.postFeedback(feedbackMessage);
-    } catch (_) {}
-
     final socialTypeString = await _userRepository.getUserSocialType();
     final socialType = socialTypeFromString(socialTypeString);
 
     if (socialType == SocialType.google) {
+      await _userRepository.deleteGoogleUser(feedbackMessage: feedbackMessage);
       await _userRepository.disconnectGoogleSignIn();
-      await _userRepository.deleteGoogleUser();
     } else if (socialType == SocialType.apple) {
-      await _userRepository.deleteAppleUser();
+      await _userRepository.deleteAppleUser(feedbackMessage: feedbackMessage);
     } else {
-      await _userRepository.deleteUser();
+      await _userRepository.deleteUser(feedbackMessage: feedbackMessage);
     }
   }
 }

--- a/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
+++ b/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
@@ -132,6 +132,12 @@ class DeleteUserModal {
       await deleteUserUseCase(controller.text);
     } catch (e) {
       debugPrint(e.toString());
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.error)),
+        );
+      }
+      return;
     }
 
     try {

--- a/lib/presentation/my_page/my_page_screen.dart
+++ b/lib/presentation/my_page/my_page_screen.dart
@@ -56,8 +56,14 @@ class MyPageScreen extends StatelessWidget {
                   title: AppLocalizations.of(context)!.deleteAccount,
                   onTap: () async {
                     final deleteUserModal = DeleteUserModal();
-                    await deleteUserModal.showDeleteUserModal(context,
-                        onConfirm: () {});
+                    await deleteUserModal.showDeleteUserModal(
+                      context,
+                      onConfirm: () {
+                        if (context.mounted) {
+                          context.go('/signIn');
+                        }
+                      },
+                    );
                   },
                 ),
               ],

--- a/test/data/data_sources/authentication_remote_data_source_test.dart
+++ b/test/data/data_sources/authentication_remote_data_source_test.dart
@@ -1,0 +1,51 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:on_time_front/core/constants/endpoint.dart';
+import 'package:on_time_front/data/data_sources/authentication_remote_data_source.dart';
+
+import '../../helpers/mock.mocks.dart';
+
+void main() {
+  late Dio dio;
+  late AuthenticationRemoteDataSourceImpl dataSource;
+
+  setUp(() {
+    dio = MockAppDio();
+    dataSource = AuthenticationRemoteDataSourceImpl(dio);
+  });
+
+  group('deleteUser', () {
+    test('sends optional feedback in the DELETE request body', () async {
+      when(dio.delete(Endpoint.deleteUser, data: anyNamed('data'))).thenAnswer(
+        (_) async => Response(
+          statusCode: 200,
+          requestOptions: RequestOptions(path: Endpoint.deleteUser),
+        ),
+      );
+
+      await dataSource.deleteUser(feedbackMessage: '  Not useful anymore.  ');
+
+      final capturedData = verify(
+        dio.delete(Endpoint.deleteUser, data: captureAnyNamed('data')),
+      ).captured.single as Map<String, dynamic>;
+      expect(capturedData['feedbackId'], isA<String>());
+      expect(capturedData['message'], 'Not useful anymore.');
+    });
+
+    test('sends an empty body when feedback is blank', () async {
+      when(dio.delete(Endpoint.deleteGoogleMe, data: anyNamed('data')))
+          .thenAnswer(
+        (_) async => Response(
+          statusCode: 200,
+          requestOptions: RequestOptions(path: Endpoint.deleteGoogleMe),
+        ),
+      );
+
+      await dataSource.deleteGoogleMe(feedbackMessage: '   ');
+
+      verify(dio.delete(Endpoint.deleteGoogleMe, data: <String, dynamic>{}))
+          .called(1);
+    });
+  });
+}

--- a/test/domain/use-cases/delete_user_use_case_test.dart
+++ b/test/domain/use-cases/delete_user_use_case_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:on_time_front/domain/entities/user_entity.dart';
+import 'package:on_time_front/domain/repositories/user_repository.dart';
+import 'package:on_time_front/domain/use-cases/delete_user_use_case.dart';
+
+void main() {
+  test('deletes normal accounts with feedback', () async {
+    final repository = _FakeUserRepository(socialType: null);
+    final useCase = DeleteUserUseCase(repository);
+
+    await useCase('Too many notifications');
+
+    expect(repository.deletedNormalFeedback, 'Too many notifications');
+    expect(repository.deletedGoogleFeedback, isNull);
+    expect(repository.deletedAppleFeedback, isNull);
+  });
+
+  test('deletes Google accounts through the Google revoke endpoint', () async {
+    final repository = _FakeUserRepository(socialType: 'GOOGLE');
+    final useCase = DeleteUserUseCase(repository);
+
+    await useCase('Switching apps');
+
+    expect(repository.deletedGoogleFeedback, 'Switching apps');
+    expect(repository.didDisconnectGoogleSignIn, isTrue);
+    expect(repository.deletedNormalFeedback, isNull);
+  });
+
+  test('deletes Apple accounts through the Apple revoke endpoint', () async {
+    final repository = _FakeUserRepository(socialType: 'apple');
+    final useCase = DeleteUserUseCase(repository);
+
+    await useCase('Fresh start');
+
+    expect(repository.deletedAppleFeedback, 'Fresh start');
+    expect(repository.deletedNormalFeedback, isNull);
+  });
+}
+
+class _FakeUserRepository implements UserRepository {
+  _FakeUserRepository({required this.socialType});
+
+  final String? socialType;
+  String? deletedNormalFeedback;
+  String? deletedGoogleFeedback;
+  String? deletedAppleFeedback;
+  bool didDisconnectGoogleSignIn = false;
+
+  @override
+  Stream<UserEntity> get userStream => const Stream.empty();
+
+  @override
+  GoogleSignIn get googleSignIn => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAppleUser({String? feedbackMessage}) async {
+    deletedAppleFeedback = feedbackMessage;
+  }
+
+  @override
+  Future<void> deleteGoogleUser({String? feedbackMessage}) async {
+    deletedGoogleFeedback = feedbackMessage;
+  }
+
+  @override
+  Future<void> deleteUser({String? feedbackMessage}) async {
+    deletedNormalFeedback = feedbackMessage;
+  }
+
+  @override
+  Future<void> disconnectGoogleSignIn() async {
+    didDisconnectGoogleSignIn = true;
+  }
+
+  @override
+  Future<String?> getUserSocialType() async => socialType;
+
+  @override
+  Future<void> getUser() => throw UnimplementedError();
+
+  @override
+  Future<void> postFeedback(String message) => throw UnimplementedError();
+
+  @override
+  Future<void> signIn({required String email, required String password}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signInWithApple({
+    required String idToken,
+    required String authCode,
+    required String fullName,
+    String? email,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signInWithGoogle(GoogleSignInAccount account) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signOut() => throw UnimplementedError();
+
+  @override
+  Future<void> signUp({
+    required String email,
+    required String password,
+    required String name,
+  }) =>
+      throw UnimplementedError();
+}

--- a/test/domain/use-cases/reconcile_alarms_use_case_test.dart
+++ b/test/domain/use-cases/reconcile_alarms_use_case_test.dart
@@ -208,13 +208,16 @@ class FakeUserRepository implements UserRepository {
   }
 
   @override
-  Future<void> deleteAppleUser() => throw UnimplementedError();
+  Future<void> deleteAppleUser({String? feedbackMessage}) =>
+      throw UnimplementedError();
 
   @override
-  Future<void> deleteGoogleUser() => throw UnimplementedError();
+  Future<void> deleteGoogleUser({String? feedbackMessage}) =>
+      throw UnimplementedError();
 
   @override
-  Future<void> deleteUser() => throw UnimplementedError();
+  Future<void> deleteUser({String? feedbackMessage}) =>
+      throw UnimplementedError();
 
   @override
   Future<void> disconnectGoogleSignIn() => throw UnimplementedError();


### PR DESCRIPTION
## Summary
- send optional withdrawal feedback in account deletion DELETE bodies
- route normal, Google, and Apple account deletion through the correct backend endpoints
- keep users signed in on deletion failure, and explicitly redirect to sign-in after successful deletion
- add focused tests for deletion payloads and social account routing

## Why
The backend now accepts optional feedback directly on account deletion requests. The previous frontend flow posted feedback separately and could sign users out even when deletion failed, which made social revoke errors look like successful withdrawal.

## Validation
- flutter analyze
- flutter test test/data/data_sources/authentication_remote_data_source_test.dart test/domain/use-cases/delete_user_use_case_test.dart test/presentation/my_page/delete_user_modal_test.dart