### PR TITLE
민감한 런타임 로그를 마스킹하고 릴리스 빌드에서 비활성화

### DIFF
--- a/android/app/src/main/kotlin/club/devkor/ontime/AlarmRingingActivity.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/AlarmRingingActivity.kt
@@ -23,7 +23,6 @@ import android.os.Looper
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.WindowInsets
@@ -57,7 +56,7 @@ class AlarmRingingActivity : Activity() {
             if (intent.action != NativeAlarmReceiver.ACTION_ALARM_DISMISSED) return
             val dismissedId = intent.getIntExtra("nativeAlarmId", -1)
             if (dismissedId == requestCode) {
-                Log.d(TAG, "AlarmRingingActivity received dismiss broadcast requestCode=$requestCode")
+                NativeLog.d(TAG, "AlarmRingingActivity received dismiss broadcast requestCode=$requestCode")
                 dismissAlarm()
             }
         }
@@ -65,7 +64,7 @@ class AlarmRingingActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.d(TAG, "AlarmRingingActivity onCreate action=${intent?.action} extras=${intent?.extras}")
+        NativeLog.d(TAG, "AlarmRingingActivity onCreate action=${intent?.action} extras=${intent?.extras}")
         configureWindow()
         capturePayload(intent)
         buildContent()
@@ -75,7 +74,7 @@ class AlarmRingingActivity : Activity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        Log.d(TAG, "AlarmRingingActivity onNewIntent action=${intent.action} extras=${intent.extras}")
+        NativeLog.d(TAG, "AlarmRingingActivity onNewIntent action=${intent.action} extras=${intent.extras}")
         setIntent(intent)
         if (intent.action == NativeAlarmReceiver.ACTION_DISMISS_ALARM) {
             dismissAlarm()
@@ -301,7 +300,7 @@ class AlarmRingingActivity : Activity() {
         dialView?.startPulseAnimation()
         handler.removeCallbacks(autoStopRunnable)
         handler.postDelayed(autoStopRunnable, MAX_RING_DURATION_MS)
-        Log.d(
+        NativeLog.d(
             TAG,
             "AlarmRingingActivity ringing started requestCode=$requestCode " +
                 "scheduleId=${payload["scheduleId"]}",
@@ -358,7 +357,7 @@ class AlarmRingingActivity : Activity() {
             statusView.text = "Alarm stopped. You can still start preparing."
         }
         stopped = true
-        Log.d(TAG, "AlarmRingingActivity ringing stopped requestCode=$requestCode")
+        NativeLog.d(TAG, "AlarmRingingActivity ringing stopped requestCode=$requestCode")
     }
 
     private fun startPreparing() {
@@ -367,7 +366,7 @@ class AlarmRingingActivity : Activity() {
         val launchPayload = payload.toMutableMap().apply {
             put("alarmLaunchAction", "startPreparation")
         }
-        Log.d(
+        NativeLog.d(
             TAG,
             "AlarmRingingActivity start preparing handoff requestCode=$requestCode " +
                 "scheduleId=${launchPayload["scheduleId"]}",

--- a/android/app/src/main/kotlin/club/devkor/ontime/MainActivity.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/MainActivity.kt
@@ -11,7 +11,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import android.view.WindowManager
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -30,17 +29,17 @@ open class MainActivity : FlutterActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.d(TAG, "MainActivity onCreate action=${intent?.action} extras=${intent?.extras}")
+        NativeLog.d(TAG, "MainActivity onCreate action=${intent?.action} extras=${intent?.extras}")
         configureAlarmLaunchWindow(intent)
         payloadFromIntent(intent)?.let {
-            Log.d(TAG, "Captured launch payload from onCreate: $it")
+            NativeLog.d(TAG, "Captured launch payload from onCreate: $it")
             launchPayload = it
         }
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-        Log.d(TAG, "configureFlutterEngine registering method channel")
+        NativeLog.d(TAG, "configureFlutterEngine registering method channel")
         methodChannel = MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,
             CHANNEL_NAME,
@@ -53,19 +52,19 @@ open class MainActivity : FlutterActivity() {
                         "nativeAlarmProvider" to "androidAlarmManager",
                         "fallbackProvider" to "localNotification",
                     )
-                    Log.d(TAG, "getCapabilities -> $capabilities")
+                    NativeLog.d(TAG, "getCapabilities -> $capabilities")
                     result.success(capabilities)
                 }
                 "checkPermission" -> {
                     val state = exactAlarmPermissionState()
-                    Log.d(TAG, "checkPermission -> $state")
+                    NativeLog.d(TAG, "checkPermission -> $state")
                     result.success(state)
                 }
                 "requestPermission" -> requestExactAlarmPermission(result)
                 "scheduleNativeAlarm" -> scheduleNativeAlarm(call, result)
                 "cancelNativeAlarm" -> cancelNativeAlarm(call, result)
                 "getLaunchPayload" -> {
-                    Log.d(TAG, "getLaunchPayload -> $launchPayload")
+                    NativeLog.d(TAG, "getLaunchPayload -> $launchPayload")
                     result.success(launchPayload)
                     launchPayload = null
                 }
@@ -76,11 +75,11 @@ open class MainActivity : FlutterActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        Log.d(TAG, "MainActivity onNewIntent action=${intent.action} extras=${intent.extras}")
+        NativeLog.d(TAG, "MainActivity onNewIntent action=${intent.action} extras=${intent.extras}")
         setIntent(intent)
         configureAlarmLaunchWindow(intent)
         payloadFromIntent(intent)?.let {
-            Log.d(TAG, "Captured launch payload from onNewIntent: $it")
+            NativeLog.d(TAG, "Captured launch payload from onNewIntent: $it")
             launchPayload = it
             methodChannel?.invokeMethod("alarmLaunch", it)
         }
@@ -89,7 +88,7 @@ open class MainActivity : FlutterActivity() {
     private fun scheduleNativeAlarm(call: MethodCall, result: MethodChannel.Result) {
         val args = call.arguments as? Map<*, *>
         if (args == null) {
-            Log.w(TAG, "scheduleNativeAlarm invalid: missing args")
+            NativeLog.w(TAG, "scheduleNativeAlarm invalid: missing args")
             result.error("invalidArguments", "Missing alarm arguments", null)
             return
         }
@@ -97,12 +96,12 @@ open class MainActivity : FlutterActivity() {
         val triggerAtMillis = (args["alarmTime"] as? Number)?.toLong()
         val scheduleId = args["scheduleId"]?.toString()
         if (triggerAtMillis == null || scheduleId.isNullOrEmpty()) {
-            Log.w(TAG, "scheduleNativeAlarm invalid args=$args")
+            NativeLog.w(TAG, "scheduleNativeAlarm invalid args=$args")
             result.error("invalidArguments", "Missing scheduleId or alarmTime", null)
             return
         }
         if (triggerAtMillis <= System.currentTimeMillis()) {
-            Log.w(
+            NativeLog.w(
                 TAG,
                 "scheduleNativeAlarm rejected past alarm scheduleId=$scheduleId " +
                     "triggerAtMillis=$triggerAtMillis now=${System.currentTimeMillis()}",
@@ -113,12 +112,12 @@ open class MainActivity : FlutterActivity() {
 
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as? AlarmManager
         if (alarmManager == null) {
-            Log.w(TAG, "scheduleNativeAlarm unsupported: AlarmManager unavailable")
+            NativeLog.w(TAG, "scheduleNativeAlarm unsupported: AlarmManager unavailable")
             result.error("unsupported", "AlarmManager is unavailable", null)
             return
         }
         if (!canScheduleExactAlarms(alarmManager)) {
-            Log.w(TAG, "scheduleNativeAlarm permissionDenied scheduleId=$scheduleId")
+            NativeLog.w(TAG, "scheduleNativeAlarm permissionDenied scheduleId=$scheduleId")
             result.error("permissionDenied", "Exact alarm permission denied", null)
             return
         }
@@ -129,7 +128,7 @@ open class MainActivity : FlutterActivity() {
             PendingIntent.FLAG_UPDATE_CURRENT,
         )
         if (alarmIntent == null) {
-            Log.w(TAG, "scheduleNativeAlarm unable to build broadcast pending intent args=$args")
+            NativeLog.w(TAG, "scheduleNativeAlarm unable to build broadcast pending intent args=$args")
             result.error("invalidArguments", "Unable to build alarm intent", null)
             return
         }
@@ -140,7 +139,7 @@ open class MainActivity : FlutterActivity() {
         )
         val alarmClockInfo = AlarmManager.AlarmClockInfo(triggerAtMillis, showIntent)
         try {
-            Log.d(
+            NativeLog.d(
                 TAG,
                 "scheduleNativeAlarm setAlarmClock scheduleId=$scheduleId " +
                     "nativeAlarmId=${args["nativeAlarmId"]} triggerAtMillis=$triggerAtMillis " +
@@ -148,18 +147,18 @@ open class MainActivity : FlutterActivity() {
             )
             alarmManager.setAlarmClock(alarmClockInfo, alarmIntent)
         } catch (error: SecurityException) {
-            Log.e(TAG, "scheduleNativeAlarm SecurityException scheduleId=$scheduleId", error)
+            NativeLog.e(TAG, "scheduleNativeAlarm SecurityException scheduleId=$scheduleId", error)
             result.error("permissionDenied", "Exact alarm permission denied", null)
             return
         }
-        Log.d(TAG, "scheduleNativeAlarm success scheduleId=$scheduleId")
+        NativeLog.d(TAG, "scheduleNativeAlarm success scheduleId=$scheduleId")
         result.success(null)
     }
 
     private fun cancelNativeAlarm(call: MethodCall, result: MethodChannel.Result) {
         val args = call.arguments as? Map<*, *>
         if (args == null) {
-            Log.d(TAG, "cancelNativeAlarm skipped: missing args")
+            NativeLog.d(TAG, "cancelNativeAlarm skipped: missing args")
             result.success(null)
             return
         }
@@ -175,7 +174,7 @@ open class MainActivity : FlutterActivity() {
             PendingIntent.FLAG_NO_CREATE,
         )
         if (alarmManager != null && activityPendingIntent != null) {
-            Log.d(
+            NativeLog.d(
                 TAG,
                 "cancelNativeAlarm cancel activity operation scheduleId=${args["scheduleId"]} " +
                     "nativeAlarmId=${args["nativeAlarmId"]}",
@@ -184,7 +183,7 @@ open class MainActivity : FlutterActivity() {
             activityPendingIntent.cancel()
         }
         if (alarmManager != null && legacyBroadcastPendingIntent != null) {
-            Log.d(
+            NativeLog.d(
                 TAG,
                 "cancelNativeAlarm cancel legacy broadcast operation scheduleId=${args["scheduleId"]} " +
                     "nativeAlarmId=${args["nativeAlarmId"]}",
@@ -193,7 +192,7 @@ open class MainActivity : FlutterActivity() {
             legacyBroadcastPendingIntent.cancel()
         }
         if (alarmManager == null || (activityPendingIntent == null && legacyBroadcastPendingIntent == null)) {
-            Log.d(
+            NativeLog.d(
                 TAG,
                 "cancelNativeAlarm no-op scheduleId=${args["scheduleId"]} " +
                     "hasAlarmManager=${alarmManager != null} " +
@@ -233,12 +232,12 @@ open class MainActivity : FlutterActivity() {
     private fun requestExactAlarmPermission(result: MethodChannel.Result) {
         val alarmManager = getSystemService(Context.ALARM_SERVICE) as? AlarmManager
         if (alarmManager == null) {
-            Log.w(TAG, "requestPermission -> unsupported: AlarmManager unavailable")
+            NativeLog.w(TAG, "requestPermission -> unsupported: AlarmManager unavailable")
             result.success("unsupported")
             return
         }
         if (canScheduleExactAlarms(alarmManager) && canPostNotifications()) {
-            Log.d(TAG, "requestPermission -> already granted")
+            NativeLog.d(TAG, "requestPermission -> already granted")
             result.success("granted")
             return
         }
@@ -247,16 +246,16 @@ open class MainActivity : FlutterActivity() {
                 data = Uri.parse("package:$packageName")
             }
             try {
-                Log.d(TAG, "Opening exact alarm permission settings")
+                NativeLog.d(TAG, "Opening exact alarm permission settings")
                 startActivity(intent)
             } catch (error: ActivityNotFoundException) {
-                Log.w(TAG, "Unable to open exact alarm permission settings", error)
+                NativeLog.w(TAG, "Unable to open exact alarm permission settings", error)
                 result.success("denied")
                 return
             }
         }
         val state = exactAlarmPermissionState()
-        Log.d(TAG, "requestPermission -> $state")
+        NativeLog.d(TAG, "requestPermission -> $state")
         result.success(state)
     }
 
@@ -273,7 +272,7 @@ open class MainActivity : FlutterActivity() {
 
     private fun configureAlarmLaunchWindow(intent: Intent?) {
         if (payloadFromIntent(intent) == null) return
-        Log.d(TAG, "configureAlarmLaunchWindow for alarm launch")
+        NativeLog.d(TAG, "configureAlarmLaunchWindow for alarm launch")
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             setShowWhenLocked(true)
             setTurnScreenOn(true)

--- a/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmBootReceiver.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmBootReceiver.kt
@@ -6,7 +6,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -23,12 +22,12 @@ class NativeAlarmBootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action
-        Log.d(TAG, "NativeAlarmBootReceiver onReceive action=$action")
+        NativeLog.d(TAG, "NativeAlarmBootReceiver onReceive action=$action")
         if (
             action != Intent.ACTION_BOOT_COMPLETED &&
             action != AlarmManager.ACTION_SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED
         ) {
-            Log.d(TAG, "Ignoring boot receiver action=$action")
+            NativeLog.d(TAG, "Ignoring boot receiver action=$action")
             return
         }
         restorePersistedNativeAlarms(context)
@@ -43,27 +42,27 @@ class NativeAlarmBootReceiver : BroadcastReceiver() {
     private fun restorePersistedNativeAlarms(context: Context) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
         if (alarmManager == null) {
-            Log.w(TAG, "restorePersistedNativeAlarms skipped: AlarmManager unavailable")
+            NativeLog.w(TAG, "restorePersistedNativeAlarms skipped: AlarmManager unavailable")
             return
         }
         if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
             !alarmManager.canScheduleExactAlarms()
         ) {
-            Log.w(TAG, "restorePersistedNativeAlarms skipped: exact alarm permission denied")
+            NativeLog.w(TAG, "restorePersistedNativeAlarms skipped: exact alarm permission denied")
             return
         }
         val rawRegistry = context.getSharedPreferences(FLUTTER_PREF_NAME, Context.MODE_PRIVATE)
             .getString(REGISTRY_PREF_KEY, null)
         if (rawRegistry == null) {
-            Log.d(TAG, "restorePersistedNativeAlarms skipped: empty registry")
+            NativeLog.d(TAG, "restorePersistedNativeAlarms skipped: empty registry")
             return
         }
         val now = System.currentTimeMillis()
         val records = try {
             JSONArray(rawRegistry)
         } catch (error: Exception) {
-            Log.w(TAG, "restorePersistedNativeAlarms registry parse failed", error)
+            NativeLog.w(TAG, "restorePersistedNativeAlarms registry parse failed", error)
             return
         }
 
@@ -86,19 +85,19 @@ class NativeAlarmBootReceiver : BroadcastReceiver() {
             }
             val alarmTime = parseAlarmTime(record.optString("alarmTime"))
             if (alarmTime == null) {
-                Log.w(TAG, "Skipping restore with unparsable alarmTime scheduleId=$scheduleId")
+                NativeLog.w(TAG, "Skipping restore with unparsable alarmTime scheduleId=$scheduleId")
                 skippedCount += 1
                 continue
             }
             if (alarmTime <= now) {
-                Log.d(TAG, "Skipping restore for past alarm scheduleId=$scheduleId alarmTime=$alarmTime")
+                NativeLog.d(TAG, "Skipping restore for past alarm scheduleId=$scheduleId alarmTime=$alarmTime")
                 skippedCount += 1
                 continue
             }
             val pendingIntent = pendingIntentFor(context, record)
             val showIntent = showIntentFor(context, record)
             if (pendingIntent == null || showIntent == null) {
-                Log.w(TAG, "Restore skipped: unable to build alarm pending intents scheduleId=$scheduleId")
+                NativeLog.w(TAG, "Restore skipped: unable to build alarm pending intents scheduleId=$scheduleId")
                 skippedCount += 1
                 continue
             }
@@ -106,16 +105,16 @@ class NativeAlarmBootReceiver : BroadcastReceiver() {
             try {
                 alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
                 restoredCount += 1
-                Log.d(
+                NativeLog.d(
                     TAG,
                     "Restored native alarm scheduleId=$scheduleId alarmTime=$alarmTime",
                 )
             } catch (error: SecurityException) {
                 skippedCount += 1
-                Log.e(TAG, "Restore failed permission denied scheduleId=$scheduleId", error)
+                NativeLog.e(TAG, "Restore failed permission denied scheduleId=$scheduleId", error)
             }
         }
-        Log.d(
+        NativeLog.d(
             TAG,
             "restorePersistedNativeAlarms complete restored=$restoredCount " +
                 "skipped=$skippedCount total=${records.length()}",

--- a/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmReceiver.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/NativeAlarmReceiver.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 
 class NativeAlarmReceiver : BroadcastReceiver() {
     companion object {
@@ -134,7 +133,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
         fun cancelAlarmNotification(context: Context, requestCode: Int) {
             val manager = context.getSystemService(NotificationManager::class.java)
             manager?.cancel(notificationId(requestCode))
-            Log.d(TAG, "Alarm notification canceled requestCode=$requestCode")
+            NativeLog.d(TAG, "Alarm notification canceled requestCode=$requestCode")
         }
 
         fun notificationId(requestCode: Int): Int {
@@ -204,7 +203,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        Log.d(TAG, "NativeAlarmReceiver onReceive action=${intent.action} extras=${intent.extras}")
+        NativeLog.d(TAG, "NativeAlarmReceiver onReceive action=${intent.action} extras=${intent.extras}")
         when (intent.action) {
             ACTION_FIRE_ALARM -> handleFireAlarm(context, intent)
             ACTION_DISMISS_ALARM -> handleDismissAlarm(context, intent)
@@ -219,7 +218,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
                 ?: extras["scheduleId"]?.hashCode()
                 ?: 1,
         )
-        Log.d(
+        NativeLog.d(
             TAG,
             "Native alarm broadcast fired requestCode=$requestCode " +
                 "scheduleId=${extras["scheduleId"]} alarmTime=${extras["alarmTime"]}",
@@ -241,7 +240,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
             putExtra("nativeAlarmId", requestCode)
             putExtra("scheduleId", extras["scheduleId"])
         })
-        Log.d(
+        NativeLog.d(
             TAG,
             "Native alarm dismissed requestCode=$requestCode scheduleId=${extras["scheduleId"]}",
         )
@@ -254,11 +253,11 @@ class NativeAlarmReceiver : BroadcastReceiver() {
     ) {
         val manager = context.getSystemService(NotificationManager::class.java)
         if (manager == null) {
-            Log.w(TAG, "Alarm notification skipped: NotificationManager unavailable")
+            NativeLog.w(TAG, "Alarm notification skipped: NotificationManager unavailable")
             return
         }
         if (!canPostNotifications(context)) {
-            Log.w(
+            NativeLog.w(
                 TAG,
                 "Alarm notification skipped: notification permission denied " +
                     "scheduleId=${extras["scheduleId"]}",
@@ -306,7 +305,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
             )
             .build()
         manager.notify(notificationId(requestCode), notification)
-        Log.d(
+        NativeLog.d(
             TAG,
             "Full-screen alarm notification posted requestCode=$requestCode " +
                 "scheduleId=${extras["scheduleId"]}",
@@ -317,7 +316,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         val existing = manager.getNotificationChannel(ALARM_CHANNEL_ID)
         if (existing != null) {
-            Log.d(TAG, "Alarm notification channel already exists")
+            NativeLog.d(TAG, "Alarm notification channel already exists")
             return
         }
         val channel = NotificationChannel(
@@ -330,7 +329,7 @@ class NativeAlarmReceiver : BroadcastReceiver() {
             setBypassDnd(true)
         }
         manager.createNotificationChannel(channel)
-        Log.d(TAG, "Alarm notification channel created")
+        NativeLog.d(TAG, "Alarm notification channel created")
     }
 
     private fun canPostNotifications(context: Context): Boolean {

--- a/android/app/src/main/kotlin/club/devkor/ontime/NativeLog.kt
+++ b/android/app/src/main/kotlin/club/devkor/ontime/NativeLog.kt
@@ -1,0 +1,29 @@
+package club.devkor.ontime
+
+import android.util.Log
+
+object NativeLog {
+    fun d(tag: String, message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d(tag, message)
+        }
+    }
+
+    fun w(tag: String, message: String, throwable: Throwable? = null) {
+        if (!BuildConfig.DEBUG) return
+        if (throwable == null) {
+            Log.w(tag, message)
+        } else {
+            Log.w(tag, message, throwable)
+        }
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        if (!BuildConfig.DEBUG) return
+        if (throwable == null) {
+            Log.e(tag, message)
+        } else {
+            Log.e(tag, message, throwable)
+        }
+    }
+}

--- a/docs/Logging-Policy.md
+++ b/docs/Logging-Policy.md
@@ -1,0 +1,40 @@
+# Logging Policy
+
+OnTime logs must be safe by default. Release builds must not write tokens,
+authorization headers, request bodies, response bodies, personal schedule
+payloads, or full alarm launch payloads to device logs.
+
+## Dart
+
+- Use `AppLogger` for new diagnostics.
+- `AppLogger` only emits logs in debug builds.
+- Pass structured maps through `AppLogger.redactValue` or
+  `AppLogger.redactMap` before including them in messages.
+- Do not log request bodies, response bodies, OAuth values, FCM tokens,
+  authorization headers, refresh tokens, schedule names, notes, or alarm
+  payloads.
+- If a token-related event needs diagnostics, log that the event happened and
+  optionally include a redacted token length through `AppLogger.redactToken`.
+- `main()` disables Flutter `debugPrint` in non-debug builds to prevent older
+  debug diagnostics from leaking in release.
+
+## Network
+
+- Dio request and response logs may include method, redacted URL, status code,
+  redacted headers, redacted query parameters, and body runtime type.
+- Dio logs must not include serialized request bodies or response data.
+- Add new sensitive header or parameter names to `AppLogger` redaction before
+  logging them.
+
+## Native Android and iOS
+
+- Android native alarm diagnostics must use `NativeLog`, which emits only in
+  debug builds.
+- iOS native alarm diagnostics must be wrapped in `#if DEBUG`.
+- Never log full `Intent` extras, AlarmKit encoded payloads, schedule titles,
+  notification bodies, or launch URLs in release builds.
+
+## Tests
+
+Redaction behavior is covered by `test/core/logging/app_logger_test.dart`.
+When adding a new sensitive key pattern, add or update a redaction test.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -367,13 +367,17 @@ public struct OpenScheduleAlarmIntent: LiveActivityIntent {
   public func perform() async throws -> some IntentResult & OpensIntent {
     if let data = encodedPayload.data(using: .utf8),
        let payload = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+      #if DEBUG
       NSLog("OnTime AlarmKit Open intent invoked for scheduleId=%@", payload["scheduleId"] ?? "")
+      #endif
       AppDelegate.storeAlarmLaunchPayload(payload)
       if let url = AppDelegate.alarmLaunchURL(payload: payload) {
         return .result(opensIntent: OpenURLIntent(url))
       }
     }
+    #if DEBUG
     NSLog("OnTime AlarmKit Open intent invoked without a valid payload")
+    #endif
     return .result(opensIntent: OpenURLIntent(URL(string: "\(onTimeAlarmLaunchURLScheme)://\(onTimeAlarmLaunchURLHost)")!))
   }
 }

--- a/lib/core/dio/interceptors/logger_interceptor.dart
+++ b/lib/core/dio/interceptors/logger_interceptor.dart
@@ -1,25 +1,37 @@
-import 'dart:developer';
-
 import 'package:dio/dio.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
 
 class LoggerInterceptor implements Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
-    log('❌ Dio Error!');
-    log('❌ Url: ${err.requestOptions.uri}');
-    log('❌ Data: ${err.requestOptions.data}');
-    log('❌ ${err.stackTrace}');
-    log('❌ Response Error: ${err.response?.data}');
-    log('❌ Response Message: ${err.message}');
+    AppLogger.debug(
+      'Dio error '
+      '${err.requestOptions.method} '
+      '${AppLogger.redactUri(err.requestOptions.uri)} '
+      'status=${err.response?.statusCode} '
+      'type=${err.type} '
+      'message=${err.message}',
+    );
+    AppLogger.debug(
+      'Dio error headers=${AppLogger.redactValue(err.requestOptions.headers)}',
+    );
     return handler.next(err);
   }
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    log('🌍 Sending network request: ${options.baseUrl}${options.path}');
-    log('🌍 Header: ${options.headers}');
-    log('🌍 Query: ${options.queryParameters}');
-    log('🌍 Data: ${options.data}');
+    AppLogger.debug(
+      'Dio request ${options.method} ${AppLogger.redactUri(options.uri)}',
+    );
+    AppLogger.debug('Dio headers=${AppLogger.redactValue(options.headers)}');
+    AppLogger.debug(
+      'Dio query=${AppLogger.redactValue(options.queryParameters)}',
+    );
+    if (options.data != null) {
+      AppLogger.debug(
+        'Dio request body=${AppLogger.omitted} type=${options.data.runtimeType}',
+      );
+    }
 
     return handler.next(options);
   }
@@ -29,15 +41,19 @@ class LoggerInterceptor implements Interceptor {
     Response<dynamic> response,
     ResponseInterceptorHandler handler,
   ) {
-    log('⬅️ Received network response');
-    if (response.data is Map && response.data['status'] != null) {
-      log('${'✅ ${response.data['status']} ✅'} ${response.requestOptions.baseUrl}${response.requestOptions.path}');
-    } else {
-      log('${'✅ ${response.statusCode} ✅'} ${response.requestOptions.baseUrl}${response.requestOptions.path}');
+    AppLogger.debug(
+      'Dio response ${response.requestOptions.method} '
+      '${AppLogger.redactUri(response.requestOptions.uri)} '
+      'status=${response.statusCode}',
+    );
+    AppLogger.debug(
+      'Dio query=${AppLogger.redactValue(response.requestOptions.queryParameters)}',
+    );
+    if (response.data != null) {
+      AppLogger.debug(
+        'Dio response body=${AppLogger.omitted} type=${response.data.runtimeType}',
+      );
     }
-    log('Query params: ${response.requestOptions.queryParameters}');
-    log('Response Data: ${response.data}');
-    log('-------------------------');
     return handler.next(response);
   }
 }

--- a/lib/core/dio/transformers/logging_transformer.dart
+++ b/lib/core/dio/transformers/logging_transformer.dart
@@ -1,6 +1,5 @@
-import 'dart:developer';
-
 import 'package:dio/dio.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
 
 /// A wrapper transformer that logs the exact serialized request payload
 /// produced by Dio's inner transformer. This reflects the precise string
@@ -14,9 +13,10 @@ class LoggingTransformer implements Transformer {
   @override
   Future<String> transformRequest(RequestOptions options) async {
     final body = await _inner.transformRequest(options);
-    try {
-      log('🧾 Serialized body (${options.method} ${options.uri}): $body');
-    } catch (_) {}
+    AppLogger.debug(
+      'Serialized request body=${AppLogger.omitted} '
+      '${options.method} ${AppLogger.redactUri(options.uri)} bytes=${body.length}',
+    );
     return body;
   }
 

--- a/lib/core/logging/app_logger.dart
+++ b/lib/core/logging/app_logger.dart
@@ -1,0 +1,111 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+final class AppLogger {
+  const AppLogger._();
+
+  static const redacted = '<redacted>';
+  static const omitted = '<omitted>';
+
+  static bool get isEnabled => kDebugMode;
+
+  static void configureFlutterDebugPrint() {
+    if (!kDebugMode) {
+      debugPrint = _discardDebugPrint;
+    }
+  }
+
+  static void debug(
+    String message, {
+    String name = 'OnTime',
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    if (!kDebugMode) return;
+    developer.log(
+      redactText(message),
+      name: name,
+      error: error == null ? null : redactValue(error),
+      stackTrace: stackTrace,
+    );
+  }
+
+  static Object? redactValue(Object? value) {
+    if (value == null) return null;
+    if (value is Uri) return redactUri(value);
+    if (value is Map) {
+      return value.map((key, nestedValue) {
+        final keyText = key.toString();
+        if (_isSensitiveKey(keyText)) {
+          return MapEntry(key, redacted);
+        }
+        return MapEntry(key, redactValue(nestedValue));
+      });
+    }
+    if (value is Iterable && value is! String) {
+      return value.map(redactValue).toList(growable: false);
+    }
+    return redactText(value.toString());
+  }
+
+  static Map<String, dynamic> redactMap(Map<dynamic, dynamic> values) {
+    return values.map(
+      (key, value) => MapEntry(key.toString(), redactValueForKey(key, value)),
+    );
+  }
+
+  static Object? redactValueForKey(Object? key, Object? value) {
+    if (_isSensitiveKey(key?.toString() ?? '')) {
+      return redacted;
+    }
+    return redactValue(value);
+  }
+
+  static String redactUri(Uri uri) {
+    if (!uri.hasQuery) return uri.toString();
+    final redactedParameters = uri.queryParameters.map(
+      (key, value) => MapEntry(key, redactValueForKey(key, value).toString()),
+    );
+    return uri.replace(queryParameters: redactedParameters).toString();
+  }
+
+  static String redactToken(String? token) {
+    if (token == null || token.isEmpty) return redacted;
+    return '$redacted length=${token.length}';
+  }
+
+  static String redactText(String message) {
+    var result = message.replaceAllMapped(
+      RegExp(
+        r'\bBearer\s+[A-Za-z0-9._~+/=-]+',
+        caseSensitive: false,
+      ),
+      (_) => 'Bearer $redacted',
+    );
+    result = result.replaceAllMapped(
+      RegExp(
+        r'\b(authorization(?:-refresh)?|access[_-]?token|refresh[_-]?token|firebase[_-]?token|fcm[_-]?token|id[_-]?token|oauth[_-]?token|token)\b\s*[:=]\s*([^,\s}\]]+)',
+        caseSensitive: false,
+      ),
+      (match) => '${match.group(1)}=$redacted',
+    );
+    return result;
+  }
+
+  static bool _isSensitiveKey(String key) {
+    final normalized = key.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+    return normalized == 'authorization' ||
+        normalized == 'authorizationrefresh' ||
+        normalized == 'accessToken'.toLowerCase() ||
+        normalized == 'refreshtoken' ||
+        normalized == 'firebasetoken' ||
+        normalized == 'fcmtoken' ||
+        normalized == 'idtoken' ||
+        normalized == 'oauthtoken' ||
+        normalized.endsWith('secret') ||
+        normalized.endsWith('token');
+  }
+}
+
+void _discardDebugPrint(String? message, {int? wrapWidth}) {}

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
 import 'package:on_time_front/core/services/js_interop_service.dart';
 import 'package:on_time_front/core/services/navigation_service.dart';
 import 'package:on_time_front/data/data_sources/notification_remote_data_source.dart';
@@ -21,12 +22,13 @@ import 'package:timezone/timezone.dart' as tz;
 
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  debugPrint('[FCM Background Handler] 메시지 수신');
+  AppLogger.configureFlutterDebugPrint();
+  AppLogger.debug('[FCM Background Handler] message received');
 
   try {
     await Firebase.initializeApp();
   } catch (e) {
-    debugPrint('[FCM Background Handler] Firebase 초기화 오류: $e');
+    AppLogger.debug('[FCM Background Handler] Firebase init failed: $e');
   }
   await NotificationService.instance.setupFlutterNotifications();
   await NotificationService.instance.showNotification(message);
@@ -137,7 +139,9 @@ class NotificationService {
   Future<void> requestNotificationToken() async {
     try {
       final token = await _messaging.getToken();
-      debugPrint('[FCM] FCM Token 획득: $token');
+      AppLogger.debug(
+        '[FCM] FCM token acquired token=${AppLogger.redactToken(token)}',
+      );
 
       if (token != null) {
         try {
@@ -155,7 +159,9 @@ class NotificationService {
       }
 
       _messaging.onTokenRefresh.listen((newToken) {
-        debugPrint('[FCM] Token 갱신됨: $newToken');
+        AppLogger.debug(
+          '[FCM] token refreshed token=${AppLogger.redactToken(newToken)}',
+        );
         getIt.get<AlarmRepository>().getDeviceId().then((deviceId) {
           getIt.get<NotificationRemoteDataSource>().fcmTokenRegister(
                 FcmTokenRegisterRequestModel(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,23 +2,25 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/date_symbol_data_local.dart';
-import 'package:on_time_front/core/constants/environment_variable.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
 import 'package:on_time_front/core/services/device_info_service/shared.dart';
 import 'package:on_time_front/firebase_options.dart';
 import 'package:on_time_front/presentation/app/screens/app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  AppLogger.configureFlutterDebugPrint();
   await HardwareKeyboard.instance.syncKeyboardState().catchError((_) {});
   await initializeDateFormatting();
   configureDependencies();
-  debugPrint(EnvironmentVariable.restApiUrl);
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  debugPrint('[FCM Main] Firebase 초기화 완료');
+  AppLogger.debug('[FCM Main] Firebase initialized');
 
-  debugPrint(DeviceInfoService.isInStandaloneMode.toString());
+  AppLogger.debug(
+    'Device standalone mode=${DeviceInfoService.isInStandaloneMode}',
+  );
   runApp(App());
 }

--- a/test/core/logging/app_logger_test.dart
+++ b/test/core/logging/app_logger_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
+
+void main() {
+  group('AppLogger redaction', () {
+    test('redacts sensitive map values recursively', () {
+      final value = AppLogger.redactValue({
+        'Authorization': 'Bearer access-token',
+        'nested': {
+          'refreshToken': 'refresh-token',
+          'safe': 'visible',
+        },
+        'items': [
+          {'firebaseToken': 'fcm-token'},
+        ],
+      });
+
+      expect(value, {
+        'Authorization': AppLogger.redacted,
+        'nested': {
+          'refreshToken': AppLogger.redacted,
+          'safe': 'visible',
+        },
+        'items': [
+          {'firebaseToken': AppLogger.redacted},
+        ],
+      });
+    });
+
+    test('redacts bearer tokens and token assignments in text', () {
+      final redacted = AppLogger.redactText(
+        'Authorization: Bearer abc.def token=secret refresh_token=rotate-value',
+      );
+
+      expect(redacted, isNot(contains('abc.def')));
+      expect(redacted, isNot(contains('secret')));
+      expect(redacted, isNot(contains('rotate-value')));
+      expect(redacted, contains('Authorization=${AppLogger.redacted}'));
+      expect(redacted, contains('token=${AppLogger.redacted}'));
+      expect(redacted, contains('refresh_token=${AppLogger.redacted}'));
+    });
+
+    test('redacts sensitive query parameters in urls', () {
+      final redacted = AppLogger.redactUri(
+        Uri.parse(
+          'https://api.example.test/path?access_token=secret&page=1',
+        ),
+      );
+
+      expect(redacted, isNot(contains('secret')));
+      final query = Uri.parse(redacted).queryParameters;
+      expect(query['access_token'], AppLogger.redacted);
+      expect(query['page'], '1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Dart 공통 로거를 추가해 `debug` 전용 로그와 민감값 마스킹을 중앙화했습니다.
- Dio 인터셉터와 request transformer에서 헤더, 쿼리, 본문, 응답 본문이 그대로 노출되지 않도록 변경했습니다.
- `main()`에서 비디버그 빌드의 `debugPrint` 출력을 차단하고, FCM 토큰 로그는 마스킹하도록 바꿨습니다.
- Android 알람 관련 `Log.*` 호출을 `NativeLog`로 감싸 릴리스 빌드에서는 출력되지 않게 했고, iOS AlarmKit 로그도 `#if DEBUG`로 제한했습니다.
- 후속 작업을 위한 [Logging-Policy.md](/Users/ejunpark/.codex/worktrees/f826/OnTime-front/docs/Logging-Policy.md)와 마스킹 테스트를 추가했습니다.

## Testing
- `flutter test test/core/logging/app_logger_test.dart`
- `flutter analyze`
- `git diff --check`
- Android Kotlin 컴파일도 시도했지만, 로컬 मशीन의 디스크 여유 공간 부족으로 Gradle 단계에서 중단되었습니다.