### PR TITLE
[codex] Add Android Play internal deploy

### DIFF
--- a/.github/workflows/android-play-internal.yml
+++ b/.github/workflows/android-play-internal.yml
@@ -1,0 +1,142 @@
+name: Android Play Internal Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: Optional Google Play release notes for en-US.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_internal:
+    name: Build and upload internal testing draft
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/ontime-upload.jks
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      REST_API_URL: ${{ vars.REST_API_URL }}
+
+    steps:
+      - name: Require main branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Android Play Internal Deploy must be run from main." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.6"
+          channel: stable
+          cache: true
+
+      - name: Install native test dependencies
+        run: sudo apt-get update && sudo apt-get install -y sqlite3 libsqlite3-dev
+
+      - name: Validate release configuration
+        env:
+          ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          missing=0
+          for name in \
+            ANDROID_GOOGLE_SERVICES_JSON_B64 \
+            ANDROID_UPLOAD_KEYSTORE_B64 \
+            ANDROID_KEYSTORE_PASSWORD \
+            ANDROID_KEY_ALIAS \
+            ANDROID_KEY_PASSWORD \
+            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON \
+            REST_API_URL
+          do
+            if [ -z "${!name}" ]; then
+              echo "$name is required for Android Play internal deploy." >&2
+              missing=1
+            fi
+          done
+          exit "$missing"
+
+      - name: Decode Android Firebase config
+        env:
+          ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+        run: |
+          mkdir -p android/app/src/release
+          printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_B64" | base64 --decode > android/app/src/release/google-services.json
+          test -s android/app/src/release/google-services.json
+
+      - name: Decode Android upload keystore
+        env:
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+        run: |
+          printf '%s' "$ANDROID_UPLOAD_KEYSTORE_B64" | base64 --decode > "$ANDROID_KEYSTORE_PATH"
+          chmod 600 "$ANDROID_KEYSTORE_PATH"
+          test -s "$ANDROID_KEYSTORE_PATH"
+
+      - name: Install Flutter packages
+        run: flutter pub get
+
+      - name: Run code generation
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Verify generated files are current
+        run: git diff --exit-code
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test
+
+      - name: Build Android app bundle
+        run: flutter build appbundle --release --dart-define=REST_API_URL="$REST_API_URL"
+
+      - name: Prepare Play release notes
+        if: ${{ inputs.release_notes != '' }}
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          mkdir -p distribution/whatsnew
+          printf '%s\n' "$RELEASE_NOTES" > distribution/whatsnew/whatsnew-en-US
+
+      - name: Upload signed app bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ontime-android-release-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload internal testing draft with release notes
+        if: ${{ inputs.release_notes != '' }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: club.devkor.ontime
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          tracks: internal
+          status: draft
+          whatsNewDirectory: distribution/whatsnew
+
+      - name: Upload internal testing draft
+        if: ${{ inputs.release_notes == '' }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: club.devkor.ontime
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          tracks: internal
+          status: draft

--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -8,6 +8,40 @@ Android release builds must include the production Firebase client config so Fir
 
 The release verification workflow decodes this secret to `android/app/src/release/google-services.json` before running the Android release build. Generated `google-services.json` files are ignored and must not be committed.
 
+## Google Play Internal Testing Deploy
+
+Use the `Android Play Internal Deploy` GitHub Actions workflow to build a signed
+Android App Bundle and upload it to the Google Play Internal Testing track as a
+draft release. The workflow is manual-only and must be dispatched from `main`.
+
+Configure a GitHub environment named `release` with required reviewers before
+using the workflow. Store these environment secrets there:
+
+- `ANDROID_GOOGLE_SERVICES_JSON_B64`: base64-encoded production Android
+  Firebase config.
+- `ANDROID_UPLOAD_KEYSTORE_B64`: base64-encoded Google Play upload keystore.
+- `ANDROID_KEYSTORE_PASSWORD`: upload keystore password.
+- `ANDROID_KEY_ALIAS`: upload key alias.
+- `ANDROID_KEY_PASSWORD`: upload key password.
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`: raw service-account JSON for the Google
+  Play Developer API.
+
+Store this environment variable in `release`:
+
+- `REST_API_URL`: production API base URL passed to Flutter with
+  `--dart-define`.
+
+The deploy workflow runs package install, code generation, generated-file drift
+checking, analysis, tests, and then `flutter build appbundle --release`. It
+uploads the signed `.aab` as a 14-day GitHub Actions artifact and creates a
+draft release on Google Play Internal Testing. If the optional release notes
+input is empty, the workflow uploads without custom release notes.
+
+`pubspec.yaml` remains the source of truth for `version: major.minor.patch+build`.
+Before dispatching the workflow, bump the build number so it is greater than
+every previously uploaded Google Play build for `club.devkor.ontime`. Duplicate
+build numbers fail during the Google Play upload step.
+
 ## Local Release Build
 
 Create the release source-set config before building:

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -57,6 +57,26 @@ The Gradle build also accepts the legacy `ONTIME_ANDROID_KEYSTORE_PATH`,
 `ONTIME_ANDROID_KEYSTORE_PASSWORD`, `ONTIME_ANDROID_KEY_ALIAS`, and
 `ONTIME_ANDROID_KEY_PASSWORD` variable names for compatibility.
 
+## Configure CI Release Signing
+
+For GitHub Actions deploys, base64-encode the upload keystore and store it as
+the `ANDROID_UPLOAD_KEYSTORE_B64` secret in the protected `release`
+environment:
+
+```sh
+base64 -i ~/secure/ontime-upload.jks | pbcopy
+```
+
+On Linux, use:
+
+```sh
+base64 -w 0 ~/secure/ontime-upload.jks
+```
+
+The deploy workflow decodes this secret into `$RUNNER_TEMP/ontime-upload.jks`
+and exports `ANDROID_KEYSTORE_PATH` to that temporary file. Do not create
+`android/key.properties` in CI.
+
 ## Build a Signed Release
 
 Google Play prefers Android App Bundles:


### PR DESCRIPTION
## Summary
- Add a manual Android Play Internal Testing deploy workflow for signed draft `.aab` uploads.
- Decode Firebase config and the upload keystore from protected `release` environment secrets.
- Document the required GitHub environment secrets, variable, and CI signing setup.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-play-internal.yml"); puts "yaml ok"'`
- `git diff --cached --check`

## Notes
- The workflow must be dispatched from `main`.
- The `release` environment should have required reviewers configured in GitHub settings.
