### PR TITLE
[codex] Add Play Console privacy policy checklist

### DIFF
--- a/handoff/issue_437_play_console_privacy_policy_url.md
+++ b/handoff/issue_437_play_console_privacy_policy_url.md
@@ -1,0 +1,60 @@
+# Issue 437 Handoff: Play Console Privacy Policy URL
+
+Parent track: #464
+Sub-issue: #437
+Prepared: 2026-05-10
+
+## Status
+
+Externally blocked. Do not close #437 until the final hosted privacy policy URL
+from #435 is entered in Google Play Console and evidence is recorded.
+
+## Blockers
+
+- #435 is still open; the final public HTTPS privacy policy URL is not available
+  in this repo.
+- Play Console entry requires a human release owner with access to the OnTime
+  Google Play Console app.
+- The saved Play Console URL must match the in-app privacy policy URL required
+  by #436.
+
+## Required Field Value
+
+- Package name: `club.devkor.ontime`
+- Privacy policy URL: `<paste final #435 HTTPS URL here>`
+- In-app privacy policy URL to compare against: `<paste final #436 URL here>`
+
+## Completion Checklist
+
+- [ ] Confirm #435 is closed and records the final hosted privacy policy URL.
+- [ ] Confirm the URL opens over HTTPS without login.
+- [ ] Confirm the URL is an HTML/web page, not a PDF, and is not publicly
+      editable.
+- [ ] Confirm the URL names OnTime or the same developer/entity used in the
+      Google Play listing.
+- [ ] Enter the URL in Play Console under the app content privacy policy field.
+- [ ] Save the Play Console change without validation errors.
+- [ ] Confirm the saved Play Console URL matches the in-app URL from #436.
+- [ ] Capture screenshot or release note evidence showing the completed field.
+- [ ] Update #437 with the evidence location and close it.
+
+## Evidence Record
+
+Fill this in after the manual console update.
+
+```text
+Release owner:
+Checked date:
+Play Console app/package: club.devkor.ontime
+Final privacy policy URL:
+Matching in-app URL:
+Evidence screenshot or release note:
+Notes:
+```
+
+## References
+
+- Google Play User Data policy:
+  https://support.google.com/googleplay/android-developer/answer/10144311
+- Google Play app review preparation:
+  https://support.google.com/googleplay/android-developer/answer/9859455

--- a/plans/issue_437_play_console_privacy_policy_url_plan.md
+++ b/plans/issue_437_play_console_privacy_policy_url_plan.md
@@ -1,0 +1,57 @@
+# Issue 437 Play Console Privacy Policy URL Plan
+
+Parent track: #464
+Sub-issue: #437
+
+## Scope
+
+Complete only the Google Play Console privacy policy URL entry for OnTime after
+the final hosted privacy policy URL exists. This issue does not draft, approve,
+host, or add the in-app privacy policy link.
+
+## Current Decision
+
+Issue #437 is externally blocked. The prerequisite issue #435 is still open, so
+there is no final public HTTPS privacy policy URL to enter. The actual Play
+Console field update also requires a human release owner with Play Console
+access.
+
+Repo-side implementation should stop at a checklist and evidence template that
+helps the release owner complete and prove the console update later.
+
+## Preconditions
+
+1. #435 is complete and has recorded the final public HTTPS privacy policy URL.
+2. #436 has either been completed or the release owner has the exact in-app URL
+   planned for #436, because #437 requires the Play Console URL to match the
+   in-app URL.
+3. The release owner has Google Play Console access for package
+   `club.devkor.ontime`.
+
+## Human Execution Plan
+
+1. Open Play Console for the OnTime app.
+2. Go to the App content page under Policy and programs.
+3. Open the privacy policy section.
+4. Paste the final HTTPS privacy policy URL from #435.
+5. Save the change and resolve any Play Console validation warning.
+6. Compare the saved Play Console URL with the in-app URL from #436.
+7. Capture a screenshot or release note proving the saved field value.
+8. Record the evidence in `handoff/issue_437_play_console_privacy_policy_url.md`
+   or the release tracker.
+
+## Verification
+
+- The saved Play Console privacy policy value is an active public HTTPS URL.
+- The URL does not require login and is not publicly editable.
+- The URL matches the in-app privacy policy link exactly after redirects are
+  considered.
+- Evidence includes the URL, check date, release owner, and screenshot or
+  release-note location.
+
+## References
+
+- Google Play User Data policy:
+  https://support.google.com/googleplay/android-developer/answer/10144311
+- Google Play app review preparation:
+  https://support.google.com/googleplay/android-developer/answer/9859455


### PR DESCRIPTION
## Summary

Advances #437 under parent track #464 by adding issue-scoped repo artifacts for the manual Play Console privacy policy URL step.

This does not close #437 because the issue remains externally blocked on the final hosted privacy policy URL from #435 and human Play Console access.

## Changes

- Added a decision plan for #437 in `plans/issue_437_play_console_privacy_policy_url_plan.md`.
- Added a handoff checklist and evidence template in `handoff/issue_437_play_console_privacy_policy_url.md`.

## Verification

- `git diff --check`
- Reviewed #464 ordered sub-issues and #437 metadata with `gh issue view`.
- Searched repo and merged PR context for an existing final privacy policy URL; none was found.

## Remaining human tasks

- Complete #435 and record the final public HTTPS privacy policy URL.
- Enter that URL in Google Play Console for package `club.devkor.ontime`.
- Confirm the saved Play Console URL matches the in-app URL from #436.
- Capture screenshot or release-note evidence and update/close #437.
