### PR TITLE
[codex] Fix schedule edit completion payload

### DIFF
--- a/lib/data/models/update_schedule_request_model.dart
+++ b/lib/data/models/update_schedule_request_model.dart
@@ -13,7 +13,6 @@ class UpdateScheduleRequestModel {
   final int moveTime;
   final int? scheduleSpareTime;
   final String scheduleNote;
-  final int latenessTime;
 
   const UpdateScheduleRequestModel({
     required this.scheduleId,
@@ -24,7 +23,6 @@ class UpdateScheduleRequestModel {
     required this.moveTime,
     this.scheduleSpareTime,
     required this.scheduleNote,
-    this.latenessTime = 0,
   });
 
   factory UpdateScheduleRequestModel.fromJson(Map<String, dynamic> json) =>
@@ -42,7 +40,6 @@ class UpdateScheduleRequestModel {
       moveTime: entity.moveTime.inMinutes,
       scheduleSpareTime: entity.scheduleSpareTime?.inMinutes,
       scheduleNote: entity.scheduleNote,
-      latenessTime: entity.latenessTime,
     );
   }
 }

--- a/test/data/data_sources/schedule_remote_data_source_test.dart
+++ b/test/data/data_sources/schedule_remote_data_source_test.dart
@@ -4,6 +4,7 @@ import 'package:mockito/mockito.dart';
 import 'package:on_time_front/core/constants/endpoint.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
 import 'package:on_time_front/data/models/create_schedule_request_model.dart';
+import 'package:on_time_front/data/models/update_schedule_request_model.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:uuid/uuid.dart';
@@ -36,6 +37,8 @@ void main() {
 
   final tCreateScheduleModel =
       CreateScheduleRequestModel.fromEntity(tScheduleEntity);
+  final tUpdateScheduleModel =
+      UpdateScheduleRequestModel.fromEntity(tScheduleEntity);
 
   setUp(() {
     dio = MockAppDio();
@@ -85,48 +88,45 @@ void main() {
     });
   });
 
-  // group('updateSchdule', () {
-  //   test('should perform a PUT request on the /schedule/modify endpoint',
-  //       () async {
-  //     // arrange
-  //     when(dio.put(Endpoint.updateSchedule(scheduleEntityId),
-  //             data: tUpdateScheduleModel.toJson()))
-  //         .thenAnswer(
-  //       (_) async => Response(
-  //         statusCode: 204,
-  //         requestOptions:
-  //             RequestOptions(path: Endpoint.updateSchedule(scheduleEntityId)),
-  //       ),
-  //     );
+  group('updateSchedule', () {
+    test('should perform a PUT request without completion fields', () async {
+      final updateJson = tUpdateScheduleModel.toJson();
+      expect(updateJson, isNot(contains('latenessTime')));
 
-  //     // act
-  //     await scheduleRemoteDataSourceImpl.updateSchedule(tScheduleEntity);
+      when(dio.put(Endpoint.updateSchedule(scheduleEntityId), data: updateJson))
+          .thenAnswer(
+        (_) async => Response(
+          statusCode: 200,
+          requestOptions:
+              RequestOptions(path: Endpoint.updateSchedule(scheduleEntityId)),
+        ),
+      );
 
-  //     // assert
-  //     verify(dio.put(Endpoint.updateSchedule(scheduleEntityId),
-  //             data: tUpdateScheduleModel.toJson()))
-  //         .called(1);
-  //   });
+      await scheduleRemoteDataSourceImpl.updateSchedule(tScheduleEntity);
 
-  //   test('should throw an exception when the response code is not 204',
-  //       () async {
-  //     when(dio.put(Endpoint.updateSchedule(scheduleEntityId),
-  //             data: tUpdateScheduleModel.toJson()))
-  //         .thenAnswer(
-  //       (_) async => Response(
-  //         statusCode: 400,
-  //         requestOptions:
-  //             RequestOptions(path: Endpoint.updateSchedule(scheduleEntityId)),
-  //       ),
-  //     );
+      verify(dio.put(Endpoint.updateSchedule(scheduleEntityId),
+              data: updateJson))
+          .called(1);
+    });
 
-  //     // act
-  //     final call = scheduleRemoteDataSourceImpl.updateSchedule(tScheduleEntity);
+    test('should throw an exception when the response code is not 200',
+        () async {
+      when(dio.put(
+        Endpoint.updateSchedule(scheduleEntityId),
+        data: tUpdateScheduleModel.toJson(),
+      )).thenAnswer(
+        (_) async => Response(
+          statusCode: 400,
+          requestOptions:
+              RequestOptions(path: Endpoint.updateSchedule(scheduleEntityId)),
+        ),
+      );
 
-  //     // assert
-  //     expect(call, throwsException);
-  //   });
-  // });
+      final call = scheduleRemoteDataSourceImpl.updateSchedule(tScheduleEntity);
+
+      expect(call, throwsException);
+    });
+  });
 
   group('deleteSchedule', () {
     test('should perform a DELETE request on the /schedule/delete endpoint',


### PR DESCRIPTION
## Summary

- Remove `latenessTime` from schedule update requests so ordinary edits do not send completion data.
- Restore schedule update remote data source tests and add a regression check that edit payloads omit completion fields.

## Root Cause

The edit flow built an update payload with `latenessTime: 0`. Elsewhere in the app, finishing a schedule with lateness time `0` maps to a normal completion, so the backend could treat an edited schedule as finished. Finished schedules are delete-only in the detail UI and are filtered out of upcoming schedules.

## Validation

- `flutter test test/data/data_sources/schedule_remote_data_source_test.dart test/data/repositories/schedule_repository_impl_stream_test.dart test/domain/use-cases/get_nearest_upcoming_schedule_use_case_test.dart`
- `flutter analyze`
