### PR TITLE
[codex] Fix Android calendar back navigation

### DIFF
--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -100,6 +100,14 @@ class _CalendarScreenState extends State<CalendarScreen> {
     );
   }
 
+  void _returnHome() {
+    if (!mounted) {
+      return;
+    }
+
+    context.go('/home');
+  }
+
   @override
   void dispose() {
     unawaited(_monthlySchedulesBloc.close());
@@ -142,286 +150,298 @@ class _CalendarScreenState extends State<CalendarScreen> {
     final colorScheme = theme.colorScheme;
     final calendarTheme = theme.extension<CalendarTheme>()!;
 
-    return BlocProvider.value(
-      value: _monthlySchedulesBloc,
-      child: Scaffold(
-        backgroundColor: colorScheme.surfaceContainerLow,
-        appBar: AppBar(
-          title: Text(AppLocalizations.of(context)!.calendarTitle),
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop) {
+          _returnHome();
+        }
+      },
+      child: BlocProvider.value(
+        value: _monthlySchedulesBloc,
+        child: Scaffold(
           backgroundColor: colorScheme.surfaceContainerLow,
-          leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: () {
-              context.go('/home');
-            },
+          appBar: AppBar(
+            title: Text(AppLocalizations.of(context)!.calendarTitle),
+            backgroundColor: colorScheme.surfaceContainerLow,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: _returnHome,
+            ),
           ),
-        ),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 18.0, vertical: 16.0),
-          child: Column(
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  color: colorScheme.surface,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 16.0,
-                    horizontal: 8.0,
+          body: Padding(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 18.0, vertical: 16.0),
+            child: Column(
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    color: colorScheme.surface,
                   ),
-                  child:
-                      BlocBuilder<MonthlySchedulesBloc, MonthlySchedulesState>(
-                    builder: (context, state) {
-                      if (state.status == MonthlySchedulesStatus.error) {
-                        return Text(AppLocalizations.of(context)!.error);
-                      }
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 16.0,
+                      horizontal: 8.0,
+                    ),
+                    child: BlocBuilder<MonthlySchedulesBloc,
+                        MonthlySchedulesState>(
+                      builder: (context, state) {
+                        if (state.status == MonthlySchedulesStatus.error) {
+                          return Text(AppLocalizations.of(context)!.error);
+                        }
 
-                      return TableCalendar(
-                        locale: Localizations.localeOf(context).toString(),
-                        daysOfWeekHeight: 40,
-                        eventLoader: (day) {
-                          day = DateTime(day.year, day.month, day.day);
-                          return state.schedules[day] ?? [];
-                        },
-                        focusedDay: _selectedDate,
-                        selectedDayPredicate: (day) =>
-                            isSameDay(_selectedDate, day),
-                        firstDay: _firstDay,
-                        lastDay: _lastDay,
-                        calendarFormat: CalendarFormat.month,
-                        headerStyle: calendarTheme.headerStyle,
-                        daysOfWeekStyle: calendarTheme.daysOfWeekStyle,
-                        calendarStyle: calendarTheme.calendarStyle,
-                        onDaySelected: (selectedDay, focusedDay) {
-                          setState(() {
-                            _selectedDate =
-                                _clampDay(selectedDay, _firstDay, _lastDay);
-                          });
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesVisibleDateChanged(
-                              date: _selectedDate,
-                            ),
-                          );
-                        },
-                        onPageChanged: (focusedDay) {
-                          final clampedFocusedDay =
-                              _clampDay(focusedDay, _firstDay, _lastDay);
-
-                          setState(() {
-                            _selectedDate = clampedFocusedDay;
-                          });
-
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesVisibleDateChanged(
-                              date: _selectedDate,
-                            ),
-                          );
-
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesMonthAdded(
-                              date: DateTime(
-                                clampedFocusedDay.year,
-                                clampedFocusedDay.month,
-                                clampedFocusedDay.day,
+                        return TableCalendar(
+                          locale: Localizations.localeOf(context).toString(),
+                          daysOfWeekHeight: 40,
+                          eventLoader: (day) {
+                            day = DateTime(day.year, day.month, day.day);
+                            return state.schedules[day] ?? [];
+                          },
+                          focusedDay: _selectedDate,
+                          selectedDayPredicate: (day) =>
+                              isSameDay(_selectedDate, day),
+                          firstDay: _firstDay,
+                          lastDay: _lastDay,
+                          calendarFormat: CalendarFormat.month,
+                          headerStyle: calendarTheme.headerStyle,
+                          daysOfWeekStyle: calendarTheme.daysOfWeekStyle,
+                          calendarStyle: calendarTheme.calendarStyle,
+                          onDaySelected: (selectedDay, focusedDay) {
+                            setState(() {
+                              _selectedDate =
+                                  _clampDay(selectedDay, _firstDay, _lastDay);
+                            });
+                            _monthlySchedulesBloc.add(
+                              MonthlySchedulesVisibleDateChanged(
+                                date: _selectedDate,
                               ),
-                            ),
-                          );
-                        },
-                        calendarBuilders: CalendarBuilders(
-                          headerTitleBuilder: (context, date) {
-                            return CenteredCalendarHeader(
-                              focusedMonth: date,
-                              onLeftArrowTap: _onLeftArrowTap,
-                              onRightArrowTap: _onRightArrowTap,
-                              titleTextStyle:
-                                  calendarTheme.headerStyle.titleTextStyle,
-                              leftIcon:
-                                  calendarTheme.headerStyle.leftChevronIcon,
-                              rightIcon:
-                                  calendarTheme.headerStyle.rightChevronIcon,
                             );
                           },
-                          selectedBuilder: (context, day, focusedDay) {
-                            return Container(
+                          onPageChanged: (focusedDay) {
+                            final clampedFocusedDay =
+                                _clampDay(focusedDay, _firstDay, _lastDay);
+
+                            setState(() {
+                              _selectedDate = clampedFocusedDay;
+                            });
+
+                            _monthlySchedulesBloc.add(
+                              MonthlySchedulesVisibleDateChanged(
+                                date: _selectedDate,
+                              ),
+                            );
+
+                            _monthlySchedulesBloc.add(
+                              MonthlySchedulesMonthAdded(
+                                date: DateTime(
+                                  clampedFocusedDay.year,
+                                  clampedFocusedDay.month,
+                                  clampedFocusedDay.day,
+                                ),
+                              ),
+                            );
+                          },
+                          calendarBuilders: CalendarBuilders(
+                            headerTitleBuilder: (context, date) {
+                              return CenteredCalendarHeader(
+                                focusedMonth: date,
+                                onLeftArrowTap: _onLeftArrowTap,
+                                onRightArrowTap: _onRightArrowTap,
+                                titleTextStyle:
+                                    calendarTheme.headerStyle.titleTextStyle,
+                                leftIcon:
+                                    calendarTheme.headerStyle.leftChevronIcon,
+                                rightIcon:
+                                    calendarTheme.headerStyle.rightChevronIcon,
+                              );
+                            },
+                            selectedBuilder: (context, day, focusedDay) {
+                              return Container(
+                                margin: const EdgeInsets.all(4.0),
+                                alignment: Alignment.center,
+                                decoration: calendarTheme.selectedDayDecoration,
+                                child: Text(
+                                  DateFormat.d(
+                                    Localizations.localeOf(context).toString(),
+                                  ).format(day),
+                                  style: calendarTheme.selectedDayTextStyle,
+                                ),
+                              );
+                            },
+                            todayBuilder: (context, day, focusedDay) =>
+                                Container(
                               margin: const EdgeInsets.all(4.0),
                               alignment: Alignment.center,
-                              decoration: calendarTheme.selectedDayDecoration,
+                              decoration: calendarTheme.todayDecoration,
                               child: Text(
                                 DateFormat.d(
                                   Localizations.localeOf(context).toString(),
                                 ).format(day),
-                                style: calendarTheme.selectedDayTextStyle,
+                                style: calendarTheme.todayTextStyle,
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 27.0),
+                Expanded(
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        SizedBox(
+                          width: double.infinity,
+                          child: Text(
+                            DateFormat.MMMMd(
+                              Localizations.localeOf(context).toString(),
+                            ).format(_selectedDate),
+                            style: textTheme.headlineExtraSmall,
+                            textAlign: TextAlign.start,
+                          ),
+                        ),
+                        const SizedBox(height: 18.0),
+                        BlocBuilder<MonthlySchedulesBloc,
+                            MonthlySchedulesState>(
+                          builder: (context, state) {
+                            if (state.schedules[_selectedDate]?.isEmpty ??
+                                true) {
+                              if (state.status ==
+                                  MonthlySchedulesStatus.loading) {
+                                return const CircularProgressIndicator();
+                              }
+
+                              if (state.status !=
+                                  MonthlySchedulesStatus.success) {
+                                return const SizedBox();
+                              }
+
+                              final now = DateTime.now();
+                              final today =
+                                  DateTime(now.year, now.month, now.day);
+                              final selected = DateTime(
+                                _selectedDate.year,
+                                _selectedDate.month,
+                                _selectedDate.day,
+                              );
+                              final isPastSelectedDay =
+                                  selected.isBefore(today);
+
+                              return Padding(
+                                padding: const EdgeInsets.all(39.0),
+                                child: Column(
+                                  spacing: 16.0,
+                                  children: [
+                                    Text(
+                                      AppLocalizations.of(context)!.noSchedules,
+                                      style: textTheme.titleMedium?.copyWith(
+                                        color: theme.colorScheme.outlineVariant,
+                                      ),
+                                    ),
+                                    if (!isPastSelectedDay)
+                                      ElevatedButton(
+                                        onPressed: () =>
+                                            _openCreateScheduleSheet(context),
+                                        style: ElevatedButton.styleFrom(
+                                          backgroundColor:
+                                              theme.colorScheme.surface,
+                                          side: BorderSide(
+                                            width: 0.5,
+                                            color: theme
+                                                .colorScheme.outlineVariant,
+                                          ),
+                                          padding: const EdgeInsets.symmetric(
+                                            vertical: 4.0,
+                                            horizontal: 12.0,
+                                          ),
+                                        ),
+                                        child: Text(
+                                          AppLocalizations.of(context)!
+                                              .addAppointment,
+                                          style: textTheme.bodyMedium?.copyWith(
+                                            color: theme
+                                                .colorScheme.onSurfaceVariant,
+                                          ),
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              );
+                            }
+
+                            return Expanded(
+                              child: ListView.builder(
+                                itemCount:
+                                    state.schedules[_selectedDate]?.length ?? 0,
+                                itemBuilder: (context, index) {
+                                  final schedule =
+                                      state.schedules[_selectedDate]![index];
+
+                                  return BlocBuilder<ScheduleBloc,
+                                      ScheduleState>(
+                                    builder: (context, scheduleState) {
+                                      final isEarlyStarted =
+                                          scheduleState.isEarlyStarted &&
+                                              scheduleState.schedule?.id ==
+                                                  schedule.id;
+
+                                      return ScheduleDetail(
+                                        schedule: schedule,
+                                        preparationTime: state
+                                                .preparationDurationByScheduleId[
+                                            schedule.id],
+                                        isEarlyStarted: isEarlyStarted,
+                                        onEdit: () {
+                                          _openEditScheduleSheet(
+                                            context,
+                                            scheduleId: schedule.id,
+                                          );
+                                        },
+                                        onDeleted: () {
+                                          showTwoButtonDeleteDialog(
+                                            context,
+                                            title: AppLocalizations.of(context)!
+                                                .scheduleDeleteConfirmTitle,
+                                            description: AppLocalizations.of(
+                                                    context)!
+                                                .scheduleDeleteConfirmDescription,
+                                            cancelText:
+                                                AppLocalizations.of(context)!
+                                                    .cancel,
+                                            confirmText: AppLocalizations.of(
+                                                    context)!
+                                                .deleteScheduleConfirmAction,
+                                          ).then((confirmed) {
+                                            if (confirmed != true ||
+                                                !context.mounted) {
+                                              return;
+                                            }
+                                            _monthlySchedulesBloc.add(
+                                              MonthlySchedulesScheduleDeleted(
+                                                schedule: schedule,
+                                              ),
+                                            );
+                                          });
+                                        },
+                                      );
+                                    },
+                                  );
+                                },
                               ),
                             );
                           },
-                          todayBuilder: (context, day, focusedDay) => Container(
-                            margin: const EdgeInsets.all(4.0),
-                            alignment: Alignment.center,
-                            decoration: calendarTheme.todayDecoration,
-                            child: Text(
-                              DateFormat.d(
-                                Localizations.localeOf(context).toString(),
-                              ).format(day),
-                              style: calendarTheme.todayTextStyle,
-                            ),
-                          ),
                         ),
-                      );
-                    },
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 27.0),
-              Expanded(
-                child: SizedBox(
-                  width: double.infinity,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        width: double.infinity,
-                        child: Text(
-                          DateFormat.MMMMd(
-                            Localizations.localeOf(context).toString(),
-                          ).format(_selectedDate),
-                          style: textTheme.headlineExtraSmall,
-                          textAlign: TextAlign.start,
-                        ),
-                      ),
-                      const SizedBox(height: 18.0),
-                      BlocBuilder<MonthlySchedulesBloc, MonthlySchedulesState>(
-                        builder: (context, state) {
-                          if (state.schedules[_selectedDate]?.isEmpty ?? true) {
-                            if (state.status ==
-                                MonthlySchedulesStatus.loading) {
-                              return const CircularProgressIndicator();
-                            }
-
-                            if (state.status !=
-                                MonthlySchedulesStatus.success) {
-                              return const SizedBox();
-                            }
-
-                            final now = DateTime.now();
-                            final today =
-                                DateTime(now.year, now.month, now.day);
-                            final selected = DateTime(
-                              _selectedDate.year,
-                              _selectedDate.month,
-                              _selectedDate.day,
-                            );
-                            final isPastSelectedDay = selected.isBefore(today);
-
-                            return Padding(
-                              padding: const EdgeInsets.all(39.0),
-                              child: Column(
-                                spacing: 16.0,
-                                children: [
-                                  Text(
-                                    AppLocalizations.of(context)!.noSchedules,
-                                    style: textTheme.titleMedium?.copyWith(
-                                      color: theme.colorScheme.outlineVariant,
-                                    ),
-                                  ),
-                                  if (!isPastSelectedDay)
-                                    ElevatedButton(
-                                      onPressed: () =>
-                                          _openCreateScheduleSheet(context),
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor:
-                                            theme.colorScheme.surface,
-                                        side: BorderSide(
-                                          width: 0.5,
-                                          color:
-                                              theme.colorScheme.outlineVariant,
-                                        ),
-                                        padding: const EdgeInsets.symmetric(
-                                          vertical: 4.0,
-                                          horizontal: 12.0,
-                                        ),
-                                      ),
-                                      child: Text(
-                                        AppLocalizations.of(context)!
-                                            .addAppointment,
-                                        style: textTheme.bodyMedium?.copyWith(
-                                          color: theme
-                                              .colorScheme.onSurfaceVariant,
-                                        ),
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            );
-                          }
-
-                          return Expanded(
-                            child: ListView.builder(
-                              itemCount:
-                                  state.schedules[_selectedDate]?.length ?? 0,
-                              itemBuilder: (context, index) {
-                                final schedule =
-                                    state.schedules[_selectedDate]![index];
-
-                                return BlocBuilder<ScheduleBloc, ScheduleState>(
-                                  builder: (context, scheduleState) {
-                                    final isEarlyStarted =
-                                        scheduleState.isEarlyStarted &&
-                                            scheduleState.schedule?.id ==
-                                                schedule.id;
-
-                                    return ScheduleDetail(
-                                      schedule: schedule,
-                                      preparationTime:
-                                          state.preparationDurationByScheduleId[
-                                              schedule.id],
-                                      isEarlyStarted: isEarlyStarted,
-                                      onEdit: () {
-                                        _openEditScheduleSheet(
-                                          context,
-                                          scheduleId: schedule.id,
-                                        );
-                                      },
-                                      onDeleted: () {
-                                        showTwoButtonDeleteDialog(
-                                          context,
-                                          title: AppLocalizations.of(context)!
-                                              .scheduleDeleteConfirmTitle,
-                                          description: AppLocalizations.of(
-                                                  context)!
-                                              .scheduleDeleteConfirmDescription,
-                                          cancelText:
-                                              AppLocalizations.of(context)!
-                                                  .cancel,
-                                          confirmText:
-                                              AppLocalizations.of(context)!
-                                                  .deleteScheduleConfirmAction,
-                                        ).then((confirmed) {
-                                          if (confirmed != true ||
-                                              !context.mounted) {
-                                            return;
-                                          }
-                                          _monthlySchedulesBloc.add(
-                                            MonthlySchedulesScheduleDeleted(
-                                              schedule: schedule,
-                                            ),
-                                          );
-                                        });
-                                      },
-                                    );
-                                  },
-                                );
-                              },
-                            ),
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/test/presentation/calendar/screens/calendar_screen_test.dart
+++ b/test/presentation/calendar/screens/calendar_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mockito/mockito.dart';
+import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
+import 'package:on_time_front/presentation/calendar/screens/calendar_screen.dart';
+import 'package:on_time_front/presentation/shared/theme/theme.dart';
+
+class _StubMonthlySchedulesBloc extends Mock implements MonthlySchedulesBloc {
+  @override
+  MonthlySchedulesState get state => const MonthlySchedulesState(
+        status: MonthlySchedulesStatus.success,
+      );
+
+  @override
+  Stream<MonthlySchedulesState> get stream => const Stream.empty();
+
+  @override
+  bool get isClosed => false;
+
+  @override
+  void add(MonthlySchedulesEvent event) {}
+
+  @override
+  Future<void> close() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  testWidgets('android system back from calendar returns to home',
+      (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(390, 844);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    getIt.registerFactory<MonthlySchedulesBloc>(
+      _StubMonthlySchedulesBloc.new,
+    );
+
+    final router = GoRouter(
+      initialLocation: '/calendar',
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (context, state) => const Scaffold(
+            body: Text('Home Screen'),
+          ),
+        ),
+        GoRoute(
+          path: '/calendar',
+          builder: (context, state) => const CalendarScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        theme: themeData,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CalendarScreen), findsOneWidget);
+    expect(find.text('Home Screen'), findsNothing);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CalendarScreen), findsNothing);
+    expect(find.text('Home Screen'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes Android system back behavior on the calendar screen so pressing back returns to the home screen instead of closing the app.

## Root Cause

The home calendar entry uses route replacement, so when `/calendar` is the top-level location Android back has no prior route to pop and the app can terminate. The calendar app-bar back button already navigated to `/home`, but the system back path was not handled.

## Changes

- Added a shared `_returnHome()` helper for calendar back navigation.
- Wrapped `CalendarScreen` in `PopScope` to intercept Android back and route to `/home`.
- Added a widget test that simulates Android back from `/calendar` and verifies the home route is shown.

## Validation

- `flutter test test/presentation/calendar/screens/calendar_screen_test.dart`
- `flutter analyze`