### PR TITLE
[codex] Fix schedule date-time validation and picker cancel flow

### DIFF
--- a/lib/presentation/schedule_create/components/schedule_multi_page_form.dart
+++ b/lib/presentation/schedule_create/components/schedule_multi_page_form.dart
@@ -107,13 +107,12 @@ class _ScheduleMultiPageFormState extends State<ScheduleMultiPageForm>
                       TopBar(
                         onNextPageButtonClicked:
                             (state.isValid && !isSubmitting)
-                            ? () => _onNextPageButtonClicked(context)
-                            : null,
+                                ? () => _onNextPageButtonClicked(context)
+                                : null,
                         // 버튼 활성화 판별
                         isNextButtonEnabled: state.isValid && !isSubmitting,
-                        onPreviousPageButtonClicked: isSubmitting
-                            ? null
-                            : _onPreviousPageButtonClicked,
+                        onPreviousPageButtonClicked:
+                            isSubmitting ? null : _onPreviousPageButtonClicked,
                       ),
                       SizedBox(height: 26),
                       StepProgress(
@@ -158,7 +157,11 @@ class _ScheduleMultiPageFormState extends State<ScheduleMultiPageForm>
         });
         break;
       case const (ScheduleDateTimeCubit):
-        context.read<ScheduleDateTimeCubit>().scheduleDateTimeSubmitted();
+        final didSubmit =
+            context.read<ScheduleDateTimeCubit>().scheduleDateTimeSubmitted();
+        if (!didSubmit) {
+          return;
+        }
         // Initialize next cubit after submitting current page
         WidgetsBinding.instance.addPostFrameCallback((_) {
           context.read<SchedulePlaceMovingTimeCubit>().initialize();

--- a/lib/presentation/schedule_create/components/top_bar.dart
+++ b/lib/presentation/schedule_create/components/top_bar.dart
@@ -38,7 +38,7 @@ class TopBar extends StatelessWidget {
         // 다음 페이지 버튼
         // 버튼 활성화 여부에 따라 색상 변화 추후 추가 가능
         TextButton(
-          onPressed: onNextPageButtonClicked,
+          onPressed: isNextButtonEnabled ? onNextPageButtonClicked : null,
           child: Text(AppLocalizations.of(context)!.next),
         ),
       ],

--- a/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_cubit.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_cubit.dart
@@ -39,12 +39,13 @@ class ScheduleDateTimeCubit extends Cubit<ScheduleDateTimeState> {
     // Check for schedule overlap if both date and time are valid
     if (scheduleDateTimeState.scheduleDate.isValid &&
         scheduleDateTimeState.scheduleTime.isValid) {
+      scheduleFormBloc.add(ScheduleFormValidated(isValid: false));
       // Load adjacent schedules first, then check overlap
       _loadAdjacentSchedules(scheduleDateTimeState.scheduleDate.value!)
           .then((_) => checkScheduleOverlap());
+    } else {
+      scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
     }
-
-    scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
   }
 
   Future<void> scheduleDateChanged(DateTime scheduleDate) async {
@@ -72,8 +73,13 @@ class ScheduleDateTimeCubit extends Cubit<ScheduleDateTimeState> {
 
     // Never load nextSchedule, only check overlap
     if (state.scheduleDate.isValid && scheduleTimeInputModel.isValid) {
+      scheduleFormBloc.add(ScheduleFormValidated(isValid: false));
       await checkScheduleOverlap();
     }
+    scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
+  }
+
+  void validateCurrentSelection() {
     scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
   }
 
@@ -97,6 +103,7 @@ class ScheduleDateTimeCubit extends Cubit<ScheduleDateTimeState> {
 
   Future<void> checkScheduleOverlap() async {
     if (state.scheduleDate.value == null || state.scheduleTime.value == null) {
+      scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
       return;
     }
 
@@ -272,9 +279,11 @@ class ScheduleDateTimeCubit extends Cubit<ScheduleDateTimeState> {
       debugPrint('Error checking schedule overlap: $e');
       emit(state.copyWith(clearOverlap: true, clearPreviousOverlap: true));
     }
+
+    scheduleFormBloc.add(ScheduleFormValidated(isValid: state.isValid));
   }
 
-  void scheduleDateTimeSubmitted() {
+  bool scheduleDateTimeSubmitted() {
     if (state.scheduleDate.isValid &&
         state.scheduleTime.isValid &&
         state.isOverlapping == false) {
@@ -291,7 +300,11 @@ class ScheduleDateTimeCubit extends Cubit<ScheduleDateTimeState> {
         maxAvailableTime: state.previousOverlapDuration,
         previousScheduleName: state.previousScheduleName,
       ));
+      return true;
     }
+
+    scheduleFormBloc.add(ScheduleFormValidated(isValid: false));
+    return false;
   }
 
   ({DateTime startDate, DateTime endDate}) _getDateRange(DateTime date) {

--- a/lib/presentation/schedule_create/schedule_date_time/screens/schedule_date_time_form.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/screens/schedule_date_time_form.dart
@@ -16,6 +16,13 @@ class ScheduleDateTimeForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final hintStyle = Theme.of(context).inputDecorationTheme.hintStyle ??
+        Theme.of(context).textTheme.bodyLarge;
+    final fadedHintStyle = hintStyle?.copyWith(
+      color: (hintStyle.color ?? Theme.of(context).hintColor)
+          .withValues(alpha: 0.45),
+    );
+
     return BlocBuilder<ScheduleDateTimeCubit, ScheduleDateTimeState>(
         builder: (context, state) {
       return Column(
@@ -31,6 +38,7 @@ class ScheduleDateTimeForm extends StatelessWidget {
                   decoration: InputDecoration(
                     labelText: AppLocalizations.of(context)!.appointmentTime,
                     hintText: _localizedDateString(context, DateTime.now()),
+                    hintStyle: fadedHintStyle,
                   ),
                   controller: TextEditingController(
                       text: state.scheduleDate.value == null
@@ -42,7 +50,11 @@ class ScheduleDateTimeForm extends StatelessWidget {
                       title: AppLocalizations.of(context)!.enterDate,
                       mode: CupertinoDatePickerMode.date,
                       initialValue: state.scheduleDate.value ?? DateTime.now(),
-                      onDisposed: () {},
+                      onDisposed: () {
+                        context
+                            .read<ScheduleDateTimeCubit>()
+                            .validateCurrentSelection();
+                      },
                       onSaved: (DateTime newDateTime) {
                         context
                             .read<ScheduleDateTimeCubit>()
@@ -63,7 +75,8 @@ class ScheduleDateTimeForm extends StatelessWidget {
                       labelText: '',
                       hintText: DateFormat.jm(
                               Localizations.localeOf(context).toString())
-                          .format(DateTime.now())),
+                          .format(DateTime.now()),
+                      hintStyle: fadedHintStyle),
                   controller: TextEditingController(
                     text: state.scheduleTime.value == null
                         ? null
@@ -76,7 +89,11 @@ class ScheduleDateTimeForm extends StatelessWidget {
                       title: AppLocalizations.of(context)!.enterTime,
                       mode: CupertinoDatePickerMode.time,
                       initialValue: state.scheduleTime.value ?? DateTime.now(),
-                      onDisposed: () {},
+                      onDisposed: () {
+                        context
+                            .read<ScheduleDateTimeCubit>()
+                            .validateCurrentSelection();
+                      },
                       onSaved: (DateTime newDateTime) {
                         context
                             .read<ScheduleDateTimeCubit>()
@@ -115,7 +132,7 @@ String _localizedDateString(BuildContext context, DateTime date) {
   if (locale == 'ko') {
     return DateFormat('yyyy년 MM월 dd일', 'ko').format(date);
   } else {
-    return DateFormat('yyyy.mm.dd.', Localizations.localeOf(context).toString())
+    return DateFormat('yyyy.MM.dd.', Localizations.localeOf(context).toString())
         .format(date);
   }
 }

--- a/lib/presentation/schedule_create/schedule_spare_and_preparing_time/screens/schedule_spare_and_preparing_time_form.dart
+++ b/lib/presentation/schedule_create/schedule_spare_and_preparing_time/screens/schedule_spare_and_preparing_time_form.dart
@@ -87,7 +87,7 @@ class _ScheduleSpareAndPreparingTimeFormState
                       decoration: InputDecoration(
                           labelText: AppLocalizations.of(context)!.spareTime),
                       controller: TextEditingController(
-                          text: formatDuration(context, spareTime)),
+                          text: formatDurationAsMinutes(context, spareTime)),
                       onTap: () {
                         context.showCupertinoMinutePickerModal(
                             title: AppLocalizations.of(context)!.enterTime,

--- a/lib/presentation/shared/utils/duration_format.dart
+++ b/lib/presentation/shared/utils/duration_format.dart
@@ -20,3 +20,8 @@ String formatDuration(BuildContext context, Duration duration) {
 
   return parts.join(' ');
 }
+
+String formatDurationAsMinutes(BuildContext context, Duration duration) {
+  final localizations = AppLocalizations.of(context)!;
+  return localizations.minuteFormatted(duration.inMinutes);
+}

--- a/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
+++ b/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
@@ -9,7 +9,9 @@ import 'package:on_time_front/domain/entities/adjacent_schedules_with_preparatio
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
 import 'package:on_time_front/domain/entities/user_entity.dart';
 import 'package:on_time_front/domain/use-cases/create_custom_preparation_use_case.dart';
 import 'package:on_time_front/domain/use-cases/create_schedule_with_place_use_case.dart';
@@ -224,6 +226,14 @@ void main() {
     await loaded;
   }
 
+  Future<void> primeCreateState(ScheduleFormBloc bloc) async {
+    final loaded = bloc.stream.firstWhere(
+      (state) => state.status == ScheduleFormStatus.success,
+    );
+    bloc.add(const ScheduleFormCreateRequested());
+    await loaded;
+  }
+
   Future<void> pumpSheet(WidgetTester tester, ScheduleFormBloc bloc) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -428,5 +438,82 @@ void main() {
     expect(updatedSchedule, isNotNull);
     expect(updatedSchedule!.scheduleName, 'Edited Meeting');
     expect(updatedSchedule!.place.placeName, 'New Office');
+  });
+
+  testWidgets('date time overlap keeps next disabled', (tester) async {
+    getAdjacentSchedulesWithPreparationUseCase =
+        StubGetAdjacentSchedulesWithPreparationUseCase(
+      ({
+        required selectedDateTime,
+        String? currentScheduleId,
+        required startDate,
+        required endDate,
+      }) async =>
+          AdjacentSchedulesWithPreparationEntity(
+        nextSchedule: ScheduleWithPreparationEntity(
+          id: 'schedule-2',
+          place: const PlaceEntity(id: 'place-2', placeName: 'Next Office'),
+          scheduleName: 'Next Meeting',
+          scheduleTime: DateTime(2026, 3, 20, 9, 20),
+          moveTime: const Duration(minutes: 10),
+          isChanged: false,
+          isStarted: false,
+          scheduleSpareTime: Duration.zero,
+          scheduleNote: '',
+          preparation: PreparationWithTimeEntity.fromPreparation(preparation),
+        ),
+      ),
+    );
+
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    await primeEditState(bloc);
+    await pumpSheet(tester, bloc);
+
+    Finder nextButton() => find.descendant(
+          of: find.byType(TopBar),
+          matching: find.byType(TextButton),
+        );
+
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    final button = tester.widget<TextButton>(nextButton());
+    expect(button.onPressed, isNull);
+  });
+
+  testWidgets('cancelling date and time pickers keeps next disabled',
+      (tester) async {
+    final bloc = buildBloc();
+    addTearDown(bloc.close);
+
+    await primeCreateState(bloc);
+    await pumpSheet(tester, bloc);
+
+    Finder nextButton() => find.descendant(
+          of: find.byType(TopBar),
+          matching: find.byType(TextButton),
+        );
+
+    await tester.enterText(find.byType(TextFormField).first, 'Meeting');
+    await tester.pump();
+    await tester.tap(nextButton());
+    await tester.pumpAndSettle();
+
+    for (var i = 0; i < 3; i++) {
+      await tester.tap(find.byType(TextField).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(TextField).at(1));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Cancel'));
+      await tester.pumpAndSettle();
+    }
+
+    final button = tester.widget<TextButton>(nextButton());
+    expect(button.onPressed, isNull);
   });
 }


### PR DESCRIPTION
## Summary
- Fix schedule date display to use the month token instead of minutes.
- Show schedule spare time as total minutes.
- Keep the date/time Next button disabled while async overlap checks run and after picker cancellations when no value was selected.
- Add widget regression coverage for overlap validation and repeated date/time picker cancellation.

## Validation
- flutter analyze
- flutter test test/presentation/schedule_create/components/schedule_multi_page_form_test.dart