### PR TITLE
[codex] Include iOS release dart defines

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -8,6 +8,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Wiki Management Guide](./Wiki-Management.md) - How to modify and upload wiki content
 - [Project Architecture](./Architecture.md) - Understanding the project structure
 - [Git Workflow](./Git.md) - Git strategy and commit message formats
+- [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
 
 ### Technical Deep Dives
 - [Error Handling System](./Error-Handling-Result-System.md) - Result-based error handling architecture

--- a/docs/iOS-Release-Configuration.md
+++ b/docs/iOS-Release-Configuration.md
@@ -1,0 +1,23 @@
+# iOS Release Configuration
+
+Release and archive builds must provide the same Dart define values that debug builds use for native iOS plist substitution.
+
+## Required Dart Defines
+
+- `GOOGLE_RESERVED_CLIENT_ID_IOS`: reversed iOS client ID used by Google Sign-In as the callback URL scheme in `ios/Runner/Info.plist`.
+
+## Local Release Build
+
+Run release builds with the required define:
+
+```sh
+flutter build ios --release --dart-define=GOOGLE_RESERVED_CLIENT_ID_IOS=<reversed-ios-client-id>
+```
+
+For Xcode archives, add the same define to the Flutter build invocation or the CI step that prepares the archive.
+
+## How Validation Works
+
+The shared Runner scheme decodes Flutter `DART_DEFINES` into `ios/Flutter/Dart-Defines.xcconfig` before the build. `ios/Flutter/Release.xcconfig` includes that generated file so `$(GOOGLE_RESERVED_CLIENT_ID_IOS)` resolves in the built `Info.plist`.
+
+Release builds fail clearly when the required define is missing. A release-only Xcode build phase also checks the built `Info.plist` and fails if the Google Sign-In URL scheme was not written into `CFBundleURLTypes`.

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include "Dart-Defines.xcconfig"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				8B7A3E6D2F1C4A9B8D5E0C13 /* Validate Release Info.plist */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				5D0BE7D05FC5FBF79E2EE388 /* [CP] Embed Pods Frameworks */,
@@ -352,6 +353,22 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		8B7A3E6D2F1C4A9B8D5E0C13 /* Validate Release Info.plist */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Validate Release Info.plist";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash \"${SRCROOT}/scripts/validate_release_info_plist.sh\"\n";
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/scripts/extract_dart_defines.sh
+++ b/ios/scripts/extract_dart_defines.sh
@@ -1,20 +1,52 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 SRCROOT="${SRCROOT:-$(pwd)}"
 
 OUTPUT_FILE="${SRCROOT}/Flutter/Dart-Defines.xcconfig"
-: > $OUTPUT_FILE
+REQUIRED_RELEASE_DEFINES=("GOOGLE_RESERVED_CLIENT_ID_IOS")
 
-function decode_url() { echo "${*}" | base64 --decode; }
+set -euo pipefail
 
-IFS=',' read -r -a define_items <<<"$DART_DEFINES"
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+: > "$OUTPUT_FILE"
+
+decode_base64() {
+    local value="$1"
+
+    if printf '%s' "$value" | base64 --decode >/dev/null 2>&1; then
+        printf '%s' "$value" | base64 --decode
+    else
+        printf '%s' "$value" | base64 -D
+    fi
+}
+
+is_release_configuration() {
+    [[ "${CONFIGURATION:-}" == "Release" ]]
+}
+
+IFS=',' read -r -a define_items <<<"${DART_DEFINES:-}"
 
 for index in "${!define_items[@]}"
 do
-    item=$(decode_url "${define_items[$index]}")
+    if [[ -z "${define_items[$index]}" ]]; then
+        continue
+    fi
+
+    item=$(decode_base64 "${define_items[$index]}")
 
     lowercase_item=$(echo "$item" | tr '[:upper:]' '[:lower:]')
     if [[ $lowercase_item != flutter* ]]; then
         echo "$item" >> "$OUTPUT_FILE"
     fi
 done
+
+if is_release_configuration; then
+    for required_define in "${REQUIRED_RELEASE_DEFINES[@]}"
+    do
+        if ! grep -Eq "^${required_define}=.+" "$OUTPUT_FILE"; then
+            echo "error: Missing required iOS release dart define: ${required_define}" >&2
+            echo "error: Pass it with --dart-define=${required_define}=<value> for release/archive builds." >&2
+            exit 1
+        fi
+    done
+fi

--- a/ios/scripts/validate_release_info_plist.sh
+++ b/ios/scripts/validate_release_info_plist.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${CONFIGURATION:-}" != "Release" ]]; then
+    exit 0
+fi
+
+required_scheme="${GOOGLE_RESERVED_CLIENT_ID_IOS:-}"
+info_plist="${TARGET_BUILD_DIR:-}/${INFOPLIST_PATH:-}"
+
+if [[ -z "$required_scheme" || "$required_scheme" == *'$('* ]]; then
+    echo "error: GOOGLE_RESERVED_CLIENT_ID_IOS is not resolved for the iOS release build." >&2
+    echo "error: Pass --dart-define=GOOGLE_RESERVED_CLIENT_ID_IOS=<value> before archiving." >&2
+    exit 1
+fi
+
+if [[ ! -f "$info_plist" ]]; then
+    echo "error: Built Info.plist not found at ${info_plist}." >&2
+    exit 1
+fi
+
+if ! /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$info_plist" \
+    | grep -Fq "$required_scheme"; then
+    echo "error: Built Info.plist does not contain the Google Sign-In URL scheme." >&2
+    echo "error: Expected CFBundleURLTypes to include: ${required_scheme}" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Include `Dart-Defines.xcconfig` in iOS release builds so plist substitutions match debug behavior.
- Harden the Dart define extraction script and fail release/archive builds when `GOOGLE_RESERVED_CLIENT_ID_IOS` is missing.
- Add a release-only Info.plist validation phase and document the required iOS release define.

## Why
Release builds previously did not include the generated Dart define xcconfig, while `Info.plist` depends on `$(GOOGLE_RESERVED_CLIENT_ID_IOS)` for the Google Sign-In redirect scheme. That could produce release/archive apps with a missing or unresolved callback URL scheme.

Fixes #387

## Validation
- `bash -n ios/scripts/extract_dart_defines.sh ios/scripts/validate_release_info_plist.sh`
- `git diff --check`
- Verified release define extraction succeeds with `GOOGLE_RESERVED_CLIENT_ID_IOS`.
- Verified missing release define fails with the intended error.
- Verified release Info.plist validation passes/fails against sample plists.
- `xcodebuild -list -project ios/Runner.xcodeproj`
- Attempted release simulator build after `flutter pub get` and `pod install`; it reached native pod compilation and then stopped with `No space left on device`.
