### PR TITLE
fix: verify account deletion flow

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -395,7 +395,7 @@
     "@deleteAccountConfirmTitle": {
         "description": "Title of the delete account confirmation modal"
     },
-    "deleteAccountConfirmDescription": "If you keep preparing with OnTime, you can reduce lateness by 60%.",
+    "deleteAccountConfirmDescription": "This will request deletion for the account you are currently signed in with. You will be signed out when deletion succeeds.",
     "@deleteAccountConfirmDescription": {
         "description": "Description of the delete account confirmation modal"
     },
@@ -423,7 +423,7 @@
     "@deleteFeedbackTitle": {
         "description": "Delete feedback modal title"
     },
-    "deleteFeedbackDescription": "Please let us know what was inconvenient so OnTime can improve.",
+    "deleteFeedbackDescription": "Feedback is optional. When you continue, OnTime will submit your account deletion request.",
     "@deleteFeedbackDescription": {
         "description": "Delete feedback modal description"
     },

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -123,7 +123,7 @@
     },
     "logOutConfirm": "로그아웃 하시겠어요?",
     "deleteAccountConfirmTitle": "정말 탈퇴하시나요?",
-    "deleteAccountConfirmDescription": "계속 온타임과 준비를 함께하면\n지각을 60% 줄일 수 있어요.",
+    "deleteAccountConfirmDescription": "현재 로그인한 계정의 탈퇴를 요청합니다.\n탈퇴가 완료되면 로그아웃됩니다.",
     "keepUsing": "계속 사용할게요",
     "deleteAnyway": "그래도 탈퇴할게요"
 ,
@@ -131,7 +131,7 @@
     "scheduleDeleteConfirmDescription": "약속을 삭제하면 다시 되돌릴 수 없어요.",
     "deleteScheduleConfirmAction": "약속 삭제",
     "deleteFeedbackTitle": "더 좋은 서비스로 다시 만나요",
