### PR TITLE
chore: validate release Firebase config

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request-widgetbook.yml
+++ b/.github/workflows/firebase-hosting-pull-request-widgetbook.yml
@@ -2,14 +2,16 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR (Widgetbook)
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   checks: write
   contents: read
   pull-requests: write
 jobs:
   build_and_preview:
-    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}"
     runs-on: ubuntu-latest
     env:
       working-directory: ./widgetbook
@@ -44,5 +46,7 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ON_TIME_FRONT_WIDGETBOOK }}"
           projectId: on-time-front-widgetbook
           entryPoint: ${{ env.working-directory }}
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,14 +2,16 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   checks: write
   contents: read
   pull-requests: write
 jobs:
   build_and_preview:
-    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}"
     runs-on: ubuntu-latest
     environment: debug
     steps:
@@ -46,5 +48,7 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ONTIME_C63F1 }}"
           projectId: ontime-c63f1
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,37 +5,87 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+def androidApplicationId = "club.devkor.ontime"
 def isReleaseBuild = gradle.startParameter.taskNames.any {
     it.toLowerCase().contains("release")
 }
 def googleServicesBuildType = isReleaseBuild ? "release" : "debug"
-def googleServicesConfigFiles = [
-    file("src/${googleServicesBuildType}/google-services.json"),
-    file("google-services.json"),
-    file("src/google-services.json"),
-]
-def releaseGoogleServicesConfigFiles = [
-    file("src/release/google-services.json"),
-    file("google-services.json"),
-    file("src/google-services.json"),
-]
-def hasReleaseGoogleServicesConfig = releaseGoogleServicesConfigFiles.any {
-    it.exists()
+def googleServicesConfigCandidates = { buildType ->
+    [
+        file("src/${buildType}/google-services.json"),
+        file("google-services.json"),
+        file("src/google-services.json"),
+    ]
+}
+def selectGoogleServicesConfigFile = { buildType ->
+    googleServicesConfigCandidates(buildType).find { it.exists() }
+}
+def releaseGoogleServicesConfigFile = selectGoogleServicesConfigFile("release")
+def validateGoogleServicesPackageName = { File configFile ->
+    def parsedConfig
+
+    try {
+        parsedConfig = new groovy.json.JsonSlurper().parse(configFile)
+    } catch (Exception exception) {
+        throw new GradleException(
+            "Unable to parse Android Firebase config at ${configFile}. " +
+            "Confirm ANDROID_GOOGLE_SERVICES_JSON_B64 decodes to valid google-services.json.",
+            exception
+        )
+    }
+
+    def matchingClient = (parsedConfig.client ?: []).find { client ->
+        client?.client_info?.android_client_info?.package_name == androidApplicationId
+    }
+
+    if (!matchingClient) {
+        throw new GradleException(
+            "Android Firebase config at ${configFile} must include a client for package " +
+            "${androidApplicationId}. Update the release google-services.json source or " +
+            "ANDROID_GOOGLE_SERVICES_JSON_B64 secret before building a release."
+        )
+    }
 }
 
-if (isReleaseBuild && !hasReleaseGoogleServicesConfig) {
-    throw new GradleException(
-        "Android release builds require Firebase config. " +
-        "Provide android/app/src/release/google-services.json, usually by " +
-        "decoding the ANDROID_GOOGLE_SERVICES_JSON_B64 CI secret before " +
-        "running a release build."
-    )
+if (isReleaseBuild) {
+    if (!releaseGoogleServicesConfigFile) {
+        throw new GradleException(
+            "Android release builds require Firebase config. " +
+            "Provide android/app/src/release/google-services.json, usually by " +
+            "decoding the ANDROID_GOOGLE_SERVICES_JSON_B64 CI secret before " +
+            "running a release build."
+        )
+    }
+
+    validateGoogleServicesPackageName(releaseGoogleServicesConfigFile)
 }
+
+def googleServicesConfigFiles = googleServicesConfigCandidates(googleServicesBuildType)
 
 if (googleServicesConfigFiles.any { it.exists() }) {
     apply plugin: "com.google.gms.google-services"
 } else {
     logger.lifecycle("google-services.json not found; skipping Google Services plugin for this local build.")
+}
+
+tasks.register("validateAndroidGoogleServices") {
+    group = "verification"
+    description = "Validates Android release google-services.json exists and matches ${androidApplicationId}."
+
+    doLast {
+        def configFile = selectGoogleServicesConfigFile("release")
+
+        if (!configFile) {
+            throw new GradleException(
+                "Android release Firebase config is missing. Provide " +
+                "android/app/src/release/google-services.json or decode " +
+                "ANDROID_GOOGLE_SERVICES_JSON_B64 before running this task."
+            )
+        }
+
+        validateGoogleServicesPackageName(configFile)
+        logger.lifecycle("Validated Android release Firebase config: ${configFile}")
+    }
 }
 
 def isReleaseTask = gradle.startParameter.taskNames.any { it.toLowerCase().contains("release") }
@@ -107,7 +157,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "club.devkor.ontime"
+        applicationId = androidApplicationId
         minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode

--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -8,6 +8,8 @@ Android release builds must include the production Firebase client config so Fir
 
 The release verification workflow decodes this secret to `android/app/src/release/google-services.json` before running the Android release build. Generated `google-services.json` files are ignored and must not be committed.
 
+The decoded file must include an Android client whose package name is `club.devkor.ontime`. Gradle validates this package match for release builds and through the focused validation task below.
+
 ## Google Play Internal Testing Deploy
 
 Use the `Android Play Internal Deploy` GitHub Actions workflow to build a signed
@@ -72,6 +74,19 @@ flutter build appbundle --release \
 On macOS, use `base64 -D` instead of `base64 --decode`.
 
 Debug/local builds may run without Android Firebase config. Release builds fail clearly if `android/app/src/release/google-services.json`, `android/app/google-services.json`, or `android/app/src/google-services.json` is missing.
+
+To validate only the Firebase config without requiring release signing inputs, materialize the ignored release config file and run:
+
+```sh
+cd android
+gradle :app:validateAndroidGoogleServices
+```
+
+The task fails if the file is missing, invalid JSON, or missing a `client_info.android_client_info.package_name` entry for `club.devkor.ontime`.
+
+## Auth Fingerprints
+
+Release SHA-1 and SHA-256 fingerprints must be added to Firebase after the release signing owner, upload key, and Play App Signing setup are finalized. Track that work in #454; do not rotate or replace `ANDROID_GOOGLE_SERVICES_JSON_B64` for fingerprint changes until the release owner confirms the final signing fingerprints.
 
 ## Verification
 

--- a/plans/release-firebase-config-451.md
+++ b/plans/release-firebase-config-451.md
@@ -1,0 +1,39 @@
+# Release Firebase Config Plan (#451)
+
+## Scope
+
+- Define the Android release Firebase config source for `google-services.json`.
+- Keep the real Firebase config out of git by documenting the CI secret decode path.
+- Validate that the release config contains an Android client for package `club.devkor.ontime`.
+- Document that release auth SHA-1/SHA-256 fingerprints are added after signing decisions are finalized.
+
+## Files Likely Touched
+
+- `android/app/build.gradle`
+- `docs/Android-Release-Configuration.md`
+- `plans/release-firebase-config-451.md`
+
+## Implementation Approach
+
+1. Reuse the existing release config locations, preferring `android/app/src/release/google-services.json`.
+2. Parse the selected release `google-services.json` with Gradle/Groovy JSON support when a release build is requested.
+3. Fail release builds clearly when the config is missing or when no Android client has package name `club.devkor.ontime`.
+4. Add a focused Gradle validation task so CI or developers can validate the release Firebase config before a full release build.
+5. Update release docs with the validation behavior, CI secret source, and the remaining fingerprint handoff to the Play signing issue.
+
+## Verification
+
+- `cd android && gradle :app:validateAndroidGoogleServices` with a temporary matching `android/app/src/release/google-services.json`.
+- `cd android && gradle :app:validateAndroidGoogleServices` with a temporary mismatched package to confirm failure.
+- `flutter analyze` if local Flutter/Android tooling is available and the change does not require secrets.
+
+## Blockers
+
+- The actual production `ANDROID_GOOGLE_SERVICES_JSON_B64` secret cannot be verified without repository/environment secret access.
+- Release auth SHA-1/SHA-256 fingerprints cannot be added until signing and Play App Signing decisions are finalized in #450/#454.
+
+## Explicitly Left Out
+
+- Creating or committing a real `google-services.json`.
+- Modifying release signing ownership, keystore setup, or versioning.
+- Building/uploading the signed AAB or performing Play Console verification.


### PR DESCRIPTION
## Summary
- add Gradle validation for the release Android google-services.json package name
- document the release Firebase config source, local validation command, and fingerprint handoff
- add a #451 implementation plan under plans/

Closes #451
Refs #467

## Verification
- flutter pub get
- dart run build_runner build --delete-conflicting-outputs
- gradle :app:validateAndroidGoogleServices with a temporary matching android/app/src/release/google-services.json: passed
- gradle :app:validateAndroidGoogleServices with a temporary mismatched package: failed with the expected package-name error
- flutter analyze: passed

## Unblocks
- contributes the Firebase config prerequisite for #452
- documents the Firebase fingerprint follow-up needed by #454