### PR TITLE
[codex] harden iOS ATS release configuration

### DIFF
--- a/docs/iOS-Release-Configuration.md
+++ b/docs/iOS-Release-Configuration.md
@@ -5,13 +5,16 @@ Release and archive builds must provide the same Dart define values that debug b
 ## Required Dart Defines
 
 - `GOOGLE_RESERVED_CLIENT_ID_IOS`: reversed iOS client ID used by Google Sign-In as the callback URL scheme in `ios/Runner/Info.plist`.
+- `REST_API_URL`: production REST API base URL. Release builds must use an `https://` URL.
 
 ## Local Release Build
 
 Run release builds with the required define:
 
 ```sh
-flutter build ios --release --dart-define=GOOGLE_RESERVED_CLIENT_ID_IOS=<reversed-ios-client-id>
+flutter build ios --release \
+  --dart-define=GOOGLE_RESERVED_CLIENT_ID_IOS=<reversed-ios-client-id> \
+  --dart-define=REST_API_URL=https://api.ontime.devkor.club
 ```
 
 For Xcode archives, add the same define to the Flutter build invocation or the CI step that prepares the archive.
@@ -20,4 +23,6 @@ For Xcode archives, add the same define to the Flutter build invocation or the C
 
 The shared Runner scheme decodes Flutter `DART_DEFINES` into `ios/Flutter/Dart-Defines.xcconfig` before the build. `ios/Flutter/Release.xcconfig` includes that generated file so `$(GOOGLE_RESERVED_CLIENT_ID_IOS)` resolves in the built `Info.plist`.
 
-Release builds fail clearly when the required define is missing. A release-only Xcode build phase also checks the built `Info.plist` and fails if the Google Sign-In URL scheme was not written into `CFBundleURLTypes`.
+Release builds fail clearly when a required define is missing or when `REST_API_URL` is not HTTPS. A release-only Xcode build phase also checks the built `Info.plist` and fails if the Google Sign-In URL scheme was not written into `CFBundleURLTypes`, or if the release plist enables arbitrary ATS loads.
+
+Debug builds use `ios/Runner/Info-Debug.plist`, which keeps `NSAllowsArbitraryLoads` for the current HTTP debug API. Profile and Release builds use `ios/Runner/Info.plist`, which must remain production-strict.

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D77738812D8A000000000001 /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9B0A0B393C9095132C2689C0 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9C12B98E3998C1270FDE43D1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -163,6 +164,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				D77738812D8A000000000001 /* Info-Debug.plist */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -703,7 +705,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = SA9884Z46P;
 				ENABLE_BITCODE = NO;
-				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_FILE = "Runner/Info-Debug.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/Runner/Info-Debug.plist
+++ b/ios/Runner/Info-Debug.plist
@@ -45,6 +45,11 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSAlarmKitUsageDescription</key>
 	<string>On Time uses alarms to remind you when it is time to prepare for schedules.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/ios/scripts/extract_dart_defines.sh
+++ b/ios/scripts/extract_dart_defines.sh
@@ -3,7 +3,7 @@
 SRCROOT="${SRCROOT:-$(pwd)}"
 
 OUTPUT_FILE="${SRCROOT}/Flutter/Dart-Defines.xcconfig"
-REQUIRED_RELEASE_DEFINES=("GOOGLE_RESERVED_CLIENT_ID_IOS")
+REQUIRED_RELEASE_DEFINES=("GOOGLE_RESERVED_CLIENT_ID_IOS" "REST_API_URL")
 
 set -euo pipefail
 
@@ -49,4 +49,11 @@ if is_release_configuration; then
             exit 1
         fi
     done
+
+    rest_api_url=$(grep -E "^REST_API_URL=" "$OUTPUT_FILE" | tail -n 1 | cut -d= -f2-)
+    if [[ "$rest_api_url" != https://* ]]; then
+        echo "error: iOS release REST_API_URL must use HTTPS." >&2
+        echo "error: Received REST_API_URL=${rest_api_url}" >&2
+        exit 1
+    fi
 fi

--- a/ios/scripts/validate_release_info_plist.sh
+++ b/ios/scripts/validate_release_info_plist.sh
@@ -26,3 +26,10 @@ if ! /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes" "$info_plist" \
     echo "error: Expected CFBundleURLTypes to include: ${required_scheme}" >&2
     exit 1
 fi
+
+arbitrary_loads=$(/usr/libexec/PlistBuddy -c "Print :NSAppTransportSecurity:NSAllowsArbitraryLoads" "$info_plist" 2>/dev/null || true)
+if [[ "$arbitrary_loads" == "true" || "$arbitrary_loads" == "1" || "$arbitrary_loads" == "YES" ]]; then
+    echo "error: iOS release Info.plist must not allow arbitrary ATS loads." >&2
+    echo "error: Remove NSAppTransportSecurity:NSAllowsArbitraryLoads from the release plist." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Remove the blanket iOS ATS arbitrary-load allowance from the shipping Runner plist.
- Add a debug-only iOS plist that preserves HTTP support for current debug API workflows.
- Require HTTPS `REST_API_URL` for iOS release builds and reject release plists that enable arbitrary ATS loads.

## Why
Issue #388 calls out that production iOS builds should not ship with a global ATS bypass. The release API already uses HTTPS, while debug currently targets an HTTP endpoint, so this keeps development working without weakening production/profile builds.

## Validation
- `plutil -lint ios/Runner/Info.plist ios/Runner/Info-Debug.plist`
- `plutil -lint ios/Runner.xcodeproj/project.pbxproj`
- Verified ATS exists only in `ios/Runner/Info-Debug.plist`
- Exercised `ios/scripts/extract_dart_defines.sh` for missing `REST_API_URL`, HTTP `REST_API_URL`, and HTTPS `REST_API_URL`
- Exercised `ios/scripts/validate_release_info_plist.sh` against strict and debug ATS plists
- `git diff --check`
- `flutter analyze`

Closes #388
