### PR TITLE
[codex] Enforce Android Firebase release config

### DIFF
--- a/.github/workflows/android-release-verify.yml
+++ b/.github/workflows/android-release-verify.yml
@@ -1,0 +1,45 @@
+name: Android Release Verification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build_release:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.6"
+          channel: "stable"
+
+      - name: Decode Android Firebase config
+        env:
+          ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+        run: |
+          if [ -z "$ANDROID_GOOGLE_SERVICES_JSON_B64" ]; then
+            echo "ANDROID_GOOGLE_SERVICES_JSON_B64 secret is required for Android release builds." >&2
+            exit 1
+          fi
+          mkdir -p android/app/src/release
+          printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_B64" | base64 --decode > android/app/src/release/google-services.json
+          test -s android/app/src/release/google-services.json
+
+      - run: flutter pub get
+
+      - run: dart run build_runner build -d
+
+      - name: Build Android app bundle
+        env:
+          REST_API_URL: ${{ vars.REST_API_URL }}
+        run: flutter build appbundle --release --dart-define=REST_API_URL=$REST_API_URL

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ app.*.map.json
 ios/Flutter/Dart-Defines.xcconfig
 ios/GoogleService-Info.plist
 android/app/google-services.json
+android/app/src/debug/google-services.json
+android/app/src/release/google-services.json
+android/app/src/google-services.json
 
 .cursor
 .codex/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,11 +5,32 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def isReleaseBuild = gradle.startParameter.taskNames.any {
+    it.toLowerCase().contains("release")
+}
+def googleServicesBuildType = isReleaseBuild ? "release" : "debug"
 def googleServicesConfigFiles = [
+    file("src/${googleServicesBuildType}/google-services.json"),
     file("google-services.json"),
-    file("src/${gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') } ? 'release' : 'debug'}/google-services.json"),
     file("src/google-services.json"),
 ]
+def releaseGoogleServicesConfigFiles = [
+    file("src/release/google-services.json"),
+    file("google-services.json"),
+    file("src/google-services.json"),
+]
+def hasReleaseGoogleServicesConfig = releaseGoogleServicesConfigFiles.any {
+    it.exists()
+}
+
+if (isReleaseBuild && !hasReleaseGoogleServicesConfig) {
+    throw new GradleException(
+        "Android release builds require Firebase config. " +
+        "Provide android/app/src/release/google-services.json, usually by " +
+        "decoding the ANDROID_GOOGLE_SERVICES_JSON_B64 CI secret before " +
+        "running a release build."
+    )
+}
 
 if (googleServicesConfigFiles.any { it.exists() }) {
     apply plugin: "com.google.gms.google-services"
@@ -30,6 +51,10 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     defaultConfig {

--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -1,0 +1,27 @@
+# Android Release Configuration
+
+Android release builds must include the production Firebase client config so Firebase Core and Firebase Messaging initialize consistently.
+
+## Required CI Secret
+
+- `ANDROID_GOOGLE_SERVICES_JSON_B64`: base64-encoded contents of the production Android `google-services.json` for Firebase project `ontime-c63f1`.
+
+The release verification workflow decodes this secret to `android/app/src/release/google-services.json` before running the Android release build. Generated `google-services.json` files are ignored and must not be committed.
+
+## Local Release Build
+
+Create the release source-set config before building:
+
+```sh
+mkdir -p android/app/src/release
+base64 --decode android-google-services.json.b64 > android/app/src/release/google-services.json
+flutter build appbundle --release --dart-define=REST_API_URL=<api-url>
+```
+
+On macOS, use `base64 -D` instead of `base64 --decode`.
+
+Debug/local builds may run without Android Firebase config. Release builds fail clearly if `android/app/src/release/google-services.json`, `android/app/google-services.json`, or `android/app/src/google-services.json` is missing.
+
+## Verification
+
+Use the `Android Release Verification` GitHub Actions workflow to confirm CI can reproduce the release build with the configured secret. For production readiness, also install a real Android release build and verify Firebase initializes and FCM token registration reaches the backend.


### PR DESCRIPTION
## Summary
- Require Android release builds to include a Firebase `google-services.json` config instead of silently skipping Google Services.
- Add a manual Android release verification workflow that decodes `ANDROID_GOOGLE_SERVICES_JSON_B64` and builds the release app bundle.
- Document the Android release config secret and keep generated source-set Firebase config files ignored.

## Why
Issue #386 identified that release builds could compile without the Android Firebase client config, leaving Firebase Core and FCM behavior dependent on local/CI filesystem state.

## Validation
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` without Android Firebase config
- `flutter build appbundle --release` without Android Firebase config, confirmed it fails with the intended Gradle error

## Notes
Release success and real-device FCM registration still require the approved production `google-services.json` / `ANDROID_GOOGLE_SERVICES_JSON_B64` secret.
