### PR TITLE
fix: align frontend validation with backend contract

### DIFF
--- a/lib/core/dio/api_error_message.dart
+++ b/lib/core/dio/api_error_message.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+
+class ApiErrorMessage {
+  const ApiErrorMessage._();
+
+  static String? fromException(Object error) {
+    if (error is DioException) {
+      return fromResponseData(error.response?.data);
+    }
+    return null;
+  }
+
+  static String? fromResponseData(Object? data) {
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final message = data['message'];
+    if (message is String && message.trim().isNotEmpty) {
+      return message.trim();
+    }
+
+    final errors = data['data'];
+    if (errors is Map<String, dynamic>) {
+      final errorList = errors['errors'];
+      if (errorList is List && errorList.isNotEmpty) {
+        final firstError = errorList.first;
+        if (firstError is Map<String, dynamic>) {
+          final fieldMessage = firstError['message'];
+          if (fieldMessage is String && fieldMessage.trim().isNotEmpty) {
+            return fieldMessage.trim();
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/lib/core/validation/backend_constraints.dart
+++ b/lib/core/validation/backend_constraints.dart
@@ -1,0 +1,58 @@
+class BackendConstraints {
+  const BackendConstraints._();
+
+  static const int maxScheduleNameLength = 30;
+  static const int maxLongTextLength = 1000;
+  static const int maxMinuteValue = 1440;
+  static const int minPasswordLength = 8;
+  static const int maxPasswordLength = 64;
+
+  static final RegExp deviceIdPattern = RegExp(r'^[A-Za-z0-9._:-]{16,128}$');
+
+  static String trimToMaxLength(String value, int maxLength) {
+    final trimmedValue = value.trim();
+    if (trimmedValue.length <= maxLength) {
+      return trimmedValue;
+    }
+    return trimmedValue.substring(0, maxLength);
+  }
+}
+
+enum PasswordPolicyError {
+  tooShort,
+  tooLong,
+  missingLetter,
+  missingNumber,
+  missingSpecialCharacter,
+}
+
+class PasswordPolicy {
+  const PasswordPolicy._();
+
+  static final RegExp _letterPattern = RegExp(r'[A-Za-z]');
+  static final RegExp _numberPattern = RegExp(r'[0-9]');
+  static final RegExp _specialCharacterPattern = RegExp(
+    r'''[!@#$%^&*(),.?":{}|<>\[\]\\;'/`~_+=\-]''',
+  );
+
+  static PasswordPolicyError? validate(String value) {
+    if (value.length < BackendConstraints.minPasswordLength) {
+      return PasswordPolicyError.tooShort;
+    }
+    if (value.length > BackendConstraints.maxPasswordLength) {
+      return PasswordPolicyError.tooLong;
+    }
+    if (!_letterPattern.hasMatch(value)) {
+      return PasswordPolicyError.missingLetter;
+    }
+    if (!_numberPattern.hasMatch(value)) {
+      return PasswordPolicyError.missingNumber;
+    }
+    if (!_specialCharacterPattern.hasMatch(value)) {
+      return PasswordPolicyError.missingSpecialCharacter;
+    }
+    return null;
+  }
+
+  static bool isValid(String value) => validate(value) == null;
+}

--- a/lib/data/data_sources/authentication_remote_data_source.dart
+++ b/lib/data/data_sources/authentication_remote_data_source.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/constants/endpoint.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/data/models/get_user_response_model.dart';
 import 'package:on_time_front/data/models/sign_in_user_response_model.dart';
 import 'package:on_time_front/data/models/sign_in_with_google_request_model.dart';
@@ -13,13 +14,18 @@ abstract interface class AuthenticationRemoteDataSource {
   Future<(UserEntity, TokenEntity)> signIn(String email, String password);
 
   Future<(UserEntity, TokenEntity)> signUp(
-      String email, String password, String name);
+    String email,
+    String password,
+    String name,
+  );
 
   Future<(UserEntity, TokenEntity)> signInWithGoogle(
-      SignInWithGoogleRequestModel signInWithGoogleRequestModel);
+    SignInWithGoogleRequestModel signInWithGoogleRequestModel,
+  );
 
   Future<(UserEntity, TokenEntity)> signInWithApple(
-      SignInWithAppleRequestModel signInWithAppleRequestModel);
+    SignInWithAppleRequestModel signInWithAppleRequestModel,
+  );
 
   Future<UserEntity> getUser();
 
@@ -42,14 +48,13 @@ class AuthenticationRemoteDataSourceImpl
 
   @override
   Future<(UserEntity, TokenEntity)> signIn(
-      String email, String password) async {
+    String email,
+    String password,
+  ) async {
     try {
       final result = await dio.post(
         Endpoint.signIn,
-        data: {
-          'email': email,
-          'password': password,
-        },
+        data: {'email': email, 'password': password},
       );
       if (result.statusCode == 200) {
         final user = SignInUserResponseModel.fromJson(result.data['data']);
@@ -65,15 +70,14 @@ class AuthenticationRemoteDataSourceImpl
 
   @override
   Future<(UserEntity, TokenEntity)> signUp(
-      String email, String password, String name) async {
+    String email,
+    String password,
+    String name,
+  ) async {
     try {
       final result = await dio.post(
         Endpoint.signUp,
-        data: {
-          'email': email,
-          'password': password,
-          'name': name,
-        },
+        data: {'email': email, 'password': password, 'name': name},
       );
       if (result.statusCode == 200) {
         final user = SignInUserResponseModel.fromJson(result.data['data']);
@@ -89,7 +93,8 @@ class AuthenticationRemoteDataSourceImpl
 
   @override
   Future<(UserEntity, TokenEntity)> signInWithGoogle(
-      SignInWithGoogleRequestModel signInWithGoogleRequestModel) async {
+    SignInWithGoogleRequestModel signInWithGoogleRequestModel,
+  ) async {
     try {
       final result = await dio.post(
         Endpoint.signInWithGoogle,
@@ -109,7 +114,8 @@ class AuthenticationRemoteDataSourceImpl
 
   @override
   Future<(UserEntity, TokenEntity)> signInWithApple(
-      SignInWithAppleRequestModel signInWithAppleRequestModel) async {
+    SignInWithAppleRequestModel signInWithAppleRequestModel,
+  ) async {
     try {
       final result = await dio.post(
         Endpoint.signInWithApple,
@@ -180,10 +186,11 @@ class AuthenticationRemoteDataSourceImpl
   Future<void> postFeedback(String message) async {
     try {
       final feedbackId = const Uuid().v4();
-      final result = await dio.post(Endpoint.feedback, data: {
-        'feedbackId': feedbackId,
-        'message': message,
-      });
+      final trimmedMessage = _trimLongText(message);
+      final result = await dio.post(
+        Endpoint.feedback,
+        data: {'feedbackId': feedbackId, 'message': trimmedMessage},
+      );
       if (result.statusCode == 200) {
         return;
       } else {
@@ -227,7 +234,9 @@ class AuthenticationRemoteDataSourceImpl
   }
 
   Map<String, dynamic> _buildDeleteFeedbackData(String? feedbackMessage) {
-    final trimmedMessage = feedbackMessage?.trim();
+    final trimmedMessage = feedbackMessage == null
+        ? null
+        : _trimLongText(feedbackMessage);
     if (trimmedMessage == null || trimmedMessage.isEmpty) {
       return <String, dynamic>{};
     }
@@ -236,5 +245,12 @@ class AuthenticationRemoteDataSourceImpl
       'feedbackId': const Uuid().v4(),
       'message': trimmedMessage,
     };
+  }
+
+  String _trimLongText(String value) {
+    return BackendConstraints.trimToMaxLength(
+      value,
+      BackendConstraints.maxLongTextLength,
+    );
   }
 }

--- a/lib/data/models/create_schedule_request_model.dart
+++ b/lib/data/models/create_schedule_request_model.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 
 part 'create_schedule_request_model.g.dart';
@@ -39,13 +40,19 @@ class CreateScheduleRequestModel {
       scheduleId: entity.id,
       placeId: entity.place.id,
       placeName: entity.place.placeName,
-      scheduleName: entity.scheduleName,
+      scheduleName: BackendConstraints.trimToMaxLength(
+        entity.scheduleName,
+        BackendConstraints.maxScheduleNameLength,
+      ),
       scheduleTime: entity.scheduleTime,
       moveTime: entity.moveTime.inMinutes,
       isChange: entity.isChanged,
       isStarted: entity.isStarted,
       scheduleSpareTime: entity.scheduleSpareTime?.inMinutes,
-      scheduleNote: entity.scheduleNote,
+      scheduleNote: BackendConstraints.trimToMaxLength(
+        entity.scheduleNote,
+        BackendConstraints.maxLongTextLength,
+      ),
     );
   }
 }

--- a/lib/data/models/update_schedule_request_model.dart
+++ b/lib/data/models/update_schedule_request_model.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 
 part 'update_schedule_request_model.g.dart';
@@ -35,11 +36,17 @@ class UpdateScheduleRequestModel {
       scheduleId: entity.id,
       placeId: entity.place.id,
       placeName: entity.place.placeName,
-      scheduleName: entity.scheduleName,
+      scheduleName: BackendConstraints.trimToMaxLength(
+        entity.scheduleName,
+        BackendConstraints.maxScheduleNameLength,
+      ),
       scheduleTime: entity.scheduleTime,
       moveTime: entity.moveTime.inMinutes,
       scheduleSpareTime: entity.scheduleSpareTime?.inMinutes,
-      scheduleNote: entity.scheduleNote,
+      scheduleNote: BackendConstraints.trimToMaxLength(
+        entity.scheduleNote,
+        BackendConstraints.maxLongTextLength,
+      ),
     );
   }
 }

--- a/lib/data/repositories/alarm_repository_impl.dart
+++ b/lib/data/repositories/alarm_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
 import 'package:on_time_front/core/services/device_info_service/shared.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/data/data_sources/alarm_remote_data_source.dart';
 import 'package:on_time_front/domain/entities/alarm_entities.dart';
 import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
@@ -24,7 +25,8 @@ class AlarmRepositoryImpl implements AlarmRepository {
   Future<String> getDeviceId() async {
     final prefs = await SharedPreferences.getInstance();
     final existing = prefs.getString(_deviceIdKey);
-    if (existing != null && existing.isNotEmpty) {
+    if (existing != null &&
+        BackendConstraints.deviceIdPattern.hasMatch(existing)) {
       return existing;
     }
 
@@ -53,12 +55,8 @@ class AlarmRepositoryImpl implements AlarmRepository {
   }
 
   @override
-  Future<AlarmSettings> updateAlarmSettings({
-    required bool alarmsEnabled,
-  }) {
-    return remoteDataSource.updateAlarmSettings(
-      alarmsEnabled: alarmsEnabled,
-    );
+  Future<AlarmSettings> updateAlarmSettings({required bool alarmsEnabled}) {
+    return remoteDataSource.updateAlarmSettings(alarmsEnabled: alarmsEnabled);
   }
 
   @override

--- a/lib/data/repositories/user_repository_impl.dart
+++ b/lib/data/repositories/user_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/logging/app_logger.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/data/data_sources/authentication_remote_data_source.dart';
 import 'package:on_time_front/data/data_sources/token_local_data_source.dart';
 import 'package:on_time_front/data/models/sign_in_with_google_request_model.dart';
@@ -101,6 +102,10 @@ class UserRepositoryImpl implements UserRepository {
     required String password,
     required String name,
   }) async {
+    final passwordError = PasswordPolicy.validate(password);
+    if (passwordError != null) {
+      throw ArgumentError.value(password, 'password', passwordError.name);
+    }
     try {
       final result = await _authenticationRemoteDataSource.signUp(
         email,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -371,6 +371,10 @@
             }
         }
     },
+    "scheduleTimePastError": "Choose a future appointment time.",
+    "@scheduleTimePastError": {
+        "description": "Error message when selected appointment time is in the past"
+    },
     "previousScheduleOverlapError": "Overlapped with \"{scheduleName}\"! You need to prepare {minutes} minutes earlier.",
     "@previousScheduleOverlapError": {
         "description": "Error message when schedule is already overlapping with previous schedule",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -105,6 +105,10 @@
             }
         }
     },
+    "scheduleTimePastError": "미래의 약속 시간을 선택해주세요.",
+    "@scheduleTimePastError": {
+        "description": "Error message when selected appointment time is in the past"
+    },
     "previousScheduleOverlapError": "\"{scheduleName}\"과 겹쳤어요! {minutes}분 더 빨리 준비해야 해요",
     "@previousScheduleOverlapError": {
         "description": "Error message when schedule is already overlapping with previous schedule",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -602,6 +602,12 @@ abstract class AppLocalizations {
   /// **'Overlapped with next schedule {scheduleName}! Next schedule preparation starts at {startTime}'**
   String scheduleOverlapError(String scheduleName, String startTime);
 
+  /// Error message when selected appointment time is in the past
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a future appointment time.'**
+  String get scheduleTimePastError;
+
   /// Error message when schedule is already overlapping with previous schedule
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -296,6 +296,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get scheduleTimePastError => 'Choose a future appointment time.';
+
+  @override
   String previousScheduleOverlapError(int minutes, String scheduleName) {
     return 'Overlapped with \"$scheduleName\"! You need to prepare $minutes minutes earlier.';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -277,6 +277,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get scheduleTimePastError => '미래의 약속 시간을 선택해주세요.';
+
+  @override
   String previousScheduleOverlapError(int minutes, String scheduleName) {
     return '\"$scheduleName\"과 겹쳤어요! $minutes분 더 빨리 준비해야 해요';
   }

--- a/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
+++ b/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/core/logging/app_logger.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
 import 'package:on_time_front/domain/use-cases/delete_user_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
@@ -29,7 +31,9 @@ class DeleteUserModal {
   }
 
   Future<void> _showDeleteFeedbackModal(
-      BuildContext context, VoidCallback onConfirm) async {
+    BuildContext context,
+    VoidCallback onConfirm,
+  ) async {
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     final l10n = AppLocalizations.of(context)!;
@@ -90,6 +94,11 @@ class DeleteUserModal {
             child: TextField(
               controller: controller,
               focusNode: focusNode,
+              inputFormatters: [
+                LengthLimitingTextInputFormatter(
+                  BackendConstraints.maxLongTextLength,
+                ),
+              ],
               maxLines: null,
               expands: true,
               textAlign: TextAlign.start,
@@ -103,8 +112,9 @@ class DeleteUserModal {
                 color: colorScheme.onSurface,
               ),
               decoration: InputDecoration(
-                hintText:
-                    focusNode.hasFocus ? '' : l10n.deleteFeedbackPlaceholder,
+                hintText: focusNode.hasFocus
+                    ? ''
+                    : l10n.deleteFeedbackPlaceholder,
                 hintStyle: textTheme.bodyMedium?.copyWith(
                   fontFamily: 'Pretendard',
                   fontWeight: FontWeight.w400,
@@ -132,13 +142,11 @@ class DeleteUserModal {
       final deleteUserUseCase = getIt<DeleteUserUseCase>();
       await deleteUserUseCase(controller.text);
     } catch (error) {
-      AppLogger.debug(
-        'Delete user failed errorType=${error.runtimeType}',
-      );
+      AppLogger.debug('Delete user failed errorType=${error.runtimeType}');
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.error)),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.error)));
       }
       return;
     }

--- a/lib/presentation/onboarding/preparation_name_select/input_models/preparation_name_input_model.dart
+++ b/lib/presentation/onboarding/preparation_name_select/input_models/preparation_name_input_model.dart
@@ -1,9 +1,7 @@
 import 'package:formz/formz.dart';
 
 /// Validation errors for the [PreparationNameInputModel] [FormzInput].
-enum PreparationNameValidationError {
-  empty,
-}
+enum PreparationNameValidationError { empty }
 
 class PreparationNameInputModel
     extends FormzInput<String, PreparationNameValidationError> {
@@ -12,6 +10,6 @@ class PreparationNameInputModel
 
   @override
   PreparationNameValidationError? validator(String value) {
-    return value.isEmpty ? PreparationNameValidationError.empty : null;
+    return value.trim().isEmpty ? PreparationNameValidationError.empty : null;
   }
 }

--- a/lib/presentation/onboarding/preparation_time/input_models/preparation_time_input_model.dart
+++ b/lib/presentation/onboarding/preparation_time/input_models/preparation_time_input_model.dart
@@ -1,19 +1,28 @@
 import 'package:formz/formz.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 
 /// Validation errors for the [PreparationTimeInputModel] [FormzInput].
-enum PreparationTimeValidationError {
-  zero,
-}
+enum PreparationTimeValidationError { zero, negative, tooLarge }
 
 class PreparationTimeInputModel
     extends FormzInput<Duration, PreparationTimeValidationError> {
   const PreparationTimeInputModel.pure([super.value = Duration.zero])
-      : super.pure();
+    : super.pure();
   const PreparationTimeInputModel.dirty([super.value = Duration.zero])
-      : super.dirty();
+    : super.dirty();
 
   @override
   PreparationTimeValidationError? validator(Duration value) {
-    return value.inMinutes == 0 ? PreparationTimeValidationError.zero : null;
+    final minutes = value.inMinutes;
+    if (minutes < 0) {
+      return PreparationTimeValidationError.negative;
+    }
+    if (minutes == 0) {
+      return PreparationTimeValidationError.zero;
+    }
+    if (minutes > BackendConstraints.maxMinuteValue) {
+      return PreparationTimeValidationError.tooLarge;
+    }
+    return null;
   }
 }

--- a/lib/presentation/schedule_create/bloc/schedule_form_bloc.dart
+++ b/lib/presentation/schedule_create/bloc/schedule_form_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/dio/api_error_message.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
@@ -116,13 +117,7 @@ class ScheduleFormBloc extends Bloc<ScheduleFormEvent, ScheduleFormState> {
     final now = DateTime.now();
     final initialScheduleTime = event.initialDate == null
         ? null
-        : DateTime(
-            event.initialDate!.year,
-            event.initialDate!.month,
-            event.initialDate!.day,
-            now.hour,
-            now.minute,
-          );
+        : _initialScheduleTime(event.initialDate!, now);
 
     emit(
       state.copyWith(
@@ -239,7 +234,7 @@ class ScheduleFormBloc extends Bloc<ScheduleFormEvent, ScheduleFormState> {
       emit(
         state.copyWith(
           submissionStatus: ScheduleFormSubmissionStatus.failure,
-          submissionError: e.toString(),
+          submissionError: ApiErrorMessage.fromException(e) ?? e.toString(),
         ),
       );
     }
@@ -279,7 +274,7 @@ class ScheduleFormBloc extends Bloc<ScheduleFormEvent, ScheduleFormState> {
       emit(
         state.copyWith(
           submissionStatus: ScheduleFormSubmissionStatus.failure,
-          submissionError: e.toString(),
+          submissionError: ApiErrorMessage.fromException(e) ?? e.toString(),
         ),
       );
     }
@@ -290,5 +285,24 @@ class ScheduleFormBloc extends Bloc<ScheduleFormEvent, ScheduleFormState> {
     Emitter<ScheduleFormState> emit,
   ) {
     emit(state.copyWith(isValid: event.isValid));
+  }
+
+  DateTime _initialScheduleTime(DateTime initialDate, DateTime now) {
+    final selectedDate = DateTime(
+      initialDate.year,
+      initialDate.month,
+      initialDate.day,
+    );
+    final today = DateTime(now.year, now.month, now.day);
+    final initialTime = selectedDate == today
+        ? now.add(const Duration(minutes: 1))
+        : now;
+    return DateTime(
+      initialDate.year,
+      initialDate.month,
+      initialDate.day,
+      initialTime.hour,
+      initialTime.minute,
+    );
   }
 }

--- a/lib/presentation/schedule_create/components/schedule_multi_page_form.dart
+++ b/lib/presentation/schedule_create/components/schedule_multi_page_form.dart
@@ -57,7 +57,11 @@ class _ScheduleMultiPageFormState extends State<ScheduleMultiPageForm>
         } else if (state.submissionStatus ==
             ScheduleFormSubmissionStatus.failure) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text(AppLocalizations.of(context)!.error)),
+            SnackBar(
+              content: Text(
+                state.submissionError ?? AppLocalizations.of(context)!.error,
+              ),
+            ),
           );
         }
       },
@@ -107,12 +111,13 @@ class _ScheduleMultiPageFormState extends State<ScheduleMultiPageForm>
                       TopBar(
                         onNextPageButtonClicked:
                             (state.isValid && !isSubmitting)
-                                ? () => _onNextPageButtonClicked(context)
-                                : null,
+                            ? () => _onNextPageButtonClicked(context)
+                            : null,
                         // 버튼 활성화 판별
                         isNextButtonEnabled: state.isValid && !isSubmitting,
-                        onPreviousPageButtonClicked:
-                            isSubmitting ? null : _onPreviousPageButtonClicked,
+                        onPreviousPageButtonClicked: isSubmitting
+                            ? null
+                            : _onPreviousPageButtonClicked,
                       ),
                       SizedBox(height: 26),
                       StepProgress(
@@ -157,8 +162,9 @@ class _ScheduleMultiPageFormState extends State<ScheduleMultiPageForm>
         });
         break;
       case const (ScheduleDateTimeCubit):
-        final didSubmit =
-            context.read<ScheduleDateTimeCubit>().scheduleDateTimeSubmitted();
+        final didSubmit = context
+            .read<ScheduleDateTimeCubit>()
+            .scheduleDateTimeSubmitted();
         if (!didSubmit) {
           return;
         }

--- a/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_state.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_state.dart
@@ -20,7 +20,32 @@ class ScheduleDateTimeState extends Equatable {
   final String? previousScheduleName;
 
   bool get isValid =>
-      Formz.validate([scheduleDate, scheduleTime]) && !isOverlapping;
+      Formz.validate([scheduleDate, scheduleTime]) &&
+      !isOverlapping &&
+      !isPastScheduleTime;
+
+  DateTime? get selectedScheduleDateTime {
+    if (scheduleDate.value == null || scheduleTime.value == null) {
+      return null;
+    }
+    final selectedDate = scheduleDate.value!;
+    final selectedTime = scheduleTime.value!;
+    return DateTime(
+      selectedDate.year,
+      selectedDate.month,
+      selectedDate.day,
+      selectedTime.hour,
+      selectedTime.minute,
+    );
+  }
+
+  bool get isPastScheduleTime {
+    final selectedDateTime = selectedScheduleDateTime;
+    if (selectedDateTime == null) {
+      return false;
+    }
+    return selectedDateTime.isBefore(DateTime.now());
+  }
 
   /// Returns true if there's an overlap warning or error to display (for next schedule)
   bool get hasOverlapMessage => isOverlapping;
@@ -35,6 +60,8 @@ class ScheduleDateTimeState extends Equatable {
   /// Returns true if there's any overlap message to display
   bool get hasAnyOverlapMessage =>
       hasOverlapMessage || hasPreviousOverlapMessage;
+
+  bool get hasPastScheduleTimeMessage => isPastScheduleTime;
 
   /// Returns the overlap message for next schedule based on whether it's an error or warning
   /// Requires BuildContext for localization
@@ -65,6 +92,11 @@ class ScheduleDateTimeState extends Equatable {
     return localizations.scheduleOverlapWarning(minutes, scheduleName);
   }
 
+  String? getPastScheduleTimeMessage(BuildContext context) {
+    if (!isPastScheduleTime) return null;
+    return AppLocalizations.of(context)!.scheduleTimePastError;
+  }
+
   ScheduleDateTimeState copyWith({
     ScheduleDateInputModel? scheduleDate,
     ScheduleTimeInputModel? scheduleTime,
@@ -79,10 +111,12 @@ class ScheduleDateTimeState extends Equatable {
     return ScheduleDateTimeState(
       scheduleDate: scheduleDate ?? this.scheduleDate,
       scheduleTime: scheduleTime ?? this.scheduleTime,
-      isOverlapping:
-          clearOverlap ? false : (isOverlapping ?? this.isOverlapping),
-      nextScheduleName:
-          clearOverlap ? null : (nextScheduleName ?? this.nextScheduleName),
+      isOverlapping: clearOverlap
+          ? false
+          : (isOverlapping ?? this.isOverlapping),
+      nextScheduleName: clearOverlap
+          ? null
+          : (nextScheduleName ?? this.nextScheduleName),
       nextPreparationStartTime: clearOverlap
           ? null
           : (nextPreparationStartTime ?? this.nextPreparationStartTime),
@@ -104,12 +138,12 @@ class ScheduleDateTimeState extends Equatable {
 
   @override
   List<Object> get props => [
-        scheduleDate,
-        scheduleTime,
-        isOverlapping,
-        nextScheduleName ?? '',
-        nextPreparationStartTime ?? DateTime(0),
-        previousOverlapDuration ?? const Duration(),
-        previousScheduleName ?? '',
-      ];
+    scheduleDate,
+    scheduleTime,
+    isOverlapping,
+    nextScheduleName ?? '',
+    nextPreparationStartTime ?? DateTime(0),
+    previousOverlapDuration ?? const Duration(),
+    previousScheduleName ?? '',
+  ];
 }

--- a/lib/presentation/schedule_create/schedule_date_time/screens/schedule_date_time_form.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/screens/schedule_date_time_form.dart
@@ -10,120 +10,133 @@ import 'package:on_time_front/presentation/schedule_create/components/message_bu
 //TODO: Format DateTime string
 //TODO: Extract Text Field widget
 class ScheduleDateTimeForm extends StatelessWidget {
-  const ScheduleDateTimeForm({
-    super.key,
-  });
+  const ScheduleDateTimeForm({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final hintStyle = Theme.of(context).inputDecorationTheme.hintStyle ??
+    final hintStyle =
+        Theme.of(context).inputDecorationTheme.hintStyle ??
         Theme.of(context).textTheme.bodyLarge;
     final fadedHintStyle = hintStyle?.copyWith(
-      color: (hintStyle.color ?? Theme.of(context).hintColor)
-          .withValues(alpha: 0.45),
+      color: (hintStyle.color ?? Theme.of(context).hintColor).withValues(
+        alpha: 0.45,
+      ),
     );
 
     return BlocBuilder<ScheduleDateTimeCubit, ScheduleDateTimeState>(
-        builder: (context, state) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                flex: 2,
-                child: TextField(
-                  readOnly: true,
-                  decoration: InputDecoration(
-                    labelText: AppLocalizations.of(context)!.appointmentTime,
-                    hintText: _localizedDateString(context, DateTime.now()),
-                    hintStyle: fadedHintStyle,
-                  ),
-                  controller: TextEditingController(
+      builder: (context, state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: TextField(
+                    readOnly: true,
+                    decoration: InputDecoration(
+                      labelText: AppLocalizations.of(context)!.appointmentTime,
+                      hintText: _localizedDateString(context, DateTime.now()),
+                      hintStyle: fadedHintStyle,
+                    ),
+                    controller: TextEditingController(
                       text: state.scheduleDate.value == null
                           ? null
                           : _localizedDateString(
-                              context, state.scheduleDate.value!)),
-                  onTap: () {
-                    context.showCupertinoDatePickerModal(
-                      title: AppLocalizations.of(context)!.enterDate,
-                      mode: CupertinoDatePickerMode.date,
-                      initialValue: state.scheduleDate.value ?? DateTime.now(),
-                      onDisposed: () {
-                        context
-                            .read<ScheduleDateTimeCubit>()
-                            .validateCurrentSelection();
-                      },
-                      onSaved: (DateTime newDateTime) {
-                        context
-                            .read<ScheduleDateTimeCubit>()
-                            .scheduleDateChanged(newDateTime);
-                      },
-                    );
-                  },
+                              context,
+                              state.scheduleDate.value!,
+                            ),
+                    ),
+                    onTap: () {
+                      context.showCupertinoDatePickerModal(
+                        title: AppLocalizations.of(context)!.enterDate,
+                        mode: CupertinoDatePickerMode.date,
+                        initialValue:
+                            state.scheduleDate.value ?? DateTime.now(),
+                        onDisposed: () {
+                          context
+                              .read<ScheduleDateTimeCubit>()
+                              .validateCurrentSelection();
+                        },
+                        onSaved: (DateTime newDateTime) {
+                          context
+                              .read<ScheduleDateTimeCubit>()
+                              .scheduleDateChanged(newDateTime);
+                        },
+                      );
+                    },
+                  ),
                 ),
-              ),
-              SizedBox(
-                width: 30,
-              ),
-              Expanded(
-                flex: 1,
-                child: TextField(
-                  readOnly: true,
-                  decoration: InputDecoration(
+                SizedBox(width: 30),
+                Expanded(
+                  flex: 1,
+                  child: TextField(
+                    readOnly: true,
+                    decoration: InputDecoration(
                       labelText: '',
                       hintText: DateFormat.jm(
-                              Localizations.localeOf(context).toString())
-                          .format(DateTime.now()),
-                      hintStyle: fadedHintStyle),
-                  controller: TextEditingController(
-                    text: state.scheduleTime.value == null
-                        ? null
-                        : DateFormat.jm(
-                                Localizations.localeOf(context).toString())
-                            .format(state.scheduleTime.value!),
+                        Localizations.localeOf(context).toString(),
+                      ).format(DateTime.now()),
+                      hintStyle: fadedHintStyle,
+                    ),
+                    controller: TextEditingController(
+                      text: state.scheduleTime.value == null
+                          ? null
+                          : DateFormat.jm(
+                              Localizations.localeOf(context).toString(),
+                            ).format(state.scheduleTime.value!),
+                    ),
+                    onTap: () {
+                      context.showCupertinoDatePickerModal(
+                        title: AppLocalizations.of(context)!.enterTime,
+                        mode: CupertinoDatePickerMode.time,
+                        initialValue:
+                            state.scheduleTime.value ?? DateTime.now(),
+                        onDisposed: () {
+                          context
+                              .read<ScheduleDateTimeCubit>()
+                              .validateCurrentSelection();
+                        },
+                        onSaved: (DateTime newDateTime) {
+                          context
+                              .read<ScheduleDateTimeCubit>()
+                              .scheduleTimeChanged(newDateTime);
+                        },
+                      );
+                    },
                   ),
-                  onTap: () {
-                    context.showCupertinoDatePickerModal(
-                      title: AppLocalizations.of(context)!.enterTime,
-                      mode: CupertinoDatePickerMode.time,
-                      initialValue: state.scheduleTime.value ?? DateTime.now(),
-                      onDisposed: () {
-                        context
-                            .read<ScheduleDateTimeCubit>()
-                            .validateCurrentSelection();
-                      },
-                      onSaved: (DateTime newDateTime) {
-                        context
-                            .read<ScheduleDateTimeCubit>()
-                            .scheduleTimeChanged(newDateTime);
-                      },
-                    );
-                  },
+                ),
+              ],
+            ),
+            if (state.hasPreviousOverlapMessage)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0, left: 16.0),
+                child: MessageBubble(
+                  message: state.getPreviousOverlapMessage(context)!,
+                  type: MessageBubbleType.warning,
                 ),
               ),
-            ],
-          ),
-          if (state.hasPreviousOverlapMessage)
-            Padding(
-              padding: const EdgeInsets.only(top: 8.0, left: 16.0),
-              child: MessageBubble(
-                message: state.getPreviousOverlapMessage(context)!,
-                type: MessageBubbleType.warning,
+            if (state.hasPastScheduleTimeMessage)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0, left: 16.0),
+                child: MessageBubble(
+                  message: state.getPastScheduleTimeMessage(context)!,
+                  type: MessageBubbleType.error,
+                ),
               ),
-            ),
-          if (state.isOverlapping)
-            Padding(
-              padding: const EdgeInsets.only(top: 8.0, left: 16.0),
-              child: MessageBubble(
-                message: state.getOverlapMessage(context)!,
-                type: MessageBubbleType.error,
+            if (state.isOverlapping)
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0, left: 16.0),
+                child: MessageBubble(
+                  message: state.getOverlapMessage(context)!,
+                  type: MessageBubbleType.error,
+                ),
               ),
-            ),
-        ],
-      );
-    });
+          ],
+        );
+      },
+    );
   }
 }
 
@@ -132,7 +145,9 @@ String _localizedDateString(BuildContext context, DateTime date) {
   if (locale == 'ko') {
     return DateFormat('yyyy년 MM월 dd일', 'ko').format(date);
   } else {
-    return DateFormat('yyyy.MM.dd.', Localizations.localeOf(context).toString())
-        .format(date);
+    return DateFormat(
+      'yyyy.MM.dd.',
+      Localizations.localeOf(context).toString(),
+    ).format(date);
   }
 }

--- a/lib/presentation/schedule_create/schedule_name/input_models/schedule_name_input_model.dart
+++ b/lib/presentation/schedule_create/schedule_name/input_models/schedule_name_input_model.dart
@@ -1,9 +1,8 @@
 import 'package:formz/formz.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 
 /// Validation errors for the [ScheduleNameInputModel] [FormzInput].
-enum ScheduleNameValidationError {
-  empty,
-}
+enum ScheduleNameValidationError { empty, tooLong }
 
 class ScheduleNameInputModel
     extends FormzInput<String, ScheduleNameValidationError> {
@@ -12,6 +11,13 @@ class ScheduleNameInputModel
 
   @override
   ScheduleNameValidationError? validator(String value) {
-    return value.isEmpty ? ScheduleNameValidationError.empty : null;
+    final trimmedValue = value.trim();
+    if (trimmedValue.isEmpty) {
+      return ScheduleNameValidationError.empty;
+    }
+    if (trimmedValue.length > BackendConstraints.maxScheduleNameLength) {
+      return ScheduleNameValidationError.tooLong;
+    }
+    return null;
   }
 }

--- a/lib/presentation/schedule_create/schedule_place_moving_time.dart/input_models/schedule_moving_time_input_model.dart
+++ b/lib/presentation/schedule_create/schedule_place_moving_time.dart/input_models/schedule_moving_time_input_model.dart
@@ -1,19 +1,28 @@
 import 'package:formz/formz.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 
 /// Validation errors for the [ScheduleMovingTimeInputModel] [FormzInput].
-enum ScheduleMovingTimeValidationError {
-  zero,
-}
+enum ScheduleMovingTimeValidationError { zero, negative, tooLarge }
 
 class ScheduleMovingTimeInputModel
     extends FormzInput<Duration, ScheduleMovingTimeValidationError> {
   const ScheduleMovingTimeInputModel.pure([super.value = Duration.zero])
-      : super.pure();
+    : super.pure();
   const ScheduleMovingTimeInputModel.dirty([super.value = Duration.zero])
-      : super.dirty();
+    : super.dirty();
 
   @override
   ScheduleMovingTimeValidationError? validator(Duration value) {
-    return value.inMinutes == 0 ? ScheduleMovingTimeValidationError.zero : null;
+    final minutes = value.inMinutes;
+    if (minutes < 0) {
+      return ScheduleMovingTimeValidationError.negative;
+    }
+    if (minutes == 0) {
+      return ScheduleMovingTimeValidationError.zero;
+    }
+    if (minutes > BackendConstraints.maxMinuteValue) {
+      return ScheduleMovingTimeValidationError.tooLarge;
+    }
+    return null;
   }
 }

--- a/lib/presentation/schedule_create/schedule_spare_and_preparing_time/input_models/schedule_spare_time_input_model.dart
+++ b/lib/presentation/schedule_create/schedule_spare_and_preparing_time/input_models/schedule_spare_time_input_model.dart
@@ -1,10 +1,8 @@
 import 'package:formz/formz.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
 
 /// Validation errors for the [ScheduleMovingTimeInputModel] [FormzInput].
-enum ScheduleSpareTimeValidationError {
-  zero,
-  empty,
-}
+enum ScheduleSpareTimeValidationError { zero, empty, negative, tooLarge }
 
 class ScheduleSpareTimeInputModel
     extends FormzInput<Duration?, ScheduleSpareTimeValidationError> {
@@ -15,8 +13,14 @@ class ScheduleSpareTimeInputModel
   ScheduleSpareTimeValidationError? validator(Duration? value) {
     if (value == null) {
       return ScheduleSpareTimeValidationError.empty;
-    } else if (value.inMinutes == 0) {
+    }
+    final minutes = value.inMinutes;
+    if (minutes < 0) {
+      return ScheduleSpareTimeValidationError.negative;
+    } else if (minutes == 0) {
       return ScheduleSpareTimeValidationError.zero;
+    } else if (minutes > BackendConstraints.maxMinuteValue) {
+      return ScheduleSpareTimeValidationError.tooLarge;
     }
     return null;
   }

--- a/test/core/dio/api_error_message_test.dart
+++ b/test/core/dio/api_error_message_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/dio/api_error_message.dart';
+
+void main() {
+  test('extracts top-level backend validation message', () {
+    final message = ApiErrorMessage.fromResponseData({
+      'status': 'error',
+      'code': 1002,
+      'message': '유효하지 않은 입력값입니다.',
+      'data': {
+        'errors': [
+          {'field': 'email', 'message': '이메일 형식이 올바르지 않습니다.'},
+        ],
+      },
+    });
+
+    expect(message, '유효하지 않은 입력값입니다.');
+  });
+
+  test(
+    'falls back to first field message when top-level message is absent',
+    () {
+      final message = ApiErrorMessage.fromResponseData({
+        'data': {
+          'errors': [
+            {'field': 'email', 'message': '이메일 형식이 올바르지 않습니다.'},
+          ],
+        },
+      });
+
+      expect(message, '이메일 형식이 올바르지 않습니다.');
+    },
+  );
+}

--- a/test/core/validation/backend_constraints_test.dart
+++ b/test/core/validation/backend_constraints_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/validation/backend_constraints.dart';
+
+void main() {
+  group('PasswordPolicy', () {
+    test('accepts 8-64 chars with letter number and special character', () {
+      expect(PasswordPolicy.validate('Password1!'), isNull);
+      expect(PasswordPolicy.validate('A1!aaaaa'), isNull);
+      expect(PasswordPolicy.validate('${'A' * 62}1!'), isNull);
+    });
+
+    test('rejects passwords outside backend policy', () {
+      expect(PasswordPolicy.validate('A1!aaaa'), PasswordPolicyError.tooShort);
+      expect(
+        PasswordPolicy.validate('${'A' * 63}1!'),
+        PasswordPolicyError.tooLong,
+      );
+      expect(
+        PasswordPolicy.validate('12345678!'),
+        PasswordPolicyError.missingLetter,
+      );
+      expect(
+        PasswordPolicy.validate('Password!'),
+        PasswordPolicyError.missingNumber,
+      );
+      expect(
+        PasswordPolicy.validate('Password1'),
+        PasswordPolicyError.missingSpecialCharacter,
+      );
+    });
+  });
+
+  test('device ID pattern matches backend contract', () {
+    expect(
+      BackendConstraints.deviceIdPattern.hasMatch(
+        '550e8400-e29b-41d4-a716-446655440000',
+      ),
+      isTrue,
+    );
+    expect(BackendConstraints.deviceIdPattern.hasMatch('device-1'), isFalse);
+    expect(
+      BackendConstraints.deviceIdPattern.hasMatch('invalid device id'),
+      isFalse,
+    );
+  });
+}

--- a/test/presentation/schedule_create/bloc/schedule_form_bloc_test.dart
+++ b/test/presentation/schedule_create/bloc/schedule_form_bloc_test.dart
@@ -78,7 +78,7 @@ class StubCreateCustomPreparationUseCase
   StubCreateCustomPreparationUseCase(this.handler);
 
   final Future<void> Function(PreparationEntity preparation, String scheduleId)
-      handler;
+  handler;
 
   @override
   Future<void> call(PreparationEntity preparationEntity, String scheduleId) {
@@ -100,7 +100,7 @@ class StubUpdatePreparationByScheduleIdUseCase
   StubUpdatePreparationByScheduleIdUseCase(this.handler);
 
   final Future<void> Function(PreparationEntity preparation, String scheduleId)
-      handler;
+  handler;
 
   @override
   Future<void> call(PreparationEntity preparationEntity, String scheduleId) {
@@ -110,7 +110,7 @@ class StubUpdatePreparationByScheduleIdUseCase
 
 void main() {
   late StubLoadPreparationByScheduleIdUseCase
-      loadPreparationByScheduleIdUseCase;
+  loadPreparationByScheduleIdUseCase;
   late StubGetPreparationByScheduleIdUseCase getPreparationByScheduleIdUseCase;
   late StubGetDefaultPreparationUseCase getDefaultPreparationUseCase;
   late StubGetScheduleByIdUseCase getScheduleByIdUseCase;
@@ -118,7 +118,7 @@ void main() {
   late StubCreateCustomPreparationUseCase createCustomPreparationUseCase;
   late StubUpdateScheduleUseCase updateScheduleUseCase;
   late StubUpdatePreparationByScheduleIdUseCase
-      updatePreparationByScheduleIdUseCase;
+  updatePreparationByScheduleIdUseCase;
   late StubAuthBloc authBloc;
 
   final preparation = PreparationEntity(
@@ -135,7 +135,7 @@ void main() {
     id: 'schedule-1',
     place: PlaceEntity(id: 'place-1', placeName: 'Office'),
     scheduleName: 'Meeting',
-    scheduleTime: DateTime(2026, 3, 20, 9, 0),
+    scheduleTime: DateTime(2027, 3, 20, 9, 0),
     moveTime: const Duration(minutes: 30),
     isChanged: false,
     isStarted: false,
@@ -158,17 +158,22 @@ void main() {
   }
 
   setUp(() {
-    loadPreparationByScheduleIdUseCase =
-        StubLoadPreparationByScheduleIdUseCase((_) async {});
-    getPreparationByScheduleIdUseCase =
-        StubGetPreparationByScheduleIdUseCase((_) async => preparation);
-    getDefaultPreparationUseCase =
-        StubGetDefaultPreparationUseCase(() async => preparation);
+    loadPreparationByScheduleIdUseCase = StubLoadPreparationByScheduleIdUseCase(
+      (_) async {},
+    );
+    getPreparationByScheduleIdUseCase = StubGetPreparationByScheduleIdUseCase(
+      (_) async => preparation,
+    );
+    getDefaultPreparationUseCase = StubGetDefaultPreparationUseCase(
+      () async => preparation,
+    );
     getScheduleByIdUseCase = StubGetScheduleByIdUseCase((_) async => schedule);
-    createScheduleWithPlaceUseCase =
-        StubCreateScheduleWithPlaceUseCase((_) async {});
-    createCustomPreparationUseCase =
-        StubCreateCustomPreparationUseCase((_, __) async {});
+    createScheduleWithPlaceUseCase = StubCreateScheduleWithPlaceUseCase(
+      (_) async {},
+    );
+    createCustomPreparationUseCase = StubCreateCustomPreparationUseCase(
+      (_, __) async {},
+    );
     updateScheduleUseCase = StubUpdateScheduleUseCase((_) async {});
     updatePreparationByScheduleIdUseCase =
         StubUpdatePreparationByScheduleIdUseCase((_, __) async {});
@@ -219,63 +224,64 @@ void main() {
     );
   });
 
-  test('ScheduleFormUpdated sends edited schedule fields to update use case',
-      () async {
-    ScheduleEntity? updatedSchedule;
-    updateScheduleUseCase = StubUpdateScheduleUseCase((schedule) async {
-      updatedSchedule = schedule;
-    });
+  test(
+    'ScheduleFormUpdated sends edited schedule fields to update use case',
+    () async {
+      ScheduleEntity? updatedSchedule;
+      updateScheduleUseCase = StubUpdateScheduleUseCase((schedule) async {
+        updatedSchedule = schedule;
+      });
 
-    final bloc = buildBloc();
-    addTearDown(bloc.close);
+      final bloc = buildBloc();
+      addTearDown(bloc.close);
 
-    final editReady = bloc.stream.firstWhere(
-      (state) => state.status == ScheduleFormStatus.success,
-    );
-    bloc.add(const ScheduleFormEditRequested(scheduleId: 'schedule-1'));
-    await editReady;
+      final editReady = bloc.stream.firstWhere(
+        (state) => state.status == ScheduleFormStatus.success,
+      );
+      bloc.add(const ScheduleFormEditRequested(scheduleId: 'schedule-1'));
+      await editReady;
 
-    bloc.add(
-      const ScheduleFormScheduleNameChanged(scheduleName: 'Edited Meeting'),
-    );
-    bloc.add(
-      ScheduleFormScheduleDateTimeChanged(
-        scheduleDate: DateTime(2026, 3, 21),
-        scheduleTime: DateTime(2026, 3, 21, 10, 30),
-      ),
-    );
-    bloc.add(const ScheduleFormPlaceNameChanged(placeName: 'New Office'));
-    bloc.add(
-      const ScheduleFormMoveTimeChanged(moveTime: Duration(minutes: 45)),
-    );
-    bloc.add(
-      const ScheduleFormScheduleSpareTimeChanged(
-        scheduleSpareTime: Duration(minutes: 25),
-      ),
-    );
+      bloc.add(
+        const ScheduleFormScheduleNameChanged(scheduleName: 'Edited Meeting'),
+      );
+      bloc.add(
+        ScheduleFormScheduleDateTimeChanged(
+          scheduleDate: DateTime(2027, 3, 21),
+          scheduleTime: DateTime(2027, 3, 21, 10, 30),
+        ),
+      );
+      bloc.add(const ScheduleFormPlaceNameChanged(placeName: 'New Office'));
+      bloc.add(
+        const ScheduleFormMoveTimeChanged(moveTime: Duration(minutes: 45)),
+      );
+      bloc.add(
+        const ScheduleFormScheduleSpareTimeChanged(
+          scheduleSpareTime: Duration(minutes: 25),
+        ),
+      );
 
-    final submitDone = bloc.stream.firstWhere(
-      (state) => state.submissionStatus == ScheduleFormSubmissionStatus.success,
-    );
-    bloc.add(const ScheduleFormUpdated());
-    await submitDone;
+      final submitDone = bloc.stream.firstWhere(
+        (state) =>
+            state.submissionStatus == ScheduleFormSubmissionStatus.success,
+      );
+      bloc.add(const ScheduleFormUpdated());
+      await submitDone;
 
-    expect(updatedSchedule, isNotNull);
-    expect(updatedSchedule!.id, 'schedule-1');
-    expect(updatedSchedule!.place.id, 'place-1');
-    expect(updatedSchedule!.place.placeName, 'New Office');
-    expect(updatedSchedule!.scheduleName, 'Edited Meeting');
-    expect(updatedSchedule!.scheduleTime, DateTime(2026, 3, 21, 10, 30));
-    expect(updatedSchedule!.moveTime, const Duration(minutes: 45));
-    expect(
-      updatedSchedule!.scheduleSpareTime,
-      const Duration(minutes: 25),
-    );
-  });
+      expect(updatedSchedule, isNotNull);
+      expect(updatedSchedule!.id, 'schedule-1');
+      expect(updatedSchedule!.place.id, 'place-1');
+      expect(updatedSchedule!.place.placeName, 'New Office');
+      expect(updatedSchedule!.scheduleName, 'Edited Meeting');
+      expect(updatedSchedule!.scheduleTime, DateTime(2027, 3, 21, 10, 30));
+      expect(updatedSchedule!.moveTime, const Duration(minutes: 45));
+      expect(updatedSchedule!.scheduleSpareTime, const Duration(minutes: 25));
+    },
+  );
 
   test('ScheduleFormUpdated emits submitting then failure on error', () async {
-    updateScheduleUseCase =
-        StubUpdateScheduleUseCase((_) => Future.error(Exception('update')));
+    updateScheduleUseCase = StubUpdateScheduleUseCase(
+      (_) => Future.error(Exception('update')),
+    );
 
     final bloc = buildBloc();
     addTearDown(bloc.close);
@@ -326,8 +332,8 @@ void main() {
     bloc.add(const ScheduleFormScheduleNameChanged(scheduleName: 'Meeting'));
     bloc.add(
       ScheduleFormScheduleDateTimeChanged(
-        scheduleDate: DateTime(2026, 3, 20),
-        scheduleTime: DateTime(2026, 3, 20, 9, 0),
+        scheduleDate: DateTime(2027, 3, 20),
+        scheduleTime: DateTime(2027, 3, 20, 9, 0),
       ),
     );
     bloc.add(const ScheduleFormPlaceNameChanged(placeName: 'Office'));
@@ -356,8 +362,9 @@ void main() {
   });
 
   test('ScheduleFormCreated emits submitting then failure on error', () async {
-    createScheduleWithPlaceUseCase =
-        StubCreateScheduleWithPlaceUseCase((_) => Future.error(Exception()));
+    createScheduleWithPlaceUseCase = StubCreateScheduleWithPlaceUseCase(
+      (_) => Future.error(Exception()),
+    );
 
     final bloc = buildBloc();
     addTearDown(bloc.close);
@@ -377,8 +384,8 @@ void main() {
     bloc.add(const ScheduleFormScheduleNameChanged(scheduleName: 'Meeting'));
     bloc.add(
       ScheduleFormScheduleDateTimeChanged(
-        scheduleDate: DateTime(2026, 3, 20),
-        scheduleTime: DateTime(2026, 3, 20, 9, 0),
+        scheduleDate: DateTime(2027, 3, 20),
+        scheduleTime: DateTime(2027, 3, 20, 9, 0),
       ),
     );
     bloc.add(const ScheduleFormPlaceNameChanged(placeName: 'Office'));

--- a/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
+++ b/test/presentation/schedule_create/components/schedule_multi_page_form_test.dart
@@ -92,7 +92,7 @@ class StubCreateCustomPreparationUseCase
   StubCreateCustomPreparationUseCase(this.handler);
 
   final Future<void> Function(PreparationEntity preparation, String scheduleId)
-      handler;
+  handler;
 
   @override
   Future<void> call(PreparationEntity preparationEntity, String scheduleId) {
@@ -114,7 +114,7 @@ class StubUpdatePreparationByScheduleIdUseCase
   StubUpdatePreparationByScheduleIdUseCase(this.handler);
 
   final Future<void> Function(PreparationEntity preparation, String scheduleId)
-      handler;
+  handler;
 
   @override
   Future<void> call(PreparationEntity preparationEntity, String scheduleId) {
@@ -129,7 +129,8 @@ class StubLoadAdjacentScheduleWithPreparationUseCase
   final Future<void> Function({
     required DateTime startDate,
     required DateTime endDate,
-  }) handler;
+  })
+  handler;
 
   @override
   Future<void> call({required DateTime startDate, required DateTime endDate}) {
@@ -146,7 +147,8 @@ class StubGetAdjacentSchedulesWithPreparationUseCase
     String? currentScheduleId,
     required DateTime startDate,
     required DateTime endDate,
-  }) handler;
+  })
+  handler;
 
   @override
   Future<AdjacentSchedulesWithPreparationEntity> call({
@@ -166,7 +168,7 @@ class StubGetAdjacentSchedulesWithPreparationUseCase
 
 void main() {
   late StubLoadPreparationByScheduleIdUseCase
-      loadPreparationByScheduleIdUseCase;
+  loadPreparationByScheduleIdUseCase;
   late StubGetPreparationByScheduleIdUseCase getPreparationByScheduleIdUseCase;
   late StubGetDefaultPreparationUseCase getDefaultPreparationUseCase;
   late StubGetScheduleByIdUseCase getScheduleByIdUseCase;
@@ -174,13 +176,13 @@ void main() {
   late StubCreateCustomPreparationUseCase createCustomPreparationUseCase;
   late StubUpdateScheduleUseCase updateScheduleUseCase;
   late StubUpdatePreparationByScheduleIdUseCase
-      updatePreparationByScheduleIdUseCase;
+  updatePreparationByScheduleIdUseCase;
   late StubAuthBloc authBloc;
 
   late StubLoadAdjacentScheduleWithPreparationUseCase
-      loadAdjacentScheduleWithPreparationUseCase;
+  loadAdjacentScheduleWithPreparationUseCase;
   late StubGetAdjacentSchedulesWithPreparationUseCase
-      getAdjacentSchedulesWithPreparationUseCase;
+  getAdjacentSchedulesWithPreparationUseCase;
 
   final preparation = PreparationEntity(
     preparationStepList: const [
@@ -196,7 +198,7 @@ void main() {
     id: 'schedule-1',
     place: PlaceEntity(id: 'place-1', placeName: 'Office'),
     scheduleName: 'Meeting',
-    scheduleTime: DateTime(2026, 3, 20, 9, 0),
+    scheduleTime: DateTime(2027, 3, 20, 9, 0),
     moveTime: const Duration(minutes: 30),
     isChanged: false,
     isStarted: false,
@@ -271,9 +273,9 @@ void main() {
 
   Future<void> goToFinalStepAndSubmit(WidgetTester tester) async {
     Finder nextButton() => find.descendant(
-          of: find.byType(TopBar),
-          matching: find.byType(TextButton),
-        );
+      of: find.byType(TopBar),
+      matching: find.byType(TextButton),
+    );
 
     await tester.tap(nextButton());
     await tester.pumpAndSettle();
@@ -289,36 +291,40 @@ void main() {
   }
 
   setUp(() {
-    loadPreparationByScheduleIdUseCase =
-        StubLoadPreparationByScheduleIdUseCase((_) async {});
-    getPreparationByScheduleIdUseCase =
-        StubGetPreparationByScheduleIdUseCase((_) async => preparation);
-    getDefaultPreparationUseCase =
-        StubGetDefaultPreparationUseCase(() async => preparation);
+    loadPreparationByScheduleIdUseCase = StubLoadPreparationByScheduleIdUseCase(
+      (_) async {},
+    );
+    getPreparationByScheduleIdUseCase = StubGetPreparationByScheduleIdUseCase(
+      (_) async => preparation,
+    );
+    getDefaultPreparationUseCase = StubGetDefaultPreparationUseCase(
+      () async => preparation,
+    );
     getScheduleByIdUseCase = StubGetScheduleByIdUseCase((_) async => schedule);
-    createScheduleWithPlaceUseCase =
-        StubCreateScheduleWithPlaceUseCase((_) async {});
-    createCustomPreparationUseCase =
-        StubCreateCustomPreparationUseCase((_, __) async {});
+    createScheduleWithPlaceUseCase = StubCreateScheduleWithPlaceUseCase(
+      (_) async {},
+    );
+    createCustomPreparationUseCase = StubCreateCustomPreparationUseCase(
+      (_, __) async {},
+    );
     updateScheduleUseCase = StubUpdateScheduleUseCase((_) async {});
     updatePreparationByScheduleIdUseCase =
         StubUpdatePreparationByScheduleIdUseCase((_, __) async {});
 
     loadAdjacentScheduleWithPreparationUseCase =
         StubLoadAdjacentScheduleWithPreparationUseCase(
-      ({required startDate, required endDate}) async {},
-    );
+          ({required startDate, required endDate}) async {},
+        );
 
     getAdjacentSchedulesWithPreparationUseCase =
         StubGetAdjacentSchedulesWithPreparationUseCase(
-      ({
-        required selectedDateTime,
-        String? currentScheduleId,
-        required startDate,
-        required endDate,
-      }) async =>
-          const AdjacentSchedulesWithPreparationEntity(),
-    );
+          ({
+            required selectedDateTime,
+            String? currentScheduleId,
+            required startDate,
+            required endDate,
+          }) async => const AdjacentSchedulesWithPreparationEntity(),
+        );
 
     authBloc = StubAuthBloc(
       AuthState(
@@ -340,36 +346,38 @@ void main() {
 
     getIt
         .registerFactoryParam<ScheduleDateTimeCubit, ScheduleFormBloc, dynamic>(
-      (scheduleFormBloc, _) => ScheduleDateTimeCubit(
-        scheduleFormBloc,
-        loadAdjacentScheduleWithPreparationUseCase,
-        getAdjacentSchedulesWithPreparationUseCase,
-      ),
-    );
+          (scheduleFormBloc, _) => ScheduleDateTimeCubit(
+            scheduleFormBloc,
+            loadAdjacentScheduleWithPreparationUseCase,
+            getAdjacentSchedulesWithPreparationUseCase,
+          ),
+        );
   });
 
   tearDown(() async {
     await getIt.reset();
   });
 
-  testWidgets('final submit does not close sheet immediately while submitting',
-      (tester) async {
-    final submitCompleter = Completer<void>();
-    updateScheduleUseCase.handler = (_) => submitCompleter.future;
+  testWidgets(
+    'final submit does not close sheet immediately while submitting',
+    (tester) async {
+      final submitCompleter = Completer<void>();
+      updateScheduleUseCase.handler = (_) => submitCompleter.future;
 
-    final bloc = buildBloc();
-    addTearDown(bloc.close);
+      final bloc = buildBloc();
+      addTearDown(bloc.close);
 
-    await primeEditState(bloc);
-    await pumpSheet(tester, bloc);
+      await primeEditState(bloc);
+      await pumpSheet(tester, bloc);
 
-    await goToFinalStepAndSubmit(tester);
+      await goToFinalStepAndSubmit(tester);
 
-    expect(find.byType(ScheduleMultiPageForm), findsOneWidget);
+      expect(find.byType(ScheduleMultiPageForm), findsOneWidget);
 
-    submitCompleter.complete();
-    await tester.pumpAndSettle();
-  });
+      submitCompleter.complete();
+      await tester.pumpAndSettle();
+    },
+  );
 
   testWidgets('sheet closes after successful submit', (tester) async {
     final bloc = buildBloc();
@@ -384,8 +392,9 @@ void main() {
     expect(find.byType(ScheduleMultiPageForm), findsNothing);
   });
 
-  testWidgets('sheet stays open and shows error when submit fails',
-      (tester) async {
+  testWidgets('sheet stays open and shows error when submit fails', (
+    tester,
+  ) async {
     updateScheduleUseCase.handler = (_) => Future.error(Exception('update'));
 
     final bloc = buildBloc();
@@ -401,8 +410,9 @@ void main() {
     expect(find.byType(SnackBar), findsOneWidget);
   });
 
-  testWidgets('edited name and place are submitted from form steps',
-      (tester) async {
+  testWidgets('edited name and place are submitted from form steps', (
+    tester,
+  ) async {
     ScheduleEntity? updatedSchedule;
     updateScheduleUseCase.handler = (schedule) async {
       updatedSchedule = schedule;
@@ -415,9 +425,9 @@ void main() {
     await pumpSheet(tester, bloc);
 
     Finder nextButton() => find.descendant(
-          of: find.byType(TopBar),
-          matching: find.byType(TextButton),
-        );
+      of: find.byType(TopBar),
+      matching: find.byType(TextButton),
+    );
 
     await tester.enterText(find.byType(TextFormField).first, 'Edited Meeting');
     await tester.pump();
@@ -443,27 +453,28 @@ void main() {
   testWidgets('date time overlap keeps next disabled', (tester) async {
     getAdjacentSchedulesWithPreparationUseCase =
         StubGetAdjacentSchedulesWithPreparationUseCase(
-      ({
-        required selectedDateTime,
-        String? currentScheduleId,
-        required startDate,
-        required endDate,
-      }) async =>
-          AdjacentSchedulesWithPreparationEntity(
-        nextSchedule: ScheduleWithPreparationEntity(
-          id: 'schedule-2',
-          place: const PlaceEntity(id: 'place-2', placeName: 'Next Office'),
-          scheduleName: 'Next Meeting',
-          scheduleTime: DateTime(2026, 3, 20, 9, 20),
-          moveTime: const Duration(minutes: 10),
-          isChanged: false,
-          isStarted: false,
-          scheduleSpareTime: Duration.zero,
-          scheduleNote: '',
-          preparation: PreparationWithTimeEntity.fromPreparation(preparation),
-        ),
-      ),
-    );
+          ({
+            required selectedDateTime,
+            String? currentScheduleId,
+            required startDate,
+            required endDate,
+          }) async => AdjacentSchedulesWithPreparationEntity(
+            nextSchedule: ScheduleWithPreparationEntity(
+              id: 'schedule-2',
+              place: const PlaceEntity(id: 'place-2', placeName: 'Next Office'),
+              scheduleName: 'Next Meeting',
+              scheduleTime: DateTime(2027, 3, 20, 9, 20),
+              moveTime: const Duration(minutes: 10),
+              isChanged: false,
+              isStarted: false,
+              scheduleSpareTime: Duration.zero,
+              scheduleNote: '',
+              preparation: PreparationWithTimeEntity.fromPreparation(
+                preparation,
+              ),
+            ),
+          ),
+        );
 
     final bloc = buildBloc();
     addTearDown(bloc.close);
@@ -472,9 +483,9 @@ void main() {
     await pumpSheet(tester, bloc);
 
     Finder nextButton() => find.descendant(
-          of: find.byType(TopBar),
-          matching: find.byType(TextButton),
-        );
+      of: find.byType(TopBar),
+      matching: find.byType(TextButton),
+    );
 
     await tester.tap(nextButton());
     await tester.pumpAndSettle();
@@ -483,8 +494,9 @@ void main() {
     expect(button.onPressed, isNull);
   });
 
-  testWidgets('cancelling date and time pickers keeps next disabled',
-      (tester) async {
+  testWidgets('cancelling date and time pickers keeps next disabled', (
+    tester,
+  ) async {
     final bloc = buildBloc();
     addTearDown(bloc.close);
 
@@ -492,9 +504,9 @@ void main() {
     await pumpSheet(tester, bloc);
 
     Finder nextButton() => find.descendant(
-          of: find.byType(TopBar),
-          matching: find.byType(TextButton),
-        );
+      of: find.byType(TopBar),
+      matching: find.byType(TextButton),
+    );
 
     await tester.enterText(find.byType(TextFormField).first, 'Meeting');
     await tester.pump();

--- a/test/presentation/schedule_create/input_models/backend_validation_input_models_test.dart
+++ b/test/presentation/schedule_create/input_models/backend_validation_input_models_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/presentation/onboarding/preparation_time/input_models/preparation_time_input_model.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_name/input_models/schedule_name_input_model.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_place_moving_time.dart/input_models/schedule_moving_time_input_model.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_spare_and_preparing_time/input_models/schedule_spare_time_input_model.dart';
+
+void main() {
+  test('schedule name rejects blank and values over 30 chars', () {
+    expect(
+      const ScheduleNameInputModel.dirty('   ').error,
+      ScheduleNameValidationError.empty,
+    );
+    expect(
+      ScheduleNameInputModel.dirty('a' * 31).error,
+      ScheduleNameValidationError.tooLong,
+    );
+    expect(ScheduleNameInputModel.dirty('a' * 30).isValid, isTrue);
+  });
+
+  test('moving time rejects negative, zero, and over 1440 minutes', () {
+    expect(
+      const ScheduleMovingTimeInputModel.dirty(Duration(minutes: -1)).error,
+      ScheduleMovingTimeValidationError.negative,
+    );
+    expect(
+      const ScheduleMovingTimeInputModel.dirty(Duration.zero).error,
+      ScheduleMovingTimeValidationError.zero,
+    );
+    expect(
+      const ScheduleMovingTimeInputModel.dirty(Duration(minutes: 1441)).error,
+      ScheduleMovingTimeValidationError.tooLarge,
+    );
+    expect(
+      const ScheduleMovingTimeInputModel.dirty(Duration(minutes: 1440)).isValid,
+      isTrue,
+    );
+  });
+
+  test('spare time rejects negative, zero, empty, and over 1440 minutes', () {
+    expect(
+      const ScheduleSpareTimeInputModel.dirty().error,
+      ScheduleSpareTimeValidationError.empty,
+    );
+    expect(
+      const ScheduleSpareTimeInputModel.dirty(Duration(minutes: -1)).error,
+      ScheduleSpareTimeValidationError.negative,
+    );
+    expect(
+      const ScheduleSpareTimeInputModel.dirty(Duration.zero).error,
+      ScheduleSpareTimeValidationError.zero,
+    );
+    expect(
+      const ScheduleSpareTimeInputModel.dirty(Duration(minutes: 1441)).error,
+      ScheduleSpareTimeValidationError.tooLarge,
+    );
+  });
+
+  test('preparation time rejects negative, zero, and over 1440 minutes', () {
+    expect(
+      const PreparationTimeInputModel.dirty(Duration(minutes: -1)).error,
+      PreparationTimeValidationError.negative,
+    );
+    expect(
+      const PreparationTimeInputModel.dirty(Duration.zero).error,
+      PreparationTimeValidationError.zero,
+    );
+    expect(
+      const PreparationTimeInputModel.dirty(Duration(minutes: 1441)).error,
+      PreparationTimeValidationError.tooLarge,
+    );
+  });
+}

--- a/test/presentation/schedule_create/schedule_date_time/schedule_date_time_state_test.dart
+++ b/test/presentation/schedule_create/schedule_date_time/schedule_date_time_state_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_date_time/cubit/schedule_date_time_cubit.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model.dart';
+
+void main() {
+  test('rejects selected schedule time in the past', () {
+    final past = DateTime.now().subtract(const Duration(minutes: 5));
+    final state = ScheduleDateTimeState(
+      scheduleDate: ScheduleDateInputModel.dirty(past),
+      scheduleTime: ScheduleTimeInputModel.dirty(past),
+    );
+
+    expect(state.isPastScheduleTime, isTrue);
+    expect(state.isValid, isFalse);
+  });
+
+  test('accepts selected schedule time in the future', () {
+    final future = DateTime.now().add(const Duration(days: 1));
+    final state = ScheduleDateTimeState(
+      scheduleDate: ScheduleDateInputModel.dirty(future),
+      scheduleTime: ScheduleTimeInputModel.dirty(future),
+    );
+
+    expect(state.isPastScheduleTime, isFalse);
+    expect(state.isValid, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add shared backend validation constraints and stricter schedule/preparation form validation
- reject past schedule times and surface localized validation messages
- parse the new backend validation error envelope for schedule form failures
- cap long feedback/note fields and regenerate invalid alarm device IDs

## Tests
- flutter analyze
- flutter test