### PR TITLE
docs: audit Android manifest permissions

### DIFF
--- a/docs/Android-Manifest-Permissions.md
+++ b/docs/Android-Manifest-Permissions.md
@@ -1,0 +1,71 @@
+# Android Manifest Permission Audit
+
+This audit records the Android manifest permission review for release issue
+#442 under parent track #465.
+
+## Source Manifests Reviewed
+
+- `android/app/src/main/AndroidManifest.xml`
+- `android/app/src/debug/AndroidManifest.xml`
+- `android/app/src/profile/AndroidManifest.xml`
+
+The main manifest is the app-owned release source of truth. Debug and profile
+manifests only add `android.permission.INTERNET` for Flutter tooling and hot
+reload.
+
+## Release Permission Inventory
+
+| Permission | Status | Justification |
+| --- | --- | --- |
+| `android.permission.POST_NOTIFICATIONS` | Keep | Required on Android 13+ for OnTime reminder, preparation-step, and alarm notifications. Native alarm fallback also checks this permission before posting the full-screen alarm notification. |
+| `android.permission.SCHEDULE_EXACT_ALARM` | Keep | Required on Android 12+ for user-scheduled schedule alarms that must fire at the selected time. Native alarm scheduling checks `AlarmManager.canScheduleExactAlarms()` before using `setAlarmClock`. |
+| `android.permission.USE_FULL_SCREEN_INTENT` | Keep | Required for the user-scheduled alarm ringing notification to present `AlarmRingingActivity` as a full-screen alarm experience. Usage is tied to alarm-category notifications, not generic or promotional notifications. |
+| `android.permission.RECEIVE_BOOT_COMPLETED` | Keep | Required for `NativeAlarmBootReceiver` to restore persisted future native alarms after device restart. The receiver is not exported. |
+| `android.permission.VIBRATE` | Keep | Required so alarm and notification channels can use vibration behavior for time-sensitive reminders and alarms. |
+
+No unused app-owned release permission was found during the audit.
+
+## Manifest Merge Notes
+
+Release manifest merge was verified with:
+
+```sh
+ANDROID_KEYSTORE_PATH=$HOME/.android/debug.keystore \
+ANDROID_KEYSTORE_PASSWORD=android \
+ANDROID_KEY_ALIAS=androiddebugkey \
+ANDROID_KEY_PASSWORD=android \
+gradle :app:processReleaseMainManifest -x :app:compileFlutterBuildRelease
+```
+
+The command used ignored local placeholder release config only to allow manifest
+merge without production Firebase and signing secrets.
+
+The merged release manifest contains the app-owned permissions above plus these
+dependency-owned permissions:
+
+| Permission | Source | Justification |
+| --- | --- | --- |
+| `android.permission.INTERNET` | Google Sign-In, Firebase Messaging, AppAuth, and related network dependencies | Required for sign-in, Firebase initialization/messaging, and app network access. |
+| `android.permission.WAKE_LOCK` | `firebase_messaging` / Firebase Messaging | Required by Firebase Messaging background delivery while processing incoming messages. |
+| `android.permission.ACCESS_NETWORK_STATE` | Firebase Messaging / Firebase Installations / Google transport dependencies | Required by Firebase and transport dependencies to check network availability for messaging and token/installation work. |
+| `com.google.android.c2dm.permission.RECEIVE` | Firebase Messaging | Required for receiving FCM push messages. |
+| `android.permission.USE_BIOMETRIC` | AndroidX biometric via Google credential dependencies | Added by AndroidX credential/biometric dependencies used by Google sign-in support. |
+| `android.permission.USE_FINGERPRINT` | AndroidX biometric via Google credential dependencies | Legacy counterpart to `USE_BIOMETRIC` from the same dependency chain. |
+| `club.devkor.ontime.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` | AndroidX core | Signature-level internal permission used by AndroidX for non-exported dynamic receiver protection. |
+
+The merge did not add location, contacts, camera, microphone, phone, SMS,
+storage, calendar, nearby-device, or Bluetooth permissions.
+
+Debug and profile merged manifests may additionally contain their variant-owned
+`android.permission.INTERNET` declaration for Flutter tooling.
+
+## Related Android Components
+
+- `MainActivity` checks exact alarm and notification permission state before
+  scheduling native alarms.
+- `NativeAlarmReceiver` posts alarm-category full-screen notifications and
+  skips posting when notification permission is denied.
+- `NativeAlarmBootReceiver` handles boot completion and exact-alarm permission
+  state changes to restore persisted native alarms.
+- `AlarmRingingActivity` is the full-screen alarm UI launched only from the
+  alarm notification path.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -34,6 +34,9 @@ OnTime.
 - Confirm the application ID is `club.devkor.ontime`.
 - Confirm the app label is `OnTime`.
 - Review launcher icons in `android/app/src/main/res/mipmap-*`.
