### PR TITLE
[Release] Configure release signing ownership and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,10 @@ android/app/google-services.json
 android/app/src/debug/google-services.json
 android/app/src/release/google-services.json
 android/app/src/google-services.json
+android/key.properties
+*.jks
+*.keystore
+*.p12
 
 .cursor
 .codex/

--- a/docs/Android-Release-Signing.md
+++ b/docs/Android-Release-Signing.md
@@ -2,6 +2,18 @@
 
 Android release builds must be signed with the production release key. Debug signing is only for debug and profile builds.
 
+## Ownership and Storage
+
+The Android release owner is the person or team role with Google Play release
+responsibility for `club.devkor.ontime`. That owner is responsible for creating
+or confirming the upload keystore, keeping access limited to release maintainers,
+and rotating or resetting the upload key if access is lost.
+
+Store the upload keystore and passwords outside the repository in the team
+password manager or CI secret manager. Record the current owner and recovery
+notes in that secure system, not in git. Do not send keystores or passwords in
+issue comments, pull requests, chat logs, screenshots, or build artifacts.
+
 ## Required Signing Inputs
 
 Release builds require all of these values:
@@ -54,8 +66,19 @@ flutter build appbundle --release \
   --build-number=<monotonic Android versionCode>
 ```
 
+The GitHub Actions Play deploy workflow expects the keystore bytes in
+`ANDROID_UPLOAD_KEYSTORE_B64`, decodes them to a temporary runner path, and then
+exports `ANDROID_KEYSTORE_PATH`. The keystore file should never be written into
+the repository checkout in CI.
+
 ## How Validation Works
 
 Gradle checks release signing inputs only when a release task is requested. Debug and profile builds do not require release signing credentials.
 
 Release builds fail before packaging if any required value is absent or if the keystore file path does not exist. The error message lists the missing inputs so local and CI setup failures are explicit.
+
+Expected setup failures look like:
+
+```text
+Android release signing is required for release builds. Missing: storeFile, ANDROID_KEYSTORE_PATH, or ONTIME_ANDROID_KEYSTORE_PATH, ...
+```

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -12,6 +12,22 @@ Use this guide when preparing OnTime for Google Play release builds.
 - Do not commit keystores, passwords, `android/key.properties`, or generated
   release artifacts.
 
+## Ownership and Secret Storage
+
+The Android release owner for `club.devkor.ontime` owns the upload keystore
+process. This role is responsible for:
+
+- creating or confirming the current upload keystore;
+- storing the keystore file and passwords in the team password manager or CI
+  secret manager;
+- limiting access to release maintainers;
+- documenting recovery notes in the secure storage record;
+- rotating or requesting a Play Console upload-key reset if the upload key is
+  lost or exposed.
+
+Never store keystore files or passwords in git, issue comments, pull requests,
+chat logs, screenshots, or build artifacts.
+
 ## Create an Upload Key
 
 Create and store the keystore somewhere outside the repository:
@@ -77,6 +93,12 @@ The deploy workflow decodes this secret into `$RUNNER_TEMP/ontime-upload.jks`
 and exports `ANDROID_KEYSTORE_PATH` to that temporary file. Do not create
 `android/key.properties` in CI.
 
+The protected environment must also provide:
+
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
 ## Build a Signed Release
 
 Google Play prefers Android App Bundles:
@@ -94,7 +116,10 @@ flutter build apk --release
 ```
 
 The Gradle config intentionally fails release builds when signing secrets are
-missing. Debug builds do not require release signing secrets.
+missing. The failure lists missing local or CI inputs, including
+`storeFile`/`ANDROID_KEYSTORE_PATH`, `storePassword`/`ANDROID_KEYSTORE_PASSWORD`,
+`keyAlias`/`ANDROID_KEY_ALIAS`, and `keyPassword`/`ANDROID_KEY_PASSWORD`. Debug
+builds do not require release signing secrets.
 
 ## First Play Console Release
 

--- a/plans/issue-450-release-signing.md
+++ b/plans/issue-450-release-signing.md
@@ -1,0 +1,43 @@
+# Issue 450 Release Signing Plan
+
+Parent track: #467
+Sub-issue: #450 - Configure release signing ownership and secrets
+
+## Scope
+
+- Document who owns the Android upload keystore and how it is stored without exposing secrets.
+- Document the local and CI signing inputs used by Gradle.
+- Ensure signing secret files are ignored by git.
+- Verify that release signing failures are explicit when required inputs are missing.
+
+## Files Likely Touched
+
+- `.gitignore`
+- `docs/Android-Release-Signing.md`
+- `docs/Android-Signing-Setup.md`
+- `plans/issue-450-release-signing.md`
+
+## Implementation Approach
+
+- Add git ignore rules for `android/key.properties`, keystores, and related signing artifacts.
+- Tighten release signing docs to name the release owner role, storage process, local `key.properties` path, CI secret names, and failure behavior.
+- Keep Firebase config, versioning, Play signing fingerprints, signed AAB production, and device smoke testing out of scope.
+
+## Verification
+
+- Review the diff for secret-free documentation only.
+- Run `git check-ignore` against representative signing secret paths.
+- Run a release Gradle validation task without signing inputs and confirm the error explains which signing inputs are missing.
+
+## Blockers
+
+- No blocker for documentation and Gradle validation.
+- A human release owner still must create or confirm the real upload keystore and store the actual secrets in the team secret manager.
+
+## Explicitly Left Out
+
+- Creating a real keystore.
+- Committing `android/key.properties`.
+- Adding Firebase `google-services.json`.
+- Building a signed AAB.
+- Recording Play App Signing SHA-1/SHA-256 fingerprints.


### PR DESCRIPTION
## Summary
- Document Android release signing ownership, secure storage, local inputs, and CI secret expectations.
- Add repository-level ignore rules for signing secret artifacts.
- Record the #450 implementation plan under `plans/`.

## Verification
- `flutter pub get` succeeded.
- `git diff --check` succeeded.
- `git check-ignore -v android/key.properties android/upload.jks android/upload.keystore android/upload.p12` confirmed signing artifacts are ignored.
- `gradle -p android :app:validateSigningRelease` was run with a temporary ignored release `google-services.json` and no signing inputs; it failed with the expected explicit missing signing input message.

## Track
Closes #450.
Part of #467.

This satisfies the signing prerequisite for #452 and #454. #452 still also needs #451 and #453; #454 still needs Play App Signing and Firebase/auth fingerprint follow-up.
