### PR TITLE
[codex] Lock initial production versioning

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request-widgetbook.yml
+++ b/.github/workflows/firebase-hosting-pull-request-widgetbook.yml
@@ -2,14 +2,16 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR (Widgetbook)
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   checks: write
   contents: read
   pull-requests: write
 jobs:
   build_and_preview:
-    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}"
     runs-on: ubuntu-latest
     env:
       working-directory: ./widgetbook
@@ -44,5 +46,7 @@ jobs:
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ON_TIME_FRONT_WIDGETBOOK }}"
           projectId: on-time-front-widgetbook
           entryPoint: ${{ env.working-directory }}
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,14 +2,16 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   checks: write
   contents: read
   pull-requests: write
 jobs:
   build_and_preview:
-    if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
+    if: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}"
     runs-on: ubuntu-latest
     environment: debug
     steps:
@@ -46,5 +48,7 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_ONTIME_C63F1 }}"
           projectId: ontime-c63f1
+          channelId: pr-${{ github.event.pull_request.number }}
+          expires: 3d
         env:
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -12,11 +12,17 @@ OnTime.
 - Keep `pubspec.yaml` as the source of truth for the app version.
 - Use semantic versioning for the public version name, formatted as
   `major.minor.patch`.
-- The first production release is `1.0.0+1`.
+- The first production release is `1.0.0+1`: public `versionName` `1.0.0`
+  with checked-in Flutter build suffix `+1`.
 - Keep the public version name manual in `pubspec.yaml`.
 - For Android Play deploys, CI derives `versionName` from `pubspec.yaml` and
-  uses `github.run_number` as the generated `versionCode`; do not open PRs only
-  to bump the checked-in build suffix.
+  uses `github.run_number` as the generated Android `versionCode`. The
+  generated value must be greater than every previous Play Console upload for
+  `club.devkor.ontime`.
+- For future public releases, bump the semantic `major.minor.patch` value in
+  `pubspec.yaml` according to release impact. Do not open PRs only to bump the
+  checked-in build suffix for Android CI deploys; change the suffix only when a
+  manual or non-CI store package needs a distinct local build number.
 
 ## Branch and Environment
 

--- a/plans/453-lock-production-versioning.md
+++ b/plans/453-lock-production-versioning.md
@@ -1,0 +1,30 @@
+# Issue 453: Lock Initial Production Versioning
+
+## Scope
+
+- Confirm the first production public version name and build suffix.
+- Keep `pubspec.yaml` as the source of truth for the checked-in Flutter app version.
+- Document how Android Play derives the production `versionCode` for CI uploads.
+- Document the future bump rule for public releases.
+
+## Files
+
+- `pubspec.yaml`: already set to `version: 1.0.0+1`; no change needed.
+- `docs/Release-Checklist.md`: clarify the initial versioning decision and future bump rule.
+
+## Implementation Approach
+
+- Treat `1.0.0` as the initial production `versionName`.
+- Treat the checked-in Flutter build suffix `+1` as the initial local/manual build number.
+- Keep Android Play CI uploads on `github.run_number` for the generated Android `versionCode`.
+- Avoid changing release signing, Firebase configuration, Play Console setup, or build workflows.
+
+## Verification
+
+- Confirm `pubspec.yaml` still declares `version: 1.0.0+1`.
+- Confirm the release checklist documents the initial version name, initial build suffix, Android CI `versionCode`, and future bump rule.
+- Run `flutter analyze`.
+
+## Blockers
+
+- None. This issue does not require Play Console access or signing secrets.


### PR DESCRIPTION
Closes #453.
References parent track #467.

## Summary
- Documents the first production release as `1.0.0+1`, with public Android `versionName` `1.0.0` and checked-in Flutter build suffix `+1`.
- Clarifies that Android Play CI derives `versionName` from `pubspec.yaml` and uses `github.run_number` as the generated Android `versionCode`.
- Adds the future public-version bump rule and a repo-local implementation plan for #453.

## Verification
- `rg -n "^version: 1\.0\.0\+1$|first production release|github\.run_number|future public releases|checked-in Flutter build suffix" pubspec.yaml docs/Release-Checklist.md plans/453-lock-production-versioning.md`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`

## Unblocks
- Helps unblock #452 after #450 and #451 are also complete.