-    "deleteFeedbackDescription": "더 나은 온타임이 될 수 있도록,\n어떤 점이 불편하셨는지\n알려주시면 감사하겠습니다.",
+    "deleteFeedbackDescription": "의견 입력은 선택 사항입니다.\n계속 진행하면 계정 탈퇴 요청이 전송됩니다.",
     "deleteFeedbackPlaceholder": "탈퇴하시는 이유를 알려주세요.",
     "keepUsingLong": "탈퇴하지 않고 계속 사용하기",
     "sendFeedbackAndDelete": "의견 보내고 탈퇴하기",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -629,7 +629,7 @@ abstract class AppLocalizations {
   /// Description of the delete account confirmation modal
   ///
   /// In en, this message translates to:
-  /// **'If you keep preparing with OnTime, you can reduce lateness by 60%.'**
+  /// **'This will request deletion for the account you are currently signed in with. You will be signed out when deletion succeeds.'**
   String get deleteAccountConfirmDescription;
 
   /// Button label to keep using the app
@@ -671,7 +671,7 @@ abstract class AppLocalizations {
   /// Delete feedback modal description
   ///
   /// In en, this message translates to:
-  /// **'Please let us know what was inconvenient so OnTime can improve.'**
+  /// **'Feedback is optional. When you continue, OnTime will submit your account deletion request.'**
   String get deleteFeedbackDescription;
 
   /// Placeholder for delete feedback input

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -312,7 +312,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deleteAccountConfirmDescription =>
-      'If you keep preparing with OnTime, you can reduce lateness by 60%.';
+      'This will request deletion for the account you are currently signed in with. You will be signed out when deletion succeeds.';
 
   @override
   String get keepUsing => 'I\'ll keep using it';
@@ -337,7 +337,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deleteFeedbackDescription =>
-      'Please let us know what was inconvenient so OnTime can improve.';
+      'Feedback is optional. When you continue, OnTime will submit your account deletion request.';
 
   @override
   String get deleteFeedbackPlaceholder =>

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -292,7 +292,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deleteAccountConfirmDescription =>
-      '계속 온타임과 준비를 함께하면\n지각을 60% 줄일 수 있어요.';
+      '현재 로그인한 계정의 탈퇴를 요청합니다.\n탈퇴가 완료되면 로그아웃됩니다.';
 
   @override
   String get keepUsing => '계속 사용할게요';
@@ -314,7 +314,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deleteFeedbackDescription =>
-      '더 나은 온타임이 될 수 있도록,\n어떤 점이 불편하셨는지\n알려주시면 감사하겠습니다.';
+      '의견 입력은 선택 사항입니다.\n계속 진행하면 계정 탈퇴 요청이 전송됩니다.';
 
   @override
   String get deleteFeedbackPlaceholder => '탈퇴하시는 이유를 알려주세요.';

--- a/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
+++ b/lib/presentation/my_page/my_page_modal/delete_user_modal.dart
@@ -6,11 +6,20 @@ import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
 import 'package:on_time_front/domain/use-cases/delete_user_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
+import 'package:on_time_front/presentation/shared/components/custom_alert_dialog.dart';
 import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
-import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
 import 'package:on_time_front/presentation/shared/components/two_button_delete_dialog.dart';
 
 class DeleteUserModal {
+  DeleteUserModal({
+    DeleteUserUseCase? deleteUserUseCase,
+    UserRepository? userRepository,
+  }) : _deleteUserUseCase = deleteUserUseCase,
+       _userRepository = userRepository;
+
+  final DeleteUserUseCase? _deleteUserUseCase;
+  final UserRepository? _userRepository;
+
   Future<void> showDeleteUserModal(
     BuildContext context, {
     required VoidCallback onConfirm,
@@ -34,132 +43,233 @@ class DeleteUserModal {
     BuildContext context,
     VoidCallback onConfirm,
   ) async {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-    final l10n = AppLocalizations.of(context)!;
-
-    final controller = TextEditingController();
-    final focusNode = FocusNode();
-
-    final result = await showTwoActionDialog(
-      context,
-      config: TwoActionDialogConfig(
-        title: l10n.deleteFeedbackTitle,
-        secondaryAction: DialogActionConfig(
-          label: l10n.keepUsingLong,
-          variant: ModalWideButtonVariant.neutral,
-          textStyle: TextStyle(
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-            fontSize: 14,
-            height: 1.4,
-            color: colorScheme.outline,
-          ),
-        ),
-        primaryAction: DialogActionConfig(
-          label: l10n.sendFeedbackAndDelete,
-          variant: ModalWideButtonVariant.destructive,
-          textStyle: TextStyle(
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-            fontSize: 14,
-            height: 1.4,
-            color: colorScheme.onError,
-          ),
-        ),
-      ),
-      customContent: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            l10n.deleteFeedbackDescription,
-            style: textTheme.bodyMedium?.copyWith(
-              fontFamily: 'Pretendard',
-              fontWeight: FontWeight.w400,
-              height: 1.4,
-              fontSize: 14,
-              color: colorScheme.outline,
-            ),
-          ),
-          const SizedBox(height: 16),
-          Container(
-            width: 249,
-            height: 160,
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: colorScheme.surface,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: colorScheme.outlineVariant, width: 1),
-            ),
-            child: TextField(
-              controller: controller,
-              focusNode: focusNode,
-              inputFormatters: [
-                LengthLimitingTextInputFormatter(
-                  BackendConstraints.maxLongTextLength,
-                ),
-              ],
-              maxLines: null,
-              expands: true,
-              textAlign: TextAlign.start,
-              textAlignVertical: TextAlignVertical.top,
-              cursorColor: colorScheme.outline,
-              style: textTheme.bodyMedium?.copyWith(
-                fontFamily: 'Pretendard',
-                fontWeight: FontWeight.w400,
-                height: 1.4,
-                fontSize: 14,
-                color: colorScheme.onSurface,
-              ),
-              decoration: InputDecoration(
-                hintText: focusNode.hasFocus
-                    ? ''
-                    : l10n.deleteFeedbackPlaceholder,
-                hintStyle: textTheme.bodyMedium?.copyWith(
-                  fontFamily: 'Pretendard',
-                  fontWeight: FontWeight.w400,
-                  height: 1.4,
-                  fontSize: 14,
-                  color: colorScheme.outlineVariant,
-                ),
-                border: InputBorder.none,
-                enabledBorder: InputBorder.none,
-                focusedBorder: InputBorder.none,
-                isCollapsed: true,
-                contentPadding: EdgeInsets.zero,
-              ),
-            ),
-          ),
-        ],
-      ),
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) {
+        return _DeleteFeedbackDialog(
+          onDelete: (feedbackMessage) async {
+            await _deleteAccount(feedbackMessage);
+          },
+        );
+      },
     );
 
