### PR TITLE
chore: finalize production metadata

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,6 +11,34 @@ def googleServicesConfigFiles = [
     file("src/google-services.json"),
 ]
 
+def releaseKeystoreProperties = new Properties()
+def releaseKeystorePropertiesFile = rootProject.file("key.properties")
+if (releaseKeystorePropertiesFile.exists()) {
+    releaseKeystorePropertiesFile.withInputStream { releaseKeystoreProperties.load(it) }
+}
+
+def releaseSigningValue = { propertyName, envName ->
+    def propertyValue = releaseKeystoreProperties.getProperty(propertyName)
+    return propertyValue ?: System.getenv(envName)
+}
+
+def releaseStoreFile = releaseSigningValue("storeFile", "ONTIME_ANDROID_KEYSTORE_PATH")
+def releaseStorePassword = releaseSigningValue("storePassword", "ONTIME_ANDROID_KEYSTORE_PASSWORD")
+def releaseKeyAlias = releaseSigningValue("keyAlias", "ONTIME_ANDROID_KEY_ALIAS")
+def releaseKeyPassword = releaseSigningValue("keyPassword", "ONTIME_ANDROID_KEY_PASSWORD")
+def releaseStoreFileObject = releaseStoreFile ? new File(releaseStoreFile) : null
+def hasReleaseSigningConfig = [
+    releaseStoreFile,
+    releaseStorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword
+].every { it != null && it.toString().trim() }
+
+def androidReleaseSigningMessage = """Missing Android release signing config.
+Provide android/key.properties with storeFile, storePassword, keyAlias, and keyPassword,
+or set ONTIME_ANDROID_KEYSTORE_PATH, ONTIME_ANDROID_KEYSTORE_PASSWORD,
+ONTIME_ANDROID_KEY_ALIAS, and ONTIME_ANDROID_KEY_PASSWORD."""
+
 if (googleServicesConfigFiles.any { it.exists() }) {
     apply plugin: "com.google.gms.google-services"
 } else {
@@ -21,6 +49,21 @@ android {
     namespace = "club.devkor.ontime"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
+
+    signingConfigs {
+        if (hasReleaseSigningConfig) {
+            release {
+                storeFile = releaseStoreFileObject.isAbsolute() ? releaseStoreFileObject : rootProject.file(releaseStoreFile)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     compileOptions {
         coreLibraryDesugaringEnabled = true
@@ -33,10 +76,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "club.devkor.ontime"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -49,10 +89,17 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            if (hasReleaseSigningConfig) {
+                signingConfig = signingConfigs.release
+            }
         }
+    }
+}
+
+gradle.taskGraph.whenReady { taskGraph ->
+    def runsReleaseTask = taskGraph.allTasks.any { it.name.toLowerCase().contains("release") }
+    if (runsReleaseTask && !hasReleaseSigningConfig) {
+        throw new GradleException(androidReleaseSigningMessage)
     }
 }
 

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -1,0 +1,103 @@
+# Android Signing Setup
+
+Use this guide when preparing OnTime for Google Play release builds.
+
+## Key Concepts
+
+- Google Play releases should use Play App Signing.
+- The local team keeps an upload key and uses it to sign app bundles before
+  uploading them to Play Console.
+- Google Play uses the upload key to verify the upload, then signs distributed
+  APKs with the app signing key.
+- Do not commit keystores, passwords, `android/key.properties`, or generated
+  release artifacts.
+
+## Create an Upload Key
+
+Create and store the keystore somewhere outside the repository:
+
+```sh
+mkdir -p ~/secure
+
+keytool -genkeypair -v \
+  -keystore ~/secure/ontime-upload.jks \
+  -storetype JKS \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000 \
+  -alias ontime
+```
+
+Save the keystore file and passwords in the team password manager or secret
+manager. Losing the upload key requires a Play Console upload-key reset.
+
+## Configure Local Release Signing
+
+Create `android/key.properties` locally:
+
+```properties
+storeFile=/absolute/path/to/ontime-upload.jks
+storePassword=<keystore-password>
+keyAlias=ontime
+keyPassword=<key-password>
+```
+
+`android/key.properties` is ignored by git and must stay local.
+
+Alternatively, set environment variables:
+
+```sh
+export ONTIME_ANDROID_KEYSTORE_PATH=/absolute/path/to/ontime-upload.jks
+export ONTIME_ANDROID_KEYSTORE_PASSWORD='<keystore-password>'
+export ONTIME_ANDROID_KEY_ALIAS=ontime
+export ONTIME_ANDROID_KEY_PASSWORD='<key-password>'
+```
+
+## Build a Signed Release
+
+Google Play prefers Android App Bundles:
+
+```sh
+flutter build appbundle --release
+```
+
+For APK validation outside Play:
+
+```sh
+flutter build apk --release
+```
+
+The Gradle config intentionally fails release builds when signing secrets are
+missing. Debug builds do not require release signing secrets.
+
+## First Play Console Release
+
+1. Create or open the app in Google Play Console.
+2. Create a release on an internal testing track first.
+3. Configure Play App Signing when prompted.
+4. Use Google-generated app signing key unless the team needs to share the same
+   signing key across multiple stores or related apps.
+5. Upload the `.aab` from `build/app/outputs/bundle/release/`.
+6. After Play App Signing is active, continue signing future uploads with the
+   same local upload key.
+
+## Existing Play Console App
+
+- If the app already has an upload key, use that existing key.
+- If the upload key is lost but Play App Signing is enabled, request an upload
+  key reset in Play Console.
+- If Play App Signing is not enabled and the app signing key is lost, the app
+  generally cannot be updated under the same package name.
+
+## Verification
+
+Run these checks before handing a release build to QA or Play Console:
+
+```sh
+flutter analyze
+flutter test
+flutter build appbundle --release
+```
+
+Confirm that `pubspec.yaml` has the intended `version` and that the build number
+is greater than every previous Play Console upload for `club.devkor.ontime`.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -1,0 +1,53 @@
+# Release Checklist
+
+Use this checklist before producing store or production distribution builds for
+OnTime.
+
+## Versioning
+
+- Keep `pubspec.yaml` as the source of truth for the app version.
+- Use semantic versioning for the build name and a monotonically increasing
+  build number, formatted as `major.minor.patch+build`.
+- The first production release is `1.0.0+1`.
+- For each store submission, bump the build number even if the public version
+  name is unchanged.
+
+## Android
+
+- Confirm the application ID is `club.devkor.ontime`.
+- Confirm the app label is `OnTime`.
+- Review launcher icons in `android/app/src/main/res/mipmap-*`.
+- Provide release signing through one of the following secret-free paths:
+  - `android/key.properties` with `storeFile`, `storePassword`, `keyAlias`, and
+    `keyPassword`.
+  - Environment variables `ONTIME_ANDROID_KEYSTORE_PATH`,
+    `ONTIME_ANDROID_KEYSTORE_PASSWORD`, `ONTIME_ANDROID_KEY_ALIAS`, and
+    `ONTIME_ANDROID_KEY_PASSWORD`.
+- Follow `docs/Android-Signing-Setup.md` when creating or configuring the
+  upload key.
+- Keep keystores, passwords, and `key.properties` out of git.
+- Verify the release build fails clearly when signing secrets are missing.
+
+## iOS
+
+- Confirm the bundle identifier is `club.devkor.ontime`.
+- Confirm the display name and bundle name are `OnTime`.
+- Review the app icon set in `ios/Runner/Assets.xcassets/AppIcon.appiconset`.
+- Confirm the launch screen, supported orientations, background modes,
+  entitlements, and AlarmKit capability declarations match the release target.
+- Pass `GOOGLE_RESERVED_CLIENT_ID_IOS` for release/archive builds as documented
+  in `docs/iOS-Release-Configuration.md`.
+
+## Web
+
+- Confirm `web/manifest.json` uses the production app name, short name,
+  description, icons, theme color, and orientation.
+- Confirm `web/index.html` uses the production description, app title, favicon,
+  apple mobile web app title, and touch icon.
+- Rebuild the web app before deployment.
+
+## Store Metadata
+
+- Confirm the app name, short description, full description, screenshots,
+  support contact, privacy policy, and category are ready for the target stores.
+- Track any brand, icon, screenshot, or store copy gaps before submission.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: on_time_front
-description: "A new Flutter project."
+description: "OnTime helps you prepare for schedules with timely alarms and reminders."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/web/index.html
+++ b/web/index.html
@@ -19,7 +19,7 @@
 
     <meta charset="UTF-8" />
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
-    <meta name="description" content="A new Flutter project." />
+    <meta name="description" content="OnTime helps you prepare for schedules with timely alarms and reminders." />
 
     <meta name="theme-color" content="transparent">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
@@ -42,7 +42,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
-    <title>on_time_front</title>
+    <title>OnTime</title>
     <link rel="manifest" href="manifest.json" />
 
     <style>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -5,7 +5,7 @@
   "display": "standalone",
   "background_color": "#0175C2",
   "theme_color": "#0175C2",
-  "description": "A new Flutter project.",
+  "description": "OnTime helps you prepare for schedules with timely alarms and reminders.",
   "orientation": "portrait-primary",
   "prefer_related_applications": false,
   "icons": [


### PR DESCRIPTION
## Summary

Closes #396.

- replace scaffold app descriptions and web title with production OnTime metadata
- configure Android release signing through local key.properties or ONTIME_ANDROID_* environment variables
- add release checklist and Android signing setup instructions for Play App Signing

## Validation

- flutter analyze
- flutter test
- flutter build web
- flutter build apk --debug
- flutter build apk --release without signing config fails with the intended signing message
- flutter build apk --release with a temporary env-backed test keystore succeeds