### PR TITLE
docs: add privacy policy hosting checklist

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -10,6 +10,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Git Workflow](./Git.md) - Git strategy and commit message formats
 - [Android Release Signing](./Android-Release-Signing.md) - Required keystore inputs and release signing validation
 - [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
+- [Privacy Policy Hosting](./Privacy-Policy-Hosting.md) - Public HTTPS privacy policy hosting checklist and evidence form
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections
 

--- a/docs/Privacy-Policy-Hosting.md
+++ b/docs/Privacy-Policy-Hosting.md
@@ -1,0 +1,71 @@
+# Privacy Policy Hosting
+
+Use this checklist to complete release issue #435 after the privacy policy text
+from #434 is approved.
+
+## Current Status
+
+- Final privacy policy URL: `TBD`
+- Hosting status: blocked until #434 provides approved policy text.
+- Release owner: `TBD`
+- Hosting owner: `TBD`
+- Last validation date: `TBD`
+
+Do not mark #435 complete until the final URL is active, public, and recorded
+below.
+
+## Hosting Requirements
+
+- Host the approved policy at a public `https://` URL.
+- Serve the policy as a normal web page, not as a PDF or downloadable file.
+- Do not require login, app installation, team membership, or special network
+  access.
+- Do not publish it as a publicly editable document.
+- Do not geofence or otherwise restrict access by country, region, device, or
+  account.
+- Keep the URL stable enough to use in the Google Play privacy policy field and
+  in the app.
+
+## Recommended Hosting Flow
+
+1. Confirm #434 is complete and the policy text has product/legal approval.
+2. Choose the final hosting surface, such as the product website or another
+   owner-managed static site.
+3. Publish the approved text as a standalone HTML page.
+4. Validate the URL using the checklist below.
+5. Record the final URL in this document, comment it on #435, and use the same
+   URL for #436 and #437.
+
+## Validation Checklist
+
+- [ ] The URL starts with `https://`.
+- [ ] A private/incognito browser session can open the page without signing in.
+- [ ] `curl -I <final-url>` returns a successful HTTP status.
+- [ ] The response is a web page and not a PDF or file download.
+- [ ] The page is read-only for public visitors.
+- [ ] The page is reachable from a non-team network.
+- [ ] The page is not blocked by country, account, or device restrictions.
+- [ ] The visible page title clearly identifies it as OnTime's privacy policy.
+- [ ] The page content exactly matches the approved policy text from #434.
+- [ ] The final URL is recorded in this document and in the #435 issue thread.
+
+## Evidence Form
+
+Fill this out when the page is live.
+
+| Field | Value |
+| --- | --- |
+| Final privacy policy URL | `TBD` |
+| Approved policy source | `#434` |
+| Hosting surface | `TBD` |
+| Release owner | `TBD` |
+| Hosting owner | `TBD` |
+| Validation date | `TBD` |
+| HTTP status from `curl -I` | `TBD` |
+| Browser validation notes | `TBD` |
+
+## Handoff To Follow-Up Issues
+
+- #436: add the final URL as the in-app privacy policy link.
+- #437: enter the final URL in the Google Play Console privacy policy field.
+- #441: check Data safety answers against the approved policy and hosted page.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -75,6 +75,8 @@ OnTime.
   support contact, privacy policy, and category are ready for the target stores.
 - Use `docs/Google-Play-Listing-Copy.md` as the draft source for Google Play
   short and full descriptions until product/design approve final copy.
+- Use `docs/Privacy-Policy-Hosting.md` to validate and record the final public
+  privacy policy URL before entering it in store metadata.
 - Track any brand, icon, screenshot, or store copy gaps before submission.
 
 ## Content Category and UGC

--- a/plans/issue-435-privacy-policy-hosting.md
+++ b/plans/issue-435-privacy-policy-hosting.md
@@ -1,0 +1,41 @@
+# Issue 435 Privacy Policy Hosting Plan
+
+Parent track: #464
+Sub-issue: #435 - Host the privacy policy on a public HTTPS URL
+
+## Decision
+
+#435 cannot be completed in this repository right now because prerequisite #434
+is still open and there is no approved privacy policy text to publish. Publishing
+also requires access to the chosen public hosting surface.
+
+The repo-side work that legitimately advances #435 is to provide the release
+owner with a hosting checklist and evidence form, then link it from release
+documentation.
+
+## Blockers
+
+- #434 must provide product/legal-approved privacy policy text.
+- A human release owner must choose or confirm the hosting surface.
+- A human with hosting access must publish the page at the final public HTTPS
+  URL.
+
+## Implementation
+
+1. Add `docs/Privacy-Policy-Hosting.md` with the hosting requirements,
+   validation checklist, and final URL evidence form.
+2. Link the document from `docs/Home.md`.
+3. Reference the document from `docs/Release-Checklist.md` so release owners do
+   not miss the privacy policy URL gate.
+
+## Verification
+
+- Run markdown/link-oriented checks only; no app code should change.
+- Do not run Flutter tests unless app code changes.
+
+## Out Of Scope
+
+- Drafting or approving the privacy policy text for #434.
+- Publishing a website or changing hosting infrastructure.
+- Adding the in-app link for #436.
+- Entering the URL in Play Console for #437.


### PR DESCRIPTION
Advances #435
References #464

## Summary
- Adds a privacy policy hosting checklist and evidence form for the public HTTPS URL required by #435.
- Links the checklist from the docs index and release checklist.
- Keeps the final URL as `TBD` because #434 is still open and publishing requires human hosting access.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `rg -n "Privacy Policy Hosting|Final privacy policy URL|curl -I|#436|#437|#441|issue 435" docs/Privacy-Policy-Hosting.md docs/Home.md docs/Release-Checklist.md plans/issue-435-privacy-policy-hosting.md`

## Remaining human tasks
- Complete #434 with product/legal-approved privacy policy text.
- Choose or confirm the public hosting surface.
- Publish the approved policy at a public HTTPS URL that is not a PDF, not publicly editable, not geofenced, and works without login.
- Fill in the evidence form in `docs/Privacy-Policy-Hosting.md` with the final URL and validation results.
- Comment the final URL on #435, then use the same URL for #436 and #437.
