### PR TITLE
[codex] Bump Android build number

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary
- Bump the Flutter app build number from `1.0.0+1` to `1.0.0+2` for the next Google Play upload.
- Keep the public version name at `1.0.0`.

## Validation
- `git diff --check`
