### PR TITLE
[codex] Derive Android version code from run number

### DIFF
--- a/.github/workflows/android-play-internal.yml
+++ b/.github/workflows/android-play-internal.yml
@@ -103,8 +103,22 @@ jobs:
       - name: Test
         run: flutter test
 
+      - name: Derive Android build name
+        run: |
+          app_version="$(sed -n 's/^version: *//p' pubspec.yaml | head -n 1)"
+          build_name="${app_version%%+*}"
+          if [ -z "$build_name" ]; then
+            echo "Unable to derive Android build name from pubspec.yaml version." >&2
+            exit 1
+          fi
+          echo "ANDROID_BUILD_NAME=$build_name" >> "$GITHUB_ENV"
+
       - name: Build Android app bundle
-        run: flutter build appbundle --release --dart-define=REST_API_URL="$REST_API_URL"
+        run: |
+          flutter build appbundle --release \
+            --build-name="$ANDROID_BUILD_NAME" \
+            --build-number="${{ github.run_number }}" \
+            --dart-define=REST_API_URL="$REST_API_URL"
 
       - name: Prepare Play release notes
         if: ${{ inputs.release_notes != '' }}

--- a/.github/workflows/android-release-verify.yml
+++ b/.github/workflows/android-release-verify.yml
@@ -39,7 +39,21 @@ jobs:
 
       - run: dart run build_runner build -d
 
+      - name: Derive Android build name
+        run: |
+          app_version="$(sed -n 's/^version: *//p' pubspec.yaml | head -n 1)"
+          build_name="${app_version%%+*}"
+          if [ -z "$build_name" ]; then
+            echo "Unable to derive Android build name from pubspec.yaml version." >&2
+            exit 1
+          fi
+          echo "ANDROID_BUILD_NAME=$build_name" >> "$GITHUB_ENV"
+
       - name: Build Android app bundle
         env:
           REST_API_URL: ${{ vars.REST_API_URL }}
-        run: flutter build appbundle --release --dart-define=REST_API_URL=$REST_API_URL
+        run: |
+          flutter build appbundle --release \
+            --build-name="$ANDROID_BUILD_NAME" \
+            --build-number="${{ github.run_number }}" \
+            --dart-define=REST_API_URL="$REST_API_URL"

--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -33,14 +33,26 @@ Store this environment variable in `release`:
 
 The deploy workflow runs package install, code generation, generated-file drift
 checking, analysis, tests, and then `flutter build appbundle --release`. It
-uploads the signed `.aab` as a 14-day GitHub Actions artifact and creates a
+derives Android `versionName` from the `pubspec.yaml` version name and supplies
+`${{ github.run_number }}` as Android `versionCode`:
+
+```sh
+flutter build appbundle --release \
+  --build-name=<version name from pubspec.yaml> \
+  --build-number=${{ github.run_number }} \
+  --dart-define=REST_API_URL="$REST_API_URL"
+```
+
+It uploads the signed `.aab` as a 14-day GitHub Actions artifact and creates a
 draft release on Google Play Internal Testing. If the optional release notes
 input is empty, the workflow uploads without custom release notes.
 
-`pubspec.yaml` remains the source of truth for `version: major.minor.patch+build`.
-Before dispatching the workflow, bump the build number so it is greater than
-every previously uploaded Google Play build for `club.devkor.ontime`. Duplicate
-build numbers fail during the Google Play upload step.
+Keep `pubspec.yaml` as the source of truth for the manually managed public
+version name, such as `version: 1.0.0+1`. Android CI ignores the checked-in
+build suffix for Play uploads, so do not open PRs only to bump `+2`, `+3`, and
+similar build numbers. The generated `github.run_number` must still be greater
+than every previously uploaded Google Play build for `club.devkor.ontime`;
+duplicate or lower build numbers fail during the Google Play upload step.
 
 ## Local Release Build
 