-    if (result != DialogActionResult.primary) {
-      return;
+    if (result == true) {
+      onConfirm();
     }
+  }
+
+  Future<void> _deleteAccount(String feedbackMessage) async {
+    final deleteUserUseCase = _deleteUserUseCase ?? getIt<DeleteUserUseCase>();
+    await deleteUserUseCase(feedbackMessage);
 
     try {
-      final deleteUserUseCase = getIt<DeleteUserUseCase>();
-      await deleteUserUseCase(controller.text);
-    } catch (error) {
-      AppLogger.debug('Delete user failed errorType=${error.runtimeType}');
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(l10n.error)));
-      }
-      return;
-    }
-
-    try {
-      final userRepository = getIt<UserRepository>();
+      final userRepository = _userRepository ?? getIt<UserRepository>();
       await userRepository.signOut();
     } catch (error) {
       AppLogger.debug(
         'Sign out after delete user failed errorType=${error.runtimeType}',
       );
     }
+  }
+}
 
-    onConfirm();
+class _DeleteFeedbackDialog extends StatefulWidget {
+  const _DeleteFeedbackDialog({required this.onDelete});
+
+  final Future<void> Function(String feedbackMessage) onDelete;
+
+  @override
+  State<_DeleteFeedbackDialog> createState() => _DeleteFeedbackDialogState();
+}
+
+class _DeleteFeedbackDialogState extends State<_DeleteFeedbackDialog> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+  bool _isDeleting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_handleFocusChanged);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_handleFocusChanged);
+    _focusNode.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final l10n = AppLocalizations.of(context)!;
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final dialogWidth = (screenWidth - 32).clamp(0.0, 277.0).toDouble();
+
+    return PopScope(
+      canPop: !_isDeleting,
+      child: CustomAlertDialog(
+        title: Text(
+          l10n.deleteFeedbackTitle,
+          style: textTheme.titleMedium?.copyWith(
+            fontFamily: 'Pretendard',
+            fontWeight: FontWeight.w600,
+            fontSize: 18,
+            height: 1.4,
+            color: colorScheme.onSurface,
+          ),
+        ),
+        innerPadding: const EdgeInsets.fromLTRB(16, 18, 16, 18),
+        titleContentSpacing: 8,
+        contentActionsSpacing: 16,
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              l10n.deleteFeedbackDescription,
+              style: textTheme.bodyMedium?.copyWith(
+                fontFamily: 'Pretendard',
+                fontWeight: FontWeight.w400,
+                height: 1.4,
+                fontSize: 14,
+                color: colorScheme.outline,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: 249,
+              height: 160,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: colorScheme.outlineVariant, width: 1),
+              ),
+              child: TextField(
+                controller: _controller,
+                focusNode: _focusNode,
+                enabled: !_isDeleting,
+                inputFormatters: [
+                  LengthLimitingTextInputFormatter(
+                    BackendConstraints.maxLongTextLength,
+                  ),
+                ],
+                maxLines: null,
+                expands: true,
+                textAlign: TextAlign.start,
+                textAlignVertical: TextAlignVertical.top,
+                cursorColor: colorScheme.outline,
+                style: textTheme.bodyMedium?.copyWith(
+                  fontFamily: 'Pretendard',
+                  fontWeight: FontWeight.w400,
+                  height: 1.4,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+                decoration: InputDecoration(
+                  hintText: _focusNode.hasFocus
+                      ? ''
+                      : l10n.deleteFeedbackPlaceholder,
+                  hintStyle: textTheme.bodyMedium?.copyWith(
+                    fontFamily: 'Pretendard',
+                    fontWeight: FontWeight.w400,
+                    height: 1.4,
+                    fontSize: 14,
+                    color: colorScheme.outlineVariant,
+                  ),
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  disabledBorder: InputBorder.none,
+                  isCollapsed: true,
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          SizedBox(
+            width: dialogWidth,
+            child: Row(
+              children: [
+                ModalWideButton(
+                  layout: ModalWideButtonLayout.flex,
+                  text: l10n.keepUsingLong,
+                  variant: ModalWideButtonVariant.neutral,
+                  textStyle: TextStyle(
+                    fontFamily: 'Pretendard',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    height: 1.4,
+                    color: colorScheme.outline,
+                  ),
+                  height: 43,
+                  onPressed: _isDeleting
+                      ? null
+                      : () => Navigator.of(context).pop(false),
+                ),
+                const SizedBox(width: 8),
+                ModalWideButton(
+                  layout: ModalWideButtonLayout.flex,
+                  text: l10n.sendFeedbackAndDelete,
+                  variant: ModalWideButtonVariant.destructive,
+                  textStyle: TextStyle(
+                    fontFamily: 'Pretendard',
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                    height: 1.4,
+                    color: colorScheme.onError,
+                  ),
+                  height: 43,
+                  isLoading: _isDeleting,
+                  onPressed: _submitDelete,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _submitDelete() async {
+    if (_isDeleting) {
+      return;
+    }
+
+    setState(() {
+      _isDeleting = true;
+    });
+
+    try {
+      await widget.onDelete(_controller.text);
+    } catch (error) {
+      AppLogger.debug('Delete user failed errorType=${error.runtimeType}');
+      if (!mounted) {
+        return;
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(AppLocalizations.of(context)!.error)),
+      );
+      setState(() {
+        _isDeleting = false;
+      });
+      return;
+    }
+
+    if (mounted) {
+      Navigator.of(context).pop(true);
+    }
   }
 }

--- a/lib/presentation/shared/components/modal_wide_button.dart
+++ b/lib/presentation/shared/components/modal_wide_button.dart
@@ -1,16 +1,8 @@
 import 'package:flutter/material.dart';
 
-enum ModalWideButtonVariant {
-  neutral,
-  primary,
-  destructive,
-}
+enum ModalWideButtonVariant { neutral, primary, destructive }
 
-enum ModalWideButtonLayout {
-  fixed,
-  full,
-  flex,
-}
+enum ModalWideButtonLayout { fixed, full, flex }
 
 class ModalWideButton extends StatelessWidget {
   const ModalWideButton({
@@ -22,6 +14,7 @@ class ModalWideButton extends StatelessWidget {
     this.height = 43,
     this.fixedWidth = 245,
     this.textStyle,
+    this.isLoading = false,
   });
 
   final VoidCallback? onPressed;
@@ -31,6 +24,7 @@ class ModalWideButton extends StatelessWidget {
   final double height;
   final double fixedWidth;
   final TextStyle? textStyle;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -39,17 +33,17 @@ class ModalWideButton extends StatelessWidget {
 
     final (backgroundColor, foregroundColor) = switch (variant) {
       ModalWideButtonVariant.neutral => (
-          colorScheme.surfaceContainerLow,
-          colorScheme.outline,
-        ),
+        colorScheme.surfaceContainerLow,
+        colorScheme.outline,
+      ),
       ModalWideButtonVariant.primary => (
-          colorScheme.primary,
-          colorScheme.onPrimary,
-        ),
+        colorScheme.primary,
+        colorScheme.onPrimary,
+      ),
       ModalWideButtonVariant.destructive => (
-          colorScheme.error,
-          colorScheme.onError,
-        ),
+        colorScheme.error,
+        colorScheme.onError,
+      ),
     };
 
     final defaultTextStyle = theme.textTheme.titleSmall?.copyWith(
@@ -74,13 +68,11 @@ class ModalWideButton extends StatelessWidget {
       },
       height: height,
       child: TextButton(
-        onPressed: onPressed,
+        onPressed: isLoading ? null : onPressed,
         style: ButtonStyle(
           backgroundColor: WidgetStateProperty.all(backgroundColor),
           shape: WidgetStateProperty.all(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
           padding: WidgetStateProperty.all(
             const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
@@ -90,13 +82,22 @@ class ModalWideButton extends StatelessWidget {
           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           visualDensity: VisualDensity.compact,
         ),
-        child: Text(
-          text,
-          textAlign: TextAlign.center,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: textStyle ?? defaultTextStyle,
-        ),
+        child: isLoading
+            ? SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(foregroundColor),
+                ),
+              )
+            : Text(
+                text,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: textStyle ?? defaultTextStyle,
+              ),
       ),
     );
 

--- a/test/presentation/my_page/delete_user_modal_test.dart
+++ b/test/presentation/my_page/delete_user_modal_test.dart
@@ -1,41 +1,32 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:on_time_front/domain/entities/user_entity.dart';
+import 'package:on_time_front/domain/repositories/user_repository.dart';
+import 'package:on_time_front/domain/use-cases/delete_user_use_case.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 import 'package:on_time_front/presentation/my_page/my_page_modal/delete_user_modal.dart';
 import 'package:on_time_front/presentation/shared/theme/theme.dart';
 
 void main() {
-  testWidgets('opens feedback dialog after confirming delete account',
-      (tester) async {
-    final modal = DeleteUserModal();
-
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: themeData,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        locale: const Locale('ko'),
-        home: Builder(
-          builder: (context) {
-            return Scaffold(
-              body: Center(
-                child: TextButton(
-                  onPressed: () async {
-                    await modal.showDeleteUserModal(context, onConfirm: () {});
-                  },
-                  child: const Text('open'),
-                ),
-              ),
-            );
-          },
-        ),
-      ),
+  testWidgets('opens feedback dialog after confirming delete account', (
+    tester,
+  ) async {
+    final repository = _FakeUserRepository();
+    final modal = DeleteUserModal(
+      deleteUserUseCase: DeleteUserUseCase(repository),
+      userRepository: repository,
     );
+
+    await _pumpDeleteModal(tester, modal: modal);
 
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
 
     expect(find.text('정말 탈퇴하시나요?'), findsOneWidget);
+    expect(find.textContaining('현재 로그인한 계정의 탈퇴'), findsOneWidget);
     expect(find.text('계속 사용할게요'), findsOneWidget);
     expect(find.text('그래도 탈퇴할게요'), findsOneWidget);
 
@@ -43,7 +34,274 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('더 좋은 서비스로 다시 만나요'), findsOneWidget);
+    expect(find.textContaining('계정 탈퇴 요청이 전송됩니다'), findsOneWidget);
     expect(find.text('탈퇴하지 않고 계속 사용하기'), findsOneWidget);
     expect(find.text('의견 보내고 탈퇴하기'), findsOneWidget);
   });
+
+  testWidgets('cancels from the first confirmation dialog', (tester) async {
+    var didConfirm = false;
+    final repository = _FakeUserRepository();
+    final modal = DeleteUserModal(
+      deleteUserUseCase: DeleteUserUseCase(repository),
+      userRepository: repository,
+    );
+
+    await _pumpDeleteModal(
+      tester,
+      modal: modal,
+      onConfirm: () => didConfirm = true,
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('계속 사용할게요'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('더 좋은 서비스로 다시 만나요'), findsNothing);
+    expect(repository.deletedNormalFeedback, isNull);
+    expect(didConfirm, isFalse);
+  });
+
+  testWidgets('cancels from the feedback dialog without deleting', (
+    tester,
+  ) async {
+    var didConfirm = false;
+    final repository = _FakeUserRepository();
+    final modal = DeleteUserModal(
+      deleteUserUseCase: DeleteUserUseCase(repository),
+      userRepository: repository,
+    );
+
+    await _pumpDeleteModal(
+      tester,
+      modal: modal,
+      onConfirm: () => didConfirm = true,
+    );
+    await _openFeedbackDialog(tester);
+
+    await tester.tap(find.text('탈퇴하지 않고 계속 사용하기'));
+    await tester.pumpAndSettle();
+
+    expect(repository.deletedNormalFeedback, isNull);
+    expect(repository.didSignOut, isFalse);
+    expect(didConfirm, isFalse);
+    expect(find.text('더 좋은 서비스로 다시 만나요'), findsNothing);
+  });
+
+  testWidgets('shows loading state while deletion is in progress', (
+    tester,
+  ) async {
+    var didConfirm = false;
+    final deleteCompleter = Completer<void>();
+    final repository = _FakeUserRepository(deleteCompleter: deleteCompleter);
+    final modal = DeleteUserModal(
+      deleteUserUseCase: DeleteUserUseCase(repository),
+      userRepository: repository,
+    );
+
+    await _pumpDeleteModal(
+      tester,
+      modal: modal,
+      onConfirm: () => didConfirm = true,
+    );
+    await _openFeedbackDialog(tester);
+
+    await tester.enterText(find.byType(TextField), 'Need a reset');
+    await tester.tap(find.text('의견 보내고 탈퇴하기'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(repository.deletedNormalFeedback, isNull);
+
+    await tester.tap(find.text('탈퇴하지 않고 계속 사용하기'));
+    await tester.pump();
+    expect(find.text('더 좋은 서비스로 다시 만나요'), findsOneWidget);
+
+    deleteCompleter.complete();
+    await tester.pumpAndSettle();
+
+    expect(repository.deletedNormalFeedback, 'Need a reset');
+    expect(repository.didSignOut, isTrue);
+    expect(didConfirm, isTrue);
+  });
+
+  testWidgets(
+    'keeps feedback dialog open and shows error when deletion fails',
+    (tester) async {
+      var didConfirm = false;
+      final repository = _FakeUserRepository(deleteError: Exception('failed'));
+      final modal = DeleteUserModal(
+        deleteUserUseCase: DeleteUserUseCase(repository),
+        userRepository: repository,
+      );
+
+      await _pumpDeleteModal(
+        tester,
+        modal: modal,
+        onConfirm: () => didConfirm = true,
+      );
+      await _openFeedbackDialog(tester);
+
+      await tester.tap(find.text('의견 보내고 탈퇴하기'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('오류'), findsOneWidget);
+      expect(find.text('더 좋은 서비스로 다시 만나요'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(repository.didSignOut, isFalse);
+      expect(didConfirm, isFalse);
+    },
+  );
+
+  testWidgets('deletes account, signs out, and calls confirm on success', (
+    tester,
+  ) async {
+    var didConfirm = false;
+    final repository = _FakeUserRepository();
+    final modal = DeleteUserModal(
+      deleteUserUseCase: DeleteUserUseCase(repository),
+      userRepository: repository,
+    );
+
+    await _pumpDeleteModal(
+      tester,
+      modal: modal,
+      onConfirm: () => didConfirm = true,
+    );
+    await _openFeedbackDialog(tester);
+
+    await tester.enterText(find.byType(TextField), 'No longer needed');
+    await tester.tap(find.text('의견 보내고 탈퇴하기'));
+    await tester.pumpAndSettle();
+
+    expect(repository.deletedNormalFeedback, 'No longer needed');
+    expect(repository.didSignOut, isTrue);
+    expect(didConfirm, isTrue);
+    expect(find.text('더 좋은 서비스로 다시 만나요'), findsNothing);
+  });
+}
+
+Future<void> _pumpDeleteModal(
+  WidgetTester tester, {
+  required DeleteUserModal modal,
+  VoidCallback? onConfirm,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: themeData,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ko'),
+      home: Builder(
+        builder: (context) {
+          return Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () async {
+                  await modal.showDeleteUserModal(
+                    context,
+                    onConfirm: onConfirm ?? () {},
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+}
+
+Future<void> _openFeedbackDialog(WidgetTester tester) async {
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('그래도 탈퇴할게요'));
+  await tester.pumpAndSettle();
+}
+
+class _FakeUserRepository implements UserRepository {
+  _FakeUserRepository({this.deleteCompleter, this.deleteError});
+
+  final Completer<void>? deleteCompleter;
+  final Object? deleteError;
+  String? deletedNormalFeedback;
+  bool didSignOut = false;
+
+  @override
+  Stream<UserEntity> get userStream => const Stream.empty();
+
+  @override
+  Stream<GoogleSignInAuthenticationEvent> get googleAuthenticationEvents =>
+      const Stream.empty();
+
+  @override
+  bool get supportsGoogleAuthenticate => false;
+
+  @override
+  Future<GoogleSignInAccount> authenticateWithGoogle() =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> initializeGoogleSignIn() async {}
+
+  @override
+  Future<void> deleteAppleUser({String? feedbackMessage}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> deleteGoogleUser({String? feedbackMessage}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> deleteUser({String? feedbackMessage}) async {
+    if (deleteError != null) {
+      throw deleteError!;
+    }
+    if (deleteCompleter != null) {
+      await deleteCompleter!.future;
+    }
+    deletedNormalFeedback = feedbackMessage;
+  }
+
+  @override
+  Future<void> disconnectGoogleSignIn() => throw UnimplementedError();
+
+  @override
+  Future<String?> getUserSocialType() async => null;
+
+  @override
+  Future<void> getUser() => throw UnimplementedError();
+
+  @override
+  Future<void> postFeedback(String message) => throw UnimplementedError();
+
+  @override
+  Future<void> signIn({required String email, required String password}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signInWithApple({
+    required String idToken,
+    required String authCode,
+    required String fullName,
+    String? email,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> signInWithGoogle(GoogleSignInAccount account) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signOut() async {
+    didSignOut = true;
+  }
+
+  @override
+  Future<void> signUp({
+    required String email,
+    required String password,
+    required String name,
+  }) => throw UnimplementedError();
 }


### PR DESCRIPTION
## Summary
- Closes #438 and supports parent release track #464.
- Clarifies localized account deletion copy in Korean and English.
- Keeps the final deletion dialog open during deletion, shows a loading spinner, disables cancellation while the request is in flight, and preserves error recovery.
- Adds widget coverage for discoverability dialogs, cancellation, loading, failure, and success; existing use-case tests cover normal, Google, and Apple provider delete routing.

## Verification
- `flutter analyze` - passed
- `flutter test test/presentation/my_page/delete_user_modal_test.dart test/domain/use-cases/delete_user_use_case_test.dart test/data/data_sources/authentication_remote_data_source_test.dart` - passed

## Unblocks
- Helps unblock #458 after backend deletion behavior (#439) and release-build prerequisites (#452) are also complete.
