### PR TITLE
[codex] Harden GoRouter route argument parsing

### DIFF
--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -12,6 +12,7 @@ import 'package:on_time_front/presentation/alarm/components/alarm_screen_top_sec
 import 'package:on_time_front/presentation/alarm/components/preparation_completion_dialog.dart';
 import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
 import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 import 'package:on_time_front/presentation/shared/utils/time_format.dart';
 
 class AlarmScreen extends StatefulWidget {
@@ -135,7 +136,10 @@ class _AlarmScreenState extends State<AlarmScreen> {
             isLate != null) {
           _resetFinishNavigation();
           context.go(
-            '/earlyLate',
+            earlyLateRouteLocation(
+              earlyLateTime: earlyLateSeconds,
+              isLate: isLate,
+            ),
             extra: {
               'earlyLateTime': earlyLateSeconds,
               'isLate': isLate,

--- a/lib/presentation/alarm/screens/schedule_start_screen.dart
+++ b/lib/presentation/alarm/screens/schedule_start_screen.dart
@@ -9,6 +9,7 @@ import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
 import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
 import 'package:on_time_front/presentation/shared/constants/app_colors.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 import 'package:on_time_front/presentation/shared/utils/duration_format.dart';
 
 enum ScheduleStartPromptVariant {
@@ -39,19 +40,20 @@ ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteValue(
 ScheduleStartPromptVariant scheduleStartPromptVariantFromRouteExtra(
   Map<String, dynamic>? extra,
 ) {
-  final isFiveMinutesBefore = extra?['isFiveMinutesBefore'] as bool? ?? false;
+  final isFiveMinutesBefore =
+      routeBoolValue(extra?['isFiveMinutesBefore']) ?? false;
   if (isFiveMinutesBefore) {
     return ScheduleStartPromptVariant.earlyStart;
   }
   return scheduleStartPromptVariantFromRouteValue(
-    extra?['promptVariant'] as String?,
+    routeStringValue(extra?['promptVariant']),
   );
 }
 
 ScheduleStartLaunchAction scheduleStartLaunchActionFromRouteExtra(
   Map<String, dynamic>? extra,
 ) {
-  switch (extra?['alarmLaunchAction'] as String?) {
+  switch (routeStringValue(extra?['alarmLaunchAction'])) {
     case 'startPreparation':
     case 'startPreparing':
       return ScheduleStartLaunchAction.startPreparation;

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -12,6 +12,7 @@ import 'package:on_time_front/presentation/home/components/week_calendar.dart';
 import 'package:on_time_front/presentation/home/utils/today_tile_navigation.dart';
 import 'package:on_time_front/presentation/shared/components/arc_indicator.dart';
 import 'package:on_time_front/presentation/shared/constants/app_colors.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -218,7 +219,7 @@ class _WeekCalendar extends StatelessWidget {
     return WeekCalendar(
       date: DateTime.now(),
       onDateSelected: (date) {
-        context.go('/calendar', extra: date);
+        context.go(calendarRouteLocation(date), extra: date);
       },
       highlightedDates: weeklySchedulesState.dates,
     );

--- a/lib/presentation/home/screens/home_screen_tmp.dart
+++ b/lib/presentation/home/screens/home_screen_tmp.dart
@@ -13,6 +13,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:on_time_front/presentation/shared/components/arc_indicator.dart';
 import 'package:on_time_front/presentation/home/components/month_calendar.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 
 /// Wrapper widget that provides the BlocProvider for HomeScreenTmp
 class HomeScreenTmp extends StatelessWidget {
@@ -249,7 +250,7 @@ class _MonthlySchedule extends StatelessWidget {
                 bottom: metrics.calendarPadding + metrics.calendarFabClearance,
               ),
               onDateSelected: (date) {
-                context.go('/calendar', extra: date);
+                context.go(calendarRouteLocation(date), extra: date);
               },
             ),
           ),

--- a/lib/presentation/shared/router/go_router.dart
+++ b/lib/presentation/shared/router/go_router.dart
@@ -23,6 +23,7 @@ import 'package:on_time_front/presentation/schedule_create/schedule_spare_and_pr
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_create_screen.dart';
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_edit_screen.dart';
 import 'package:on_time_front/presentation/shared/components/bottom_nav_bar_scaffold.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 import 'package:on_time_front/presentation/shared/utils/stream_to_listenable.dart';
 import 'package:on_time_front/presentation/startup/screens/startup_screen.dart';
 
@@ -112,7 +113,7 @@ GoRouter goRouterConfig(
       GoRoute(
         path: '/calendar',
         builder: (context, state) => CalendarScreen(
-          initialDate: state.extra as DateTime?,
+          initialDate: calendarInitialDateFromState(state),
         ),
       ),
       GoRoute(
@@ -129,7 +130,7 @@ GoRouter goRouterConfig(
         path: '/scheduleStart',
         name: 'scheduleStart',
         builder: (context, state) {
-          final extra = state.extra as Map<String, dynamic>?;
+          final extra = scheduleStartRouteExtraFromState(state);
           return _ScheduleStartRouteGate(extra: extra);
         },
       ),
@@ -141,14 +142,20 @@ GoRouter goRouterConfig(
       ),
       GoRoute(
         path: '/earlyLate',
+        redirect: (context, state) {
+          return earlyLateRouteArgumentsFromState(state) == null
+              ? '/home'
+              : null;
+        },
         builder: (context, state) {
-          final extra = state.extra as Map<String, dynamic>;
-          final earlyLateTime = extra['earlyLateTime'] as int;
-          final isLate = extra['isLate'] as bool;
+          final arguments = earlyLateRouteArgumentsFromState(state);
+          if (arguments == null) {
+            return const LoadingScreen();
+          }
 
           return EarlyLateScreen(
-            earlyLateTime: earlyLateTime,
-            isLate: isLate,
+            earlyLateTime: arguments.earlyLateTime,
+            isLate: arguments.isLate,
           );
         },
       ),
@@ -177,14 +184,14 @@ class _ScheduleStartRouteGateState extends State<_ScheduleStartRouteGate> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_requestedValidation) return;
-    final scheduleId = widget.extra?['scheduleId']?.toString();
+    final scheduleId = routeStringValue(widget.extra?['scheduleId']);
     if (scheduleId == null || scheduleId.isEmpty) return;
     _requestedValidation = true;
     context.read<ScheduleBloc>().add(
           ScheduleAlarmPromptRequested(
             scheduleId: scheduleId,
             scheduleFingerprint:
-                widget.extra?['scheduleFingerprint']?.toString(),
+                routeStringValue(widget.extra?['scheduleFingerprint']),
             startPreparation: scheduleStartLaunchActionFromRouteExtra(
                   widget.extra,
                 ) ==
@@ -200,9 +207,9 @@ class _ScheduleStartRouteGateState extends State<_ScheduleStartRouteGate> {
       return const AlarmScreen();
     }
 
-    final scheduleId = widget.extra?['scheduleId']?.toString();
+    final scheduleId = routeStringValue(widget.extra?['scheduleId']);
     final scheduleFingerprint =
-        widget.extra?['scheduleFingerprint']?.toString();
+        routeStringValue(widget.extra?['scheduleFingerprint']);
     final allowsStaleFingerprint = scheduleStartLaunchActionFromRouteExtra(
           widget.extra,
         ) ==

--- a/lib/presentation/shared/router/route_arguments.dart
+++ b/lib/presentation/shared/router/route_arguments.dart
@@ -1,0 +1,161 @@
+import 'package:go_router/go_router.dart';
+
+Map<String, dynamic>? routeExtraMap(Object? extra) {
+  if (extra == null) return null;
+  if (extra is Map<String, dynamic>) return extra;
+  if (extra is! Map) return null;
+
+  final parsed = <String, dynamic>{};
+  for (final entry in extra.entries) {
+    final key = entry.key;
+    if (key is! String) return null;
+    parsed[key] = entry.value;
+  }
+  return parsed;
+}
+
+String? routeStringValue(Object? value) {
+  return value is String && value.isNotEmpty ? value : null;
+}
+
+bool? routeBoolValue(Object? value) {
+  if (value is bool) return value;
+  if (value is int) {
+    if (value == 1) return true;
+    if (value == 0) return false;
+  }
+  if (value is String) {
+    switch (value.toLowerCase()) {
+      case 'true':
+      case '1':
+        return true;
+      case 'false':
+      case '0':
+        return false;
+    }
+  }
+  return null;
+}
+
+DateTime? calendarInitialDateFromState(GoRouterState state) {
+  return parseCalendarInitialDate(
+    extra: state.extra,
+    queryParameters: state.uri.queryParameters,
+  );
+}
+
+DateTime? parseCalendarInitialDate({
+  Object? extra,
+  Map<String, String> queryParameters = const {},
+}) {
+  final extraDate = _dateTimeValue(extra);
+  if (extraDate != null) return extraDate;
+
+  return _dateTimeValue(
+    queryParameters['date'] ?? queryParameters['initialDate'],
+  );
+}
+
+String calendarRouteLocation(DateTime date) {
+  final normalizedDate = DateTime(date.year, date.month, date.day);
+  return Uri(
+    path: '/calendar',
+    queryParameters: {'date': normalizedDate.toIso8601String()},
+  ).toString();
+}
+
+Map<String, dynamic>? scheduleStartRouteExtraFromState(GoRouterState state) {
+  final extra = routeExtraMap(state.extra);
+  final queryExtra = _scheduleStartExtraFromQuery(state.uri.queryParameters);
+  if (queryExtra == null) return extra;
+  return {
+    ...queryExtra,
+    if (extra != null) ...extra,
+  };
+}
+
+class EarlyLateRouteArguments {
+  const EarlyLateRouteArguments({
+    required this.earlyLateTime,
+    required this.isLate,
+  });
+
+  final int earlyLateTime;
+  final bool isLate;
+}
+
+EarlyLateRouteArguments? earlyLateRouteArgumentsFromState(
+  GoRouterState state,
+) {
+  return parseEarlyLateRouteArguments(
+    extra: state.extra,
+    queryParameters: state.uri.queryParameters,
+  );
+}
+
+EarlyLateRouteArguments? parseEarlyLateRouteArguments({
+  Object? extra,
+  Map<String, String> queryParameters = const {},
+}) {
+  final extraMap = routeExtraMap(extra);
+  final earlyLateTime = _intValue(extraMap?['earlyLateTime']) ??
+      _intValue(queryParameters['earlyLateTime']);
+  final isLate = routeBoolValue(extraMap?['isLate']) ??
+      routeBoolValue(queryParameters['isLate']);
+
+  if (earlyLateTime == null || isLate == null) return null;
+  return EarlyLateRouteArguments(
+    earlyLateTime: earlyLateTime,
+    isLate: isLate,
+  );
+}
+
+String earlyLateRouteLocation({
+  required int earlyLateTime,
+  required bool isLate,
+}) {
+  return Uri(
+    path: '/earlyLate',
+    queryParameters: {
+      'earlyLateTime': earlyLateTime.toString(),
+      'isLate': isLate.toString(),
+    },
+  ).toString();
+}
+
+Map<String, dynamic>? _scheduleStartExtraFromQuery(
+  Map<String, String> queryParameters,
+) {
+  final parsed = <String, dynamic>{};
+
+  for (final key in const [
+    'scheduleId',
+    'scheduleFingerprint',
+    'promptVariant',
+    'alarmLaunchAction',
+  ]) {
+    final value = routeStringValue(queryParameters[key]);
+    if (value != null) parsed[key] = value;
+  }
+
+  final isFiveMinutesBefore = routeBoolValue(
+    queryParameters['isFiveMinutesBefore'],
+  );
+  if (isFiveMinutesBefore != null) {
+    parsed['isFiveMinutesBefore'] = isFiveMinutesBefore;
+  }
+
+  return parsed.isEmpty ? null : parsed;
+}
+
+DateTime? _dateTimeValue(Object? value) {
+  if (value is DateTime) return value;
+  if (value is String) return DateTime.tryParse(value);
+  return null;
+}
+
+int? _intValue(Object? value) {
+  if (value is int) return value;
+  if (value is String) return int.tryParse(value);
+  return null;
+}

--- a/test/presentation/shared/router/route_arguments_test.dart
+++ b/test/presentation/shared/router/route_arguments_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:on_time_front/presentation/alarm/screens/schedule_start_screen.dart';
+import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
+
+void main() {
+  group('calendar route arguments', () {
+    test('prefers DateTime extra and falls back to query parameters', () {
+      final extraDate = DateTime(2026, 5, 7);
+      final queryDate = DateTime(2026, 5, 8);
+
+      expect(
+        parseCalendarInitialDate(
+          extra: extraDate,
+          queryParameters: {'date': queryDate.toIso8601String()},
+        ),
+        extraDate,
+      );
+      expect(
+        parseCalendarInitialDate(
+          queryParameters: {'date': queryDate.toIso8601String()},
+        ),
+        queryDate,
+      );
+      expect(parseCalendarInitialDate(extra: 'not-a-date'), isNull);
+    });
+
+    testWidgets('router does not throw for malformed calendar extras',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: '/calendar',
+        routes: [
+          GoRoute(
+            path: '/calendar',
+            builder: (context, state) {
+              final date = calendarInitialDateFromState(state);
+              return Material(
+                child: Text(date?.toIso8601String() ?? 'NO_DATE'),
+              );
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      router.go('/calendar', extra: 'not-a-date');
+      await tester.pumpAndSettle();
+
+      expect(find.text('NO_DATE'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('router reads durable calendar query parameter',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: calendarRouteLocation(DateTime(2026, 5, 7)),
+        routes: [
+          GoRoute(
+            path: '/calendar',
+            builder: (context, state) {
+              final date = calendarInitialDateFromState(state);
+              return Material(child: Text('${date?.year}-${date?.month}'));
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2026-5'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('scheduleStart route arguments', () {
+    test('rejects non-map extras and accepts string-keyed legacy maps', () {
+      expect(routeExtraMap('bad-extra'), isNull);
+      expect(
+        routeExtraMap(<String, Object?>{'scheduleId': 'schedule-1'}),
+        {'scheduleId': 'schedule-1'},
+      );
+      expect(routeExtraMap(<Object, Object>{1: 'bad-key'}), isNull);
+    });
+
+    test('prompt helpers ignore malformed optional fields', () {
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(
+          const {'isFiveMinutesBefore': 'definitely'},
+        ),
+        ScheduleStartPromptVariant.officialStart,
+      );
+      expect(
+        scheduleStartPromptVariantFromRouteExtra(
+          const {'promptVariant': 1},
+        ),
+        ScheduleStartPromptVariant.officialStart,
+      );
+      expect(
+        scheduleStartLaunchActionFromRouteExtra(
+          const {'alarmLaunchAction': false},
+        ),
+        ScheduleStartLaunchAction.prompt,
+      );
+    });
+
+    testWidgets('router treats malformed scheduleStart extra as absent',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: '/scheduleStart',
+        routes: [
+          GoRoute(
+            path: '/scheduleStart',
+            builder: (context, state) {
+              final extra = scheduleStartRouteExtraFromState(state);
+              return Material(
+                child: Text(extra == null ? 'NO_EXTRA' : 'HAS_EXTRA'),
+              );
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      router.go('/scheduleStart', extra: 'bad-extra');
+      await tester.pumpAndSettle();
+
+      expect(find.text('NO_EXTRA'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('earlyLate route arguments', () {
+    test('parses extras and durable query parameters', () {
+      final extraArguments = parseEarlyLateRouteArguments(
+        extra: const {'earlyLateTime': 45, 'isLate': false},
+      );
+      final queryArguments = parseEarlyLateRouteArguments(
+        queryParameters: const {'earlyLateTime': '-30', 'isLate': 'true'},
+      );
+
+      expect(extraArguments?.earlyLateTime, 45);
+      expect(extraArguments?.isLate, isFalse);
+      expect(queryArguments?.earlyLateTime, -30);
+      expect(queryArguments?.isLate, isTrue);
+    });
+
+    test('rejects missing and wrong-type required values', () {
+      expect(parseEarlyLateRouteArguments(), isNull);
+      expect(
+        parseEarlyLateRouteArguments(
+          extra: const {
+            'earlyLateTime': <int>[1],
+            'isLate': false
+          },
+        ),
+        isNull,
+      );
+      expect(
+        parseEarlyLateRouteArguments(
+          extra: const {
+            'earlyLateTime': 1,
+            'isLate': <bool>[true]
+          },
+        ),
+        isNull,
+      );
+    });
+
+    testWidgets('router redirects missing and malformed earlyLate args home',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: '/earlyLate',
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/earlyLate',
+            redirect: (context, state) {
+              return earlyLateRouteArgumentsFromState(state) == null
+                  ? '/home'
+                  : null;
+            },
+            builder: (context, state) {
+              final args = earlyLateRouteArgumentsFromState(state)!;
+              return Text('EARLY_LATE:${args.earlyLateTime}:${args.isLate}');
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      router.go('/earlyLate', extra: 'bad-extra');
+      await tester.pumpAndSettle();
+
+      expect(find.text('HOME'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('router accepts valid earlyLate query arguments',
+        (tester) async {
+      final router = GoRouter(
+        initialLocation: earlyLateRouteLocation(
+          earlyLateTime: 90,
+          isLate: true,
+        ),
+        routes: [
+          GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
+          GoRoute(
+            path: '/earlyLate',
+            redirect: (context, state) {
+              return earlyLateRouteArgumentsFromState(state) == null
+                  ? '/home'
+                  : null;
+            },
+            builder: (context, state) {
+              final args = earlyLateRouteArgumentsFromState(state)!;
+              return Text('EARLY_LATE:${args.earlyLateTime}:${args.isLate}');
+            },
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(find.text('EARLY_LATE:90:true'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add defensive typed route argument parsing for `/calendar`, `/scheduleStart`, and `/earlyLate`
- preserve valid existing extras while adding durable query parameters for calendar and early/late routes
- redirect malformed `/earlyLate` payloads to `/home` instead of crashing
- cover missing, malformed, legacy, and query-based route payloads with focused tests

## Why
Direct URL entry, browser refresh, stale links, or native/deep-link payload drift can drop or corrupt `state.extra`. The previous direct casts could throw in production before the user reached a recoverable state.

Closes #391

## Validation
- `flutter test test/presentation/shared/router/route_arguments_test.dart`
- `flutter test test/presentation/alarm/screens/preparation_flow_widget_test.dart`
- `flutter analyze`
- `git diff --check`