### PR TITLE
Restore the calendar to a natural, smaller layout

### DIFF
--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
 import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
@@ -27,6 +28,12 @@ class CalendarScreen extends StatefulWidget {
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
+  static const double _calendarHorizontalPadding = 8.0;
+  static const double _calendarVerticalPadding = 16.0;
+  static const double _calendarDaysOfWeekHeight = 40.0;
+  static const double _calendarHeaderHeight = 64.0;
+  static const double _selectedDateMinHeight = 120.0;
+
   late DateTime _selectedDate;
   late final MonthlySchedulesBloc _monthlySchedulesBloc;
 
@@ -135,6 +142,49 @@ class _CalendarScreenState extends State<CalendarScreen> {
     _refreshSchedulesIfSaved(saved);
   }
 
+  double _calendarDetailGap(double maxHeight) {
+    if (!maxHeight.isFinite) {
+      return 27.0;
+    }
+
+    if (maxHeight < 620.0) {
+      return 12.0;
+    }
+
+    if (maxHeight < 720.0) {
+      return 18.0;
+    }
+
+    return 27.0;
+  }
+
+  double _calendarRowHeight({
+    required double maxHeight,
+    required double detailGap,
+  }) {
+    if (!maxHeight.isFinite) {
+      return 52.0;
+    }
+
+    final availableCalendarHeight =
+        maxHeight - detailGap - _selectedDateMinHeight;
+    final availableRowsHeight = availableCalendarHeight -
+        (_calendarVerticalPadding * 2) -
+        _calendarHeaderHeight -
+        _calendarDaysOfWeekHeight;
+    final fittedRowHeight = availableRowsHeight / 6;
+
+    return fittedRowHeight.clamp(24.0, 52.0).toDouble();
+  }
+
+  double _selectedDateHeadingGap(double maxHeight) {
+    if (maxHeight.isFinite && maxHeight < 620.0) {
+      return 12.0;
+    }
+
+    return 18.0;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -158,271 +208,329 @@ class _CalendarScreenState extends State<CalendarScreen> {
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 18.0, vertical: 16.0),
-          child: Column(
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  color: colorScheme.surface,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 16.0,
-                    horizontal: 8.0,
-                  ),
-                  child:
-                      BlocBuilder<MonthlySchedulesBloc, MonthlySchedulesState>(
-                    builder: (context, state) {
-                      if (state.status == MonthlySchedulesStatus.error) {
-                        return Text(AppLocalizations.of(context)!.error);
-                      }
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final detailGap = _calendarDetailGap(constraints.maxHeight);
+              final rowHeight = _calendarRowHeight(
+                maxHeight: constraints.maxHeight,
+                detailGap: detailGap,
+              );
+              final selectedDateHeadingGap =
+                  _selectedDateHeadingGap(constraints.maxHeight);
 
-                      return TableCalendar(
-                        locale: Localizations.localeOf(context).toString(),
-                        daysOfWeekHeight: 40,
-                        eventLoader: (day) {
-                          day = DateTime(day.year, day.month, day.day);
-                          return state.schedules[day] ?? [];
-                        },
-                        focusedDay: _selectedDate,
-                        selectedDayPredicate: (day) =>
-                            isSameDay(_selectedDate, day),
-                        firstDay: _firstDay,
-                        lastDay: _lastDay,
-                        calendarFormat: CalendarFormat.month,
-                        headerStyle: calendarTheme.headerStyle,
-                        daysOfWeekStyle: calendarTheme.daysOfWeekStyle,
-                        calendarStyle: calendarTheme.calendarStyle,
-                        onDaySelected: (selectedDay, focusedDay) {
-                          setState(() {
-                            _selectedDate =
-                                _clampDay(selectedDay, _firstDay, _lastDay);
-                          });
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesVisibleDateChanged(
-                              date: _selectedDate,
-                            ),
-                          );
-                        },
-                        onPageChanged: (focusedDay) {
-                          final clampedFocusedDay =
-                              _clampDay(focusedDay, _firstDay, _lastDay);
-
-                          setState(() {
-                            _selectedDate = clampedFocusedDay;
-                          });
-
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesVisibleDateChanged(
-                              date: _selectedDate,
-                            ),
-                          );
-
-                          _monthlySchedulesBloc.add(
-                            MonthlySchedulesMonthAdded(
-                              date: DateTime(
-                                clampedFocusedDay.year,
-                                clampedFocusedDay.month,
-                                clampedFocusedDay.day,
-                              ),
-                            ),
-                          );
-                        },
-                        calendarBuilders: CalendarBuilders(
-                          headerTitleBuilder: (context, date) {
-                            return CenteredCalendarHeader(
-                              focusedMonth: date,
-                              onLeftArrowTap: _onLeftArrowTap,
-                              onRightArrowTap: _onRightArrowTap,
-                              titleTextStyle:
-                                  calendarTheme.headerStyle.titleTextStyle,
-                              leftIcon:
-                                  calendarTheme.headerStyle.leftChevronIcon,
-                              rightIcon:
-                                  calendarTheme.headerStyle.rightChevronIcon,
-                            );
-                          },
-                          selectedBuilder: (context, day, focusedDay) {
-                            return Container(
-                              margin: const EdgeInsets.all(4.0),
-                              alignment: Alignment.center,
-                              decoration: calendarTheme.selectedDayDecoration,
-                              child: Text(
-                                DateFormat.d(
-                                  Localizations.localeOf(context).toString(),
-                                ).format(day),
-                                style: calendarTheme.selectedDayTextStyle,
-                              ),
-                            );
-                          },
-                          todayBuilder: (context, day, focusedDay) => Container(
-                            margin: const EdgeInsets.all(4.0),
-                            alignment: Alignment.center,
-                            decoration: calendarTheme.todayDecoration,
-                            child: Text(
-                              DateFormat.d(
-                                Localizations.localeOf(context).toString(),
-                              ).format(day),
-                              style: calendarTheme.todayTextStyle,
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-              const SizedBox(height: 27.0),
-              Expanded(
-                child: SizedBox(
-                  width: double.infinity,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        width: double.infinity,
-                        child: Text(
-                          DateFormat.MMMMd(
-                            Localizations.localeOf(context).toString(),
-                          ).format(_selectedDate),
-                          style: textTheme.headlineExtraSmall,
-                          textAlign: TextAlign.start,
-                        ),
+              return Column(
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      color: colorScheme.surface,
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: _calendarVerticalPadding,
+                        horizontal: _calendarHorizontalPadding,
                       ),
-                      const SizedBox(height: 18.0),
-                      BlocBuilder<MonthlySchedulesBloc, MonthlySchedulesState>(
+                      child: BlocBuilder<MonthlySchedulesBloc,
+                          MonthlySchedulesState>(
                         builder: (context, state) {
-                          if (state.schedules[_selectedDate]?.isEmpty ?? true) {
-                            if (state.status ==
-                                MonthlySchedulesStatus.loading) {
-                              return const CircularProgressIndicator();
-                            }
-
-                            if (state.status !=
-                                MonthlySchedulesStatus.success) {
-                              return const SizedBox();
-                            }
-
-                            final now = DateTime.now();
-                            final today =
-                                DateTime(now.year, now.month, now.day);
-                            final selected = DateTime(
-                              _selectedDate.year,
-                              _selectedDate.month,
-                              _selectedDate.day,
-                            );
-                            final isPastSelectedDay = selected.isBefore(today);
-
-                            return Padding(
-                              padding: const EdgeInsets.all(39.0),
-                              child: Column(
-                                spacing: 16.0,
-                                children: [
-                                  Text(
-                                    AppLocalizations.of(context)!.noSchedules,
-                                    style: textTheme.titleMedium?.copyWith(
-                                      color: theme.colorScheme.outlineVariant,
-                                    ),
-                                  ),
-                                  if (!isPastSelectedDay)
-                                    ElevatedButton(
-                                      onPressed: () =>
-                                          _openCreateScheduleSheet(context),
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor:
-                                            theme.colorScheme.surface,
-                                        side: BorderSide(
-                                          width: 0.5,
-                                          color:
-                                              theme.colorScheme.outlineVariant,
-                                        ),
-                                        padding: const EdgeInsets.symmetric(
-                                          vertical: 4.0,
-                                          horizontal: 12.0,
-                                        ),
-                                      ),
-                                      child: Text(
-                                        AppLocalizations.of(context)!
-                                            .addAppointment,
-                                        style: textTheme.bodyMedium?.copyWith(
-                                          color: theme
-                                              .colorScheme.onSurfaceVariant,
-                                        ),
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            );
+                          if (state.status == MonthlySchedulesStatus.error) {
+                            return Text(AppLocalizations.of(context)!.error);
                           }
 
-                          return Expanded(
-                            child: ListView.builder(
-                              itemCount:
-                                  state.schedules[_selectedDate]?.length ?? 0,
-                              itemBuilder: (context, index) {
-                                final schedule =
-                                    state.schedules[_selectedDate]![index];
+                          return TableCalendar(
+                            locale: Localizations.localeOf(context).toString(),
+                            daysOfWeekHeight: _calendarDaysOfWeekHeight,
+                            sixWeekMonthsEnforced: true,
+                            rowHeight: rowHeight,
+                            eventLoader: (day) {
+                              day = DateTime(day.year, day.month, day.day);
+                              return state.schedules[day] ?? [];
+                            },
+                            focusedDay: _selectedDate,
+                            selectedDayPredicate: (day) =>
+                                isSameDay(_selectedDate, day),
+                            firstDay: _firstDay,
+                            lastDay: _lastDay,
+                            calendarFormat: CalendarFormat.month,
+                            headerStyle: calendarTheme.headerStyle,
+                            daysOfWeekStyle: calendarTheme.daysOfWeekStyle,
+                            calendarStyle: calendarTheme.calendarStyle,
+                            onDaySelected: (selectedDay, focusedDay) {
+                              setState(() {
+                                _selectedDate =
+                                    _clampDay(selectedDay, _firstDay, _lastDay);
+                              });
+                              _monthlySchedulesBloc.add(
+                                MonthlySchedulesVisibleDateChanged(
+                                  date: _selectedDate,
+                                ),
+                              );
+                            },
+                            onPageChanged: (focusedDay) {
+                              final clampedFocusedDay =
+                                  _clampDay(focusedDay, _firstDay, _lastDay);
 
-                                return BlocBuilder<ScheduleBloc, ScheduleState>(
-                                  builder: (context, scheduleState) {
-                                    final isEarlyStarted =
-                                        scheduleState.isEarlyStarted &&
-                                            scheduleState.schedule?.id ==
-                                                schedule.id;
+                              setState(() {
+                                _selectedDate = clampedFocusedDay;
+                              });
 
-                                    return ScheduleDetail(
-                                      schedule: schedule,
-                                      preparationTime:
-                                          state.preparationDurationByScheduleId[
-                                              schedule.id],
-                                      isEarlyStarted: isEarlyStarted,
-                                      onEdit: () {
-                                        _openEditScheduleSheet(
-                                          context,
-                                          scheduleId: schedule.id,
-                                        );
-                                      },
-                                      onDeleted: () {
-                                        showTwoButtonDeleteDialog(
-                                          context,
-                                          title: AppLocalizations.of(context)!
-                                              .scheduleDeleteConfirmTitle,
-                                          description: AppLocalizations.of(
-                                                  context)!
-                                              .scheduleDeleteConfirmDescription,
-                                          cancelText:
-                                              AppLocalizations.of(context)!
-                                                  .cancel,
-                                          confirmText:
-                                              AppLocalizations.of(context)!
-                                                  .deleteScheduleConfirmAction,
-                                        ).then((confirmed) {
-                                          if (confirmed != true ||
-                                              !context.mounted) {
-                                            return;
-                                          }
-                                          _monthlySchedulesBloc.add(
-                                            MonthlySchedulesScheduleDeleted(
-                                              schedule: schedule,
-                                            ),
-                                          );
-                                        });
-                                      },
-                                    );
+                              _monthlySchedulesBloc.add(
+                                MonthlySchedulesVisibleDateChanged(
+                                  date: _selectedDate,
+                                ),
+                              );
+
+                              _monthlySchedulesBloc.add(
+                                MonthlySchedulesMonthAdded(
+                                  date: DateTime(
+                                    clampedFocusedDay.year,
+                                    clampedFocusedDay.month,
+                                    clampedFocusedDay.day,
+                                  ),
+                                ),
+                              );
+                            },
+                            calendarBuilders: CalendarBuilders(
+                              headerTitleBuilder: (context, date) {
+                                return CenteredCalendarHeader(
+                                  focusedMonth: date,
+                                  onLeftArrowTap: _onLeftArrowTap,
+                                  onRightArrowTap: _onRightArrowTap,
+                                  titleTextStyle:
+                                      calendarTheme.headerStyle.titleTextStyle,
+                                  leftIcon:
+                                      calendarTheme.headerStyle.leftChevronIcon,
+                                  rightIcon: calendarTheme
+                                      .headerStyle.rightChevronIcon,
+                                );
+                              },
+                              selectedBuilder: (context, day, focusedDay) {
+                                return Container(
+                                  margin: const EdgeInsets.all(4.0),
+                                  alignment: Alignment.center,
+                                  decoration:
+                                      calendarTheme.selectedDayDecoration,
+                                  child: Text(
+                                    DateFormat.d(
+                                      Localizations.localeOf(context)
+                                          .toString(),
+                                    ).format(day),
+                                    style: calendarTheme.selectedDayTextStyle,
+                                  ),
+                                );
+                              },
+                              todayBuilder: (context, day, focusedDay) =>
+                                  Container(
+                                margin: const EdgeInsets.all(4.0),
+                                alignment: Alignment.center,
+                                decoration: calendarTheme.todayDecoration,
+                                child: Text(
+                                  DateFormat.d(
+                                    Localizations.localeOf(context).toString(),
+                                  ).format(day),
+                                  style: calendarTheme.todayTextStyle,
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: detailGap),
+                  Expanded(
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          SizedBox(
+                            width: double.infinity,
+                            child: Text(
+                              DateFormat.MMMMd(
+                                Localizations.localeOf(context).toString(),
+                              ).format(_selectedDate),
+                              style: textTheme.headlineExtraSmall,
+                              textAlign: TextAlign.start,
+                            ),
+                          ),
+                          SizedBox(height: selectedDateHeadingGap),
+                          Expanded(
+                            child: BlocBuilder<MonthlySchedulesBloc,
+                                MonthlySchedulesState>(
+                              builder: (context, state) {
+                                return _SelectedDateSchedulesContent(
+                                  selectedDate: _selectedDate,
+                                  state: state,
+                                  onAddSchedule: () =>
+                                      _openCreateScheduleSheet(context),
+                                  onEditSchedule: (scheduleId) =>
+                                      _openEditScheduleSheet(
+                                    context,
+                                    scheduleId: scheduleId,
+                                  ),
+                                  onDeleteSchedule: (schedule) {
+                                    showTwoButtonDeleteDialog(
+                                      context,
+                                      title: AppLocalizations.of(context)!
+                                          .scheduleDeleteConfirmTitle,
+                                      description: AppLocalizations.of(context)!
+                                          .scheduleDeleteConfirmDescription,
+                                      cancelText:
+                                          AppLocalizations.of(context)!.cancel,
+                                      confirmText: AppLocalizations.of(context)!
+                                          .deleteScheduleConfirmAction,
+                                    ).then((confirmed) {
+                                      if (confirmed != true ||
+                                          !context.mounted) {
+                                        return;
+                                      }
+                                      _monthlySchedulesBloc.add(
+                                        MonthlySchedulesScheduleDeleted(
+                                          schedule: schedule,
+                                        ),
+                                      );
+                                    });
                                   },
                                 );
                               },
                             ),
-                          );
-                        },
+                          ),
+                        ],
                       ),
-                    ],
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectedDateSchedulesContent extends StatelessWidget {
+  const _SelectedDateSchedulesContent({
+    required this.selectedDate,
+    required this.state,
+    required this.onAddSchedule,
+    required this.onEditSchedule,
+    required this.onDeleteSchedule,
+  });
+
+  final DateTime selectedDate;
+  final MonthlySchedulesState state;
+  final VoidCallback onAddSchedule;
+  final ValueChanged<String> onEditSchedule;
+  final ValueChanged<ScheduleEntity> onDeleteSchedule;
+
+  @override
+  Widget build(BuildContext context) {
+    final schedules = state.schedules[selectedDate] ?? const [];
+
+    if (schedules.isEmpty) {
+      if (state.status == MonthlySchedulesStatus.loading) {
+        return const Center(child: CircularProgressIndicator());
+      }
+
+      if (state.status != MonthlySchedulesStatus.success) {
+        return const SizedBox.expand();
+      }
+
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      final selected = DateTime(
+        selectedDate.year,
+        selectedDate.month,
+        selectedDate.day,
+      );
+
+      return _EmptySchedulesView(
+        showAddButton: !selected.isBefore(today),
+        onAddSchedule: onAddSchedule,
+      );
+    }
+
+    return ListView.builder(
+      padding: EdgeInsets.zero,
+      itemCount: schedules.length,
+      itemBuilder: (context, index) {
+        final schedule = schedules[index];
+
+        return BlocBuilder<ScheduleBloc, ScheduleState>(
+          builder: (context, scheduleState) {
+            final isEarlyStarted = scheduleState.isEarlyStarted &&
+                scheduleState.schedule?.id == schedule.id;
+
+            return ScheduleDetail(
+              schedule: schedule,
+              preparationTime:
+                  state.preparationDurationByScheduleId[schedule.id],
+              isEarlyStarted: isEarlyStarted,
+              onEdit: () => onEditSchedule(schedule.id),
+              onDeleted: () => onDeleteSchedule(schedule),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _EmptySchedulesView extends StatelessWidget {
+  const _EmptySchedulesView({
+    required this.showAddButton,
+    required this.onAddSchedule,
+  });
+
+  final bool showAddButton;
+  final VoidCallback onAddSchedule;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 16.0,
+          children: [
+            Text(
+              AppLocalizations.of(context)!.noSchedules,
+              style: textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.outlineVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (showAddButton)
+              ElevatedButton(
+                onPressed: onAddSchedule,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: theme.colorScheme.surface,
+                  side: BorderSide(
+                    width: 0.5,
+                    color: theme.colorScheme.outlineVariant,
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 4.0,
+                    horizontal: 12.0,
+                  ),
+                ),
+                child: Text(
+                  AppLocalizations.of(context)!.addAppointment,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
                   ),
                 ),
               ),
-            ],
-          ),
+          ],
         ),
       ),
     );

--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -29,10 +29,9 @@ class CalendarScreen extends StatefulWidget {
 
 class _CalendarScreenState extends State<CalendarScreen> {
   static const double _calendarHorizontalPadding = 8.0;
-  static const double _calendarVerticalPadding = 16.0;
-  static const double _calendarDaysOfWeekHeight = 40.0;
-  static const double _calendarHeaderHeight = 64.0;
-  static const double _selectedDateMinHeight = 120.0;
+  static const double _calendarVerticalPadding = 12.0;
+  static const double _calendarDaysOfWeekHeight = 36.0;
+  static const double _calendarRowHeight = 44.0;
 
   late DateTime _selectedDate;
   late final MonthlySchedulesBloc _monthlySchedulesBloc;
@@ -158,25 +157,6 @@ class _CalendarScreenState extends State<CalendarScreen> {
     return 27.0;
   }
 
-  double _calendarRowHeight({
-    required double maxHeight,
-    required double detailGap,
-  }) {
-    if (!maxHeight.isFinite) {
-      return 52.0;
-    }
-
-    final availableCalendarHeight =
-        maxHeight - detailGap - _selectedDateMinHeight;
-    final availableRowsHeight = availableCalendarHeight -
-        (_calendarVerticalPadding * 2) -
-        _calendarHeaderHeight -
-        _calendarDaysOfWeekHeight;
-    final fittedRowHeight = availableRowsHeight / 6;
-
-    return fittedRowHeight.clamp(24.0, 52.0).toDouble();
-  }
-
   double _selectedDateHeadingGap(double maxHeight) {
     if (maxHeight.isFinite && maxHeight < 620.0) {
       return 12.0;
@@ -207,20 +187,18 @@ class _CalendarScreenState extends State<CalendarScreen> {
           ),
         ),
         body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 18.0, vertical: 16.0),
+          padding: const EdgeInsets.symmetric(horizontal: 18.0) +
+              EdgeInsets.only(bottom: 12.0),
           child: LayoutBuilder(
             builder: (context, constraints) {
               final detailGap = _calendarDetailGap(constraints.maxHeight);
-              final rowHeight = _calendarRowHeight(
-                maxHeight: constraints.maxHeight,
-                detailGap: detailGap,
-              );
               final selectedDateHeadingGap =
                   _selectedDateHeadingGap(constraints.maxHeight);
 
               return Column(
                 children: [
                   Container(
+                    key: const Key('calendar_card'),
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(12),
                       color: colorScheme.surface,
@@ -240,8 +218,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                           return TableCalendar(
                             locale: Localizations.localeOf(context).toString(),
                             daysOfWeekHeight: _calendarDaysOfWeekHeight,
-                            sixWeekMonthsEnforced: true,
-                            rowHeight: rowHeight,
+                            rowHeight: _calendarRowHeight,
                             eventLoader: (day) {
                               day = DateTime(day.year, day.month, day.day);
                               return state.schedules[day] ?? [];
@@ -306,7 +283,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                               },
                               selectedBuilder: (context, day, focusedDay) {
                                 return Container(
-                                  margin: const EdgeInsets.all(4.0),
+                                  margin: const EdgeInsets.all(2.0),
                                   alignment: Alignment.center,
                                   decoration:
                                       calendarTheme.selectedDayDecoration,
@@ -321,7 +298,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
                               },
                               todayBuilder: (context, day, focusedDay) =>
                                   Container(
-                                margin: const EdgeInsets.all(4.0),
+                                margin: const EdgeInsets.all(2.0),
                                 alignment: Alignment.center,
                                 decoration: calendarTheme.todayDecoration,
                                 child: Text(

--- a/lib/presentation/shared/components/calendar/centered_calendar_header.dart
+++ b/lib/presentation/shared/components/calendar/centered_calendar_header.dart
@@ -23,45 +23,55 @@ class CenteredCalendarHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        spacing: 16,
-        children: [
-          IconButton(
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-            visualDensity: VisualDensity.compact,
-            style: IconButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(4.4),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final spacing = constraints.maxWidth < 260.0 ? 8.0 : 16.0;
+
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            spacing: spacing,
+            children: [
+              IconButton(
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                visualDensity: VisualDensity.compact,
+                style: IconButton.styleFrom(
+                  backgroundColor: theme.colorScheme.surfaceContainer,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4.4),
+                  ),
+                ),
+                icon: leftIcon,
+                onPressed: onLeftArrowTap,
               ),
-            ),
-            icon: leftIcon,
-            onPressed: onLeftArrowTap,
-          ),
-          Text(
-            DateFormat.yMMMM(AppLocalizations.of(context)!.localeName)
-                .format(focusedMonth),
-            style: textTheme.titleSmall,
-          ),
-          IconButton(
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-            visualDensity: VisualDensity.compact,
-            style: IconButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(4.4),
+              Flexible(
+                child: Text(
+                  DateFormat.yMMMM(AppLocalizations.of(context)!.localeName)
+                      .format(focusedMonth),
+                  style: titleTextStyle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                ),
               ),
-            ),
-            icon: rightIcon,
-            onPressed: onRightArrowTap,
-          ),
-        ],
+              IconButton(
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                visualDensity: VisualDensity.compact,
+                style: IconButton.styleFrom(
+                  backgroundColor: theme.colorScheme.surfaceContainer,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4.4),
+                  ),
+                ),
+                icon: rightIcon,
+                onPressed: onRightArrowTap,
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/presentation/shared/components/calendar/centered_calendar_header.dart
+++ b/lib/presentation/shared/components/calendar/centered_calendar_header.dart
@@ -24,10 +24,10 @@ class CenteredCalendarHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      padding: EdgeInsets.zero,
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final spacing = constraints.maxWidth < 260.0 ? 8.0 : 16.0;
+          final spacing = constraints.maxWidth < 260.0 ? 6.0 : 12.0;
 
           return Row(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/presentation/shared/theme/calendar_theme.dart
+++ b/lib/presentation/shared/theme/calendar_theme.dart
@@ -63,6 +63,7 @@ class CalendarTheme extends ThemeExtension<CalendarTheme> {
         titleCentered: true,
         leftChevronVisible: false,
         rightChevronVisible: false,
+        headerPadding: EdgeInsets.zero,
         leftChevronIcon: Icon(
           Icons.chevron_left,
           color: colorScheme.outlineVariant,
@@ -82,6 +83,7 @@ class CalendarTheme extends ThemeExtension<CalendarTheme> {
         outsideDaysVisible: false,
         weekendTextStyle: textTheme.bodyLarge!,
         defaultTextStyle: textTheme.bodyLarge!,
+        cellMargin: const EdgeInsets.all(2.0),
         markerDecoration: BoxDecoration(
           color: colorScheme.primary,
           shape: BoxShape.circle,

--- a/test/presentation/calendar/screens/calendar_screen_test.dart
+++ b/test/presentation/calendar/screens/calendar_screen_test.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/use-cases/delete_schedule_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/get_schedules_by_date_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_preparation_by_schedule_id_use_case.dart';
+import 'package:on_time_front/domain/use-cases/load_schedules_for_month_use_case.dart';
+import 'package:on_time_front/domain/use-cases/stream_preparations_use_case.dart';
+import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
+import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
+import 'package:on_time_front/presentation/calendar/screens/calendar_screen.dart';
+import 'package:on_time_front/presentation/shared/theme/theme.dart';
+
+class _FakeSvgAssetBundle extends CachingAssetBundle {
+  static const _svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>';
+
+  @override
+  Future<ByteData> load(String key) async {
+    final bytes = Uint8List.fromList(utf8.encode(_svg));
+    return ByteData.view(bytes.buffer);
+  }
+}
+
+class _StubLoadSchedulesForMonthUseCase
+    implements LoadSchedulesForMonthUseCase {
+  @override
+  Future<void> call(DateTime date) async {}
+}
+
+class _StubGetSchedulesByDateUseCase implements GetSchedulesByDateUseCase {
+  _StubGetSchedulesByDateUseCase(this.schedules);
+
+  final List<ScheduleEntity> schedules;
+
+  @override
+  Stream<List<ScheduleEntity>> call(DateTime startDate, DateTime endDate) {
+    return Stream.value(schedules);
+  }
+}
+
+class _StubDeleteScheduleUseCase implements DeleteScheduleUseCase {
+  @override
+  Future<void> call(ScheduleEntity schedule) async {}
+}
+
+class _StubLoadPreparationByScheduleIdUseCase
+    implements LoadPreparationByScheduleIdUseCase {
+  @override
+  Future<void> call(String scheduleId) async {}
+}
+
+class _StubGetPreparationByScheduleIdUseCase
+    implements GetPreparationByScheduleIdUseCase {
+  @override
+  Future<PreparationEntity> call(String scheduleId) async {
+    return const PreparationEntity(preparationStepList: []);
+  }
+}
+
+class _StubStreamPreparationsUseCase implements StreamPreparationsUseCase {
+  @override
+  Stream<Map<String, PreparationEntity>> call() {
+    return const Stream.empty();
+  }
+}
+
+class _StubScheduleBloc extends Mock implements ScheduleBloc {
+  @override
+  ScheduleState get state => const ScheduleState.notExists();
+
+  @override
+  Stream<ScheduleState> get stream => const Stream.empty();
+
+  @override
+  bool get isClosed => false;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await getIt.reset();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  Future<void> pumpCalendarScreen(
+    WidgetTester tester, {
+    required Size size,
+    required DateTime initialDate,
+    List<ScheduleEntity> schedules = const [],
+    double textScale = 1.0,
+  }) async {
+    getIt.registerFactory<MonthlySchedulesBloc>(
+      () => MonthlySchedulesBloc(
+        _StubLoadSchedulesForMonthUseCase(),
+        _StubGetSchedulesByDateUseCase(schedules),
+        _StubDeleteScheduleUseCase(),
+        _StubLoadPreparationByScheduleIdUseCase(),
+        _StubGetPreparationByScheduleIdUseCase(),
+        _StubStreamPreparationsUseCase(),
+      ),
+    );
+
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      DefaultAssetBundle(
+        bundle: _FakeSvgAssetBundle(),
+        child: MaterialApp(
+          theme: themeData,
+          locale: const Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: MediaQueryData(
+              size: size,
+              textScaler: TextScaler.linear(textScale),
+            ),
+            child: BlocProvider<ScheduleBloc>.value(
+              value: _StubScheduleBloc(),
+              child: CalendarScreen(initialDate: initialDate),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('compact future empty state fits with add button',
+      (tester) async {
+    final futureDate = DateTime.now().add(const Duration(days: 7));
+
+    await pumpCalendarScreen(
+      tester,
+      size: const Size(360, 640),
+      textScale: 1.3,
+      initialDate: futureDate,
+    );
+
+    expect(find.text('No schedules'), findsOneWidget);
+    expect(find.text('Add appointment'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('short past empty state fits without add button', (tester) async {
+    final pastDate = DateTime.now().subtract(const Duration(days: 7));
+
+    await pumpCalendarScreen(
+      tester,
+      size: const Size(360, 560),
+      textScale: 1.3,
+      initialDate: pastDate,
+    );
+
+    expect(find.text('No schedules'), findsOneWidget);
+    expect(find.text('Add appointment'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('compact selected day with schedules scrolls without overflow',
+      (tester) async {
+    final selectedDate = DateTime.now().add(const Duration(days: 7));
+    final schedule = ScheduleEntity(
+      id: 'schedule-1',
+      place: PlaceEntity(id: 'place-1', placeName: 'Office'),
+      scheduleName: 'Design Review',
+      scheduleTime: DateTime(
+        selectedDate.year,
+        selectedDate.month,
+        selectedDate.day,
+        9,
+      ),
+      moveTime: const Duration(minutes: 30),
+      isChanged: false,
+      isStarted: false,
+      scheduleSpareTime: const Duration(minutes: 10),
+      scheduleNote: '',
+    );
+
+    await pumpCalendarScreen(
+      tester,
+      size: const Size(360, 640),
+      textScale: 1.3,
+      initialDate: selectedDate,
+      schedules: [schedule],
+    );
+
+    expect(find.text('Design Review'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Removed the height-capping and scaling behavior from the calendar card.
- Kept the calendar slightly more compact by reducing row height, day-of-week height, and surrounding padding.
- Tightened the month/year header spacing so the top section uses less vertical room.

## Testing
- `flutter test test/presentation/calendar`
- `flutter analyze`