### PR TITLE
[codex] Harden token refresh retry handling

### DIFF
--- a/lib/core/dio/interceptors/token_interceptor.dart
+++ b/lib/core/dio/interceptors/token_interceptor.dart
@@ -2,9 +2,13 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:on_time_front/data/data_sources/token_local_data_source.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/domain/entities/token_entity.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
 
 class TokenInterceptor implements InterceptorsWrapper {
+  static const _refreshTokenPath = '/refresh-token';
+  static const _retryAfterRefreshKey = 'tokenInterceptor.retryAfterRefresh';
+
   final Dio dio;
   TokenInterceptor(this.dio);
   final TokenLocalDataSource tokenLocalDataSource =
@@ -35,76 +39,61 @@ class TokenInterceptor implements InterceptorsWrapper {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
-    final response = err.response;
-    if (response != null &&
-        // status code for unauthorized usually 401
-        response.statusCode == 401 &&
-        // refresh token call maybe fail by it self
-        // eg: when refreshToken also is expired -> can't get new accessToken
-        // usually server also return 401 unauthorized for this case
-        // need to exlude it to prevent loop infinite call
-        response.requestOptions.path != "/refresh-token") {
+    if (_shouldRefreshToken(err)) {
+      final response = err.response;
       // if hasn't not refreshing yet, let's start it
+      _requestsNeedRetry.add((options: err.requestOptions, handler: handler));
+
       if (!_isRefreshing) {
         _isRefreshing = true;
-
-        // add request (requestOptions and handler) to queue and wait to retry later
-        _requestsNeedRetry
-            .add((options: response.requestOptions, handler: handler));
 
         // call api refresh token
         final isRefreshSuccess = await _refreshToken();
 
-        if (isRefreshSuccess) {
-          // refresh success, loop requests need retry
-          for (var requestNeedRetry in _requestsNeedRetry) {
-            // don't need set new accessToken to header here, because these retry
-            // will go through onRequest callback above (where new accessToken will be set to header)
-
-            // won't use await because this loop will take longer -> maybe throw: Unhandled Exception: Concurrent modification during iteration
-            // because method _requestsNeedRetry.add() is called at the same time
-            // final response = await dio.fetch(requestNeedRetry.options);
-            // requestNeedRetry.handler.resolve(response);
-
-            dio.fetch(requestNeedRetry.options).then((response) {
-              requestNeedRetry.handler.resolve(response);
-            }).catchError((_) {});
+        try {
+          if (isRefreshSuccess) {
+            while (_requestsNeedRetry.isNotEmpty) {
+              final requestsNeedRetry = List.of(_requestsNeedRetry);
+              _requestsNeedRetry.clear();
+              await _retryRequests(requestsNeedRetry);
+            }
+          } else {
+            for (final requestNeedRetry in _requestsNeedRetry) {
+              requestNeedRetry.handler.reject(
+                DioException(
+                  requestOptions: requestNeedRetry.options,
+                  response: response,
+                  type: err.type,
+                  error: err.error,
+                  message: err.message,
+                ),
+              );
+            }
+            _requestsNeedRetry.clear();
+            // Force a local logout when the refresh token is rejected. The full
+            // sign-out use case may make authenticated cleanup calls, which can
+            // deadlock while the interceptor is already refreshing.
+            await _signOutLocally();
           }
-
-          _requestsNeedRetry.clear();
-          _isRefreshing = false;
-        } else {
-          for (final requestNeedRetry in _requestsNeedRetry) {
-            requestNeedRetry.handler.reject(
-              DioException(
-                requestOptions: requestNeedRetry.options,
-                response: response,
-                type: err.type,
-                error: err.error,
-                message: err.message,
-              ),
-            );
-          }
-          _requestsNeedRetry.clear();
-          // Force a local logout when the refresh token is rejected. The full
-          // sign-out use case may make authenticated cleanup calls, which can
-          // deadlock while the interceptor is already refreshing.
-          try {
-            await getIt.get<UserRepository>().signOut();
-          } catch (_) {
-            await tokenLocalDataSource.deleteToken();
-          }
+        } finally {
           _isRefreshing = false;
         }
-      } else {
-        // if refresh flow is processing, add this request to queue and wait to retry later
-        _requestsNeedRetry
-            .add((options: response.requestOptions, handler: handler));
       }
     } else {
       // ignore other error is not unauthorized
       return handler.next(err);
     }
+  }
+
+  bool _shouldRefreshToken(DioException err) {
+    final response = err.response;
+    if (response?.statusCode != 401) {
+      return false;
+    }
+
+    final requestOptions = err.requestOptions;
+    return requestOptions.path != _refreshTokenPath &&
+        requestOptions.extra[_retryAfterRefreshKey] != true;
   }
 
   Future<bool> _refreshToken() async {
@@ -113,8 +102,11 @@ class TokenInterceptor implements InterceptorsWrapper {
       final refreshToken = tokenEntity.refreshToken;
 
       final res = await dio.get(
-        '/refresh-token',
+        _refreshTokenPath,
         options: Options(
+          extra: {
+            _retryAfterRefreshKey: true,
+          },
           headers: {
             'Authorization-refresh': 'Bearer $refreshToken',
           },
@@ -122,9 +114,19 @@ class TokenInterceptor implements InterceptorsWrapper {
       );
       if (res.statusCode == 200) {
         debugPrint("token refreshing success");
-        final authToken = res.headers['authorization']![0];
-        // save new access + refresh token to your local storage for using later
-        await tokenLocalDataSource.storeAuthToken(authToken);
+        final accessToken = res.headers.value('authorization');
+        final refreshedRefreshToken =
+            res.headers.value('authorization-refresh');
+        if (accessToken == null || refreshedRefreshToken == null) {
+          throw StateError(
+              'Refresh response must include authorization and authorization-refresh headers');
+        }
+        await tokenLocalDataSource.storeTokens(
+          TokenEntity(
+            accessToken: accessToken,
+            refreshToken: refreshedRefreshToken,
+          ),
+        );
         return true;
       } else {
         debugPrint("refresh token fail ${res.statusMessage ?? res.toString()}");
@@ -133,6 +135,39 @@ class TokenInterceptor implements InterceptorsWrapper {
     } catch (error) {
       debugPrint("refresh token fail $error");
       return false;
+    }
+  }
+
+  Future<void> _retryRequests(
+    List<({RequestOptions options, ErrorInterceptorHandler handler})> requests,
+  ) async {
+    await Future.wait(
+      requests.map((requestNeedRetry) async {
+        final options = requestNeedRetry.options;
+        options.extra[_retryAfterRefreshKey] = true;
+
+        try {
+          final response = await dio.fetch(options);
+          requestNeedRetry.handler.resolve(response);
+        } on DioException catch (error) {
+          requestNeedRetry.handler.reject(error);
+        } catch (error) {
+          requestNeedRetry.handler.reject(
+            DioException(
+              requestOptions: options,
+              error: error,
+            ),
+          );
+        }
+      }),
+    );
+  }
+
+  Future<void> _signOutLocally() async {
+    try {
+      await getIt.get<UserRepository>().signOut();
+    } catch (_) {
+      await tokenLocalDataSource.deleteToken();
     }
   }
 

--- a/test/core/dio/interceptors/token_interceptor_test.dart
+++ b/test/core/dio/interceptors/token_interceptor_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
@@ -16,7 +17,7 @@ void main() {
   late Dio dio;
   late _FakeTokenLocalDataSource tokenLocalDataSource;
   late _FakeUserRepository userRepository;
-  late _UnauthorizedAdapter adapter;
+  late _TokenRefreshAdapter adapter;
 
   setUp(() async {
     await getIt.reset();
@@ -26,7 +27,7 @@ void main() {
     getIt.registerSingleton<TokenLocalDataSource>(tokenLocalDataSource);
     getIt.registerSingleton<UserRepository>(userRepository);
 
-    adapter = _UnauthorizedAdapter();
+    adapter = _TokenRefreshAdapter();
     dio = Dio(
       BaseOptions(
         baseUrl: 'https://example.com',
@@ -40,7 +41,72 @@ void main() {
     await getIt.reset();
   });
 
+  test('stores refreshed access and refresh tokens before retrying request',
+      () async {
+    final response = await dio.get<String>('/protected');
+
+    expect(response.statusCode, 200);
+    expect(
+        tokenLocalDataSource.storedToken,
+        const TokenEntity(
+          accessToken: 'new-access-token',
+          refreshToken: 'new-refresh-token',
+        ));
+    expect(tokenLocalDataSource.storeTokensCallCount, 1);
+    expect(adapter.refreshRequests, 1);
+    expect(
+      adapter.protectedAuthorizationHeaders,
+      contains('Bearer new-access-token'),
+    );
+  });
+
+  test('retries concurrent queued requests after a single refresh', () async {
+    final refreshCompleter = Completer<void>();
+    adapter = _TokenRefreshAdapter(refreshCompleter: refreshCompleter);
+    dio.httpClientAdapter = adapter;
+
+    final firstRequest = dio.get<String>('/protected/one');
+    await _flushMicrotasks();
+    final secondRequest = dio.get<String>('/protected/two');
+    await _flushMicrotasks();
+
+    expect(adapter.refreshRequests, 1);
+    refreshCompleter.complete();
+
+    final responses = await Future.wait([firstRequest, secondRequest]);
+
+    expect(responses.map((response) => response.statusCode), everyElement(200));
+    expect(adapter.refreshRequests, 1);
+    expect(
+      adapter.protectedAuthorizationHeaders
+          .where((header) => header == 'Bearer new-access-token'),
+      hasLength(2),
+    );
+  });
+
+  test('rejects original request when retry after refresh fails', () async {
+    adapter = _TokenRefreshAdapter(retryStatusCode: 500);
+    dio.httpClientAdapter = adapter;
+
+    await expectLater(
+      dio.get<void>('/protected'),
+      throwsA(
+        isA<DioException>().having(
+          (error) => error.response?.statusCode,
+          'statusCode',
+          500,
+        ),
+      ),
+    );
+
+    expect(adapter.refreshRequests, 1);
+    expect(userRepository.signOutCalled, isFalse);
+  });
+
   test('locally signs out when refresh token request returns 401', () async {
+    adapter = _TokenRefreshAdapter(refreshStatusCode: 401);
+    dio.httpClientAdapter = adapter;
+
     await expectLater(
       dio.get<void>('/protected'),
       throwsA(isA<DioException>()),
@@ -48,13 +114,35 @@ void main() {
 
     expect(
         adapter.requestedPaths, containsAll(['/protected', '/refresh-token']));
+    expect(adapter.refreshRequests, 1);
     expect(userRepository.signOutCalled, isTrue);
     expect(tokenLocalDataSource.deleteTokenCalled, isTrue);
   });
 }
 
-class _UnauthorizedAdapter implements HttpClientAdapter {
+Future<void> _flushMicrotasks() async {
+  for (var i = 0; i < 5; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+class _TokenRefreshAdapter implements HttpClientAdapter {
+  _TokenRefreshAdapter({
+    this.refreshStatusCode = 200,
+    this.retryStatusCode = 200,
+    this.refreshCompleter,
+  });
+
+  final int refreshStatusCode;
+  final int retryStatusCode;
+  final Completer<void>? refreshCompleter;
+
   final requestedPaths = <String>[];
+  final protectedAuthorizationHeaders = <String?>[];
+  final refreshAuthorizationHeaders = <String?>[];
+  final _pathRequestCounts = <String, int>{};
+
+  int refreshRequests = 0;
 
   @override
   Future<ResponseBody> fetch(
@@ -63,9 +151,44 @@ class _UnauthorizedAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     requestedPaths.add(options.path);
+    if (options.path == '/refresh-token') {
+      refreshRequests++;
+      refreshAuthorizationHeaders
+          .add(options.headers['Authorization-refresh']?.toString());
+      await refreshCompleter?.future;
+      return ResponseBody.fromString(
+        '{"message":"Refresh response"}',
+        refreshStatusCode,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+          if (refreshStatusCode == 200) ...{
+            'authorization': ['new-access-token'],
+            'authorization-refresh': ['new-refresh-token'],
+          },
+        },
+      );
+    }
+
+    if (options.path.startsWith('/protected')) {
+      protectedAuthorizationHeaders
+          .add(options.headers['Authorization']?.toString());
+      final requestCount = (_pathRequestCounts[options.path] ?? 0) + 1;
+      _pathRequestCounts[options.path] = requestCount;
+
+      if (requestCount == 1) {
+        return _response(401, '{"message":"Unauthorized"}');
+      }
+
+      return _response(retryStatusCode, '{"message":"Retried response"}');
+    }
+
+    return _response(200, '{"message":"OK"}');
+  }
+
+  ResponseBody _response(int statusCode, String body) {
     return ResponseBody.fromString(
-      '{"message":"Unauthorized"}',
-      401,
+      body,
+      statusCode,
       headers: {
         Headers.contentTypeHeader: [Headers.jsonContentType],
       },
@@ -77,7 +200,13 @@ class _UnauthorizedAdapter implements HttpClientAdapter {
 }
 
 class _FakeTokenLocalDataSource implements TokenLocalDataSource {
+  TokenEntity token = const TokenEntity(
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+  );
+  TokenEntity? storedToken;
   bool deleteTokenCalled = false;
+  int storeTokensCallCount = 0;
 
   @override
   Future<void> deleteToken() async {
@@ -86,17 +215,18 @@ class _FakeTokenLocalDataSource implements TokenLocalDataSource {
 
   @override
   Future<TokenEntity> getToken() async {
-    return const TokenEntity(
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
-    );
+    return token;
   }
 
   @override
   Future<void> storeAuthToken(String token) async {}
 
   @override
-  Future<void> storeTokens(TokenEntity token) async {}
+  Future<void> storeTokens(TokenEntity token) async {
+    storeTokensCallCount++;
+    storedToken = token;
+    this.token = token;
+  }
 }
 
 class _FakeUserRepository implements UserRepository {


### PR DESCRIPTION
## Summary
- Store both refreshed access and refresh tokens from the refresh response headers.
- Ensure queued requests are always resolved or rejected after refresh.
- Mark refresh and post-refresh retry requests to avoid recursive refresh loops.
- Add focused interceptor tests for token rotation, concurrent queued requests, retry failures, and refresh failure sign-out.

## Root Cause
The token refresh flow persisted only the refreshed access token, leaving rotated refresh tokens stale. Queued request retries also swallowed retry failures, which could leave original request handlers without a clear failure path.

## Validation
- `flutter test test/core/dio/interceptors/token_interceptor_test.dart`
- `flutter analyze`
- `flutter test`
- `git diff --check`

Closes #390
