### PR TITLE
[codex] Fix Android deploy workflow env

### DIFF
--- a/.github/workflows/android-play-internal.yml
+++ b/.github/workflows/android-play-internal.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     env:
-      ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/ontime-upload.jks
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
       ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
       ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
@@ -43,6 +42,9 @@ jobs:
           flutter-version: "3.32.6"
           channel: stable
           cache: true
+
+      - name: Set Android keystore path
+        run: echo "ANDROID_KEYSTORE_PATH=$RUNNER_TEMP/ontime-upload.jks" >> "$GITHUB_ENV"
 
       - name: Install native test dependencies
         run: sudo apt-get update && sudo apt-get install -y sqlite3 libsqlite3-dev


### PR DESCRIPTION
## Summary
- Fix the Android Play Internal Deploy workflow syntax error by removing `runner.temp` from job-level `env`.
- Set `ANDROID_KEYSTORE_PATH` at runtime through `$GITHUB_ENV` using the runner-provided `$RUNNER_TEMP` path.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-play-internal.yml"); puts "yaml ok"'`
- `git diff --check`