@@ -49,7 +61,10 @@ Create the release source-set config before building:
 ```sh
 mkdir -p android/app/src/release
 base64 --decode android-google-services.json.b64 > android/app/src/release/google-services.json
-flutter build appbundle --release --dart-define=REST_API_URL=<api-url>
+flutter build appbundle --release \
+  --build-name=<version name from pubspec.yaml> \
+  --build-number=<monotonic Android versionCode> \
+  --dart-define=REST_API_URL=<api-url>
 ```
 
 On macOS, use `base64 -D` instead of `base64 --decode`.

--- a/docs/Android-Release-Signing.md
+++ b/docs/Android-Release-Signing.md
@@ -49,7 +49,9 @@ export ANDROID_KEYSTORE_PASSWORD=<keystore-password>
 export ANDROID_KEY_ALIAS=<release-key-alias>
 export ANDROID_KEY_PASSWORD=<release-key-password>
 
-flutter build appbundle --release
+flutter build appbundle --release \
+  --build-name=<version name from pubspec.yaml> \
+  --build-number=<monotonic Android versionCode>
 ```
 
 ## How Validation Works

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -82,7 +82,9 @@ and exports `ANDROID_KEYSTORE_PATH` to that temporary file. Do not create
 Google Play prefers Android App Bundles:
 
 ```sh
-flutter build appbundle --release
+flutter build appbundle --release \
+  --build-name=<version name from pubspec.yaml> \
+  --build-number=<monotonic Android versionCode>
 ```
 
 For APK validation outside Play:
@@ -120,8 +122,12 @@ Run these checks before handing a release build to QA or Play Console:
 ```sh
 flutter analyze
 flutter test
-flutter build appbundle --release
+flutter build appbundle --release \
+  --build-name=<version name from pubspec.yaml> \
+  --build-number=<monotonic Android versionCode>
 ```
 
-Confirm that `pubspec.yaml` has the intended `version` and that the build number
-is greater than every previous Play Console upload for `club.devkor.ontime`.
+Confirm that `pubspec.yaml` has the intended public version name. In GitHub
+Actions deploys, Android `versionCode` comes from `github.run_number`; for any
+manual Play upload, provide a build number greater than every previous Play
+Console upload for `club.devkor.ontime`.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -6,11 +6,13 @@ OnTime.
 ## Versioning
 
 - Keep `pubspec.yaml` as the source of truth for the app version.
-- Use semantic versioning for the build name and a monotonically increasing
-  build number, formatted as `major.minor.patch+build`.
+- Use semantic versioning for the public version name, formatted as
+  `major.minor.patch`.
 - The first production release is `1.0.0+1`.
-- For each store submission, bump the build number even if the public version
-  name is unchanged.
+- Keep the public version name manual in `pubspec.yaml`.
+- For Android Play deploys, CI derives `versionName` from `pubspec.yaml` and
+  uses `github.run_number` as the generated `versionCode`; do not open PRs only
+  to bump the checked-in build suffix.
 
 ## Android
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+3
+version: 1.0.0+1
 
 environment:
   sdk: ^3.8.0


### PR DESCRIPTION
## Summary

- Derive Android `versionName` from `pubspec.yaml` in release workflows.
- Use `github.run_number` as the generated Android `versionCode` for Play upload and release verification builds.
- Reset `pubspec.yaml` to `1.0.0+1` and update Android release docs so future redeploys do not require PRs that only bump `+2`, `+3`, etc.

## Why

Google Play requires a monotonically increasing Android `versionCode`, but checked-in Flutter build suffix bumps create noisy PRs. Using the workflow run number keeps CI uploads monotonic while leaving the public version name manually controlled in `pubspec.yaml`.

## Validation

- Parsed `.github/workflows/android-play-internal.yml`, `.github/workflows/android-release-verify.yml`, and `pubspec.yaml` with Ruby YAML.
- Ran `git diff --check`.
- Verified the shell extraction resolves `1.0.0+1` to Android build name `1.0.0`.