+- Review `docs/Android-Manifest-Permissions.md` and confirm app-owned release
+  manifest permissions are still limited to user-facing notification, exact
+  alarm, full-screen alarm, boot restore, and vibration behavior.
 - Provide release signing through one of the following secret-free paths:
   - `android/key.properties` with `storeFile`, `storePassword`, `keyAlias`, and
     `keyPassword`.

--- a/plans/issue_442_android_manifest_permissions_plan.md
+++ b/plans/issue_442_android_manifest_permissions_plan.md
@@ -1,0 +1,45 @@
+# Issue 442 Android Manifest Permission Audit Plan
+
+## Scope
+
+Audit Android manifest permissions for release readiness under parent track #465.
+This issue covers only manifest permission inventory, permission justification,
+and merged-manifest verification for Android.
+
+## Files Likely Touched
+
+- `docs/Android-Manifest-Permissions.md`
+- `docs/Release-Checklist.md`
+
+No Android manifest permission removal is planned unless the audit finds an
+unused release permission.
+
+## Implementation Approach
+
+1. Review `android/app/src/main/AndroidManifest.xml` for release permissions.
+2. Review `android/app/src/debug/AndroidManifest.xml` and
+   `android/app/src/profile/AndroidManifest.xml` for variant-only permissions.
+3. Trace each release permission to current native or Flutter behavior.
+4. Document the release permission inventory and justification.
+5. Link the audit from the release checklist.
+6. Run manifest-merge verification and confirm no unexpected sensitive
+   permission is introduced by plugins or manifest merge.
+
+## Verification
+
+- `flutter pub get`
+- Android merged manifest task, then inspect merged permissions.
+- `git diff --check`
+
+## Blockers
+
+None for this issue. A full signed release build may require Firebase and
+signing secrets, but manifest merge can be verified without changing release
+behavior.
+
+## Explicitly Left Out
+
+- Notification permission UX changes for #443.
+- Exact alarm permission UX changes for #444.
+- Play Console full-screen intent declaration submission for #445.
+- Device alarm and notification QA for #457.


### PR DESCRIPTION
## Summary
- Closes #442
- References parent track #465
- Adds an Android manifest permission audit documenting app-owned release permissions and dependency-owned merged permissions.
- Links the audit from the release checklist and records the #442 implementation plan under plans/.

## Verification
- flutter pub get: passed
- gradle :app:processDebugMainManifest: failed before manifest output because generated Dart files are absent in this checkout
- gradle :app:processDebugMainManifest -x :app:compileFlutterBuildDebug: passed
- ANDROID_KEYSTORE_PATH=$HOME/.android/debug.keystore ANDROID_KEYSTORE_PASSWORD=android ANDROID_KEY_ALIAS=androiddebugkey ANDROID_KEY_PASSWORD=android gradle :app:processReleaseMainManifest -x :app:compileFlutterBuildRelease: passed with ignored local placeholder Firebase config for manifest merge only
- rg -n "uses-permission" build/app/intermediates/merged_manifest/release/processReleaseMainManifest/AndroidManifest.xml: confirmed merged release permission inventory
- git diff --check: passed

## Unblocks
- Partially unblocks #457 once #443, #444, and #452 are also complete.