### PR TITLE
[codex] Add release screenshot capture checklist

### DIFF
--- a/docs/Google-Play-Release-Screenshots.md
+++ b/docs/Google-Play-Release-Screenshots.md
@@ -1,0 +1,93 @@
+# Google Play Release Screenshots
+
+Use this checklist to capture the Play Store screenshots for issue #449. The
+final screenshots must come from a release-like app build on a real device or
+release-equivalent emulator; do not use mock-only screens, Widgetbook states, or
+debug-only data.
+
+Last checked against Google Play Console Help on 2026-05-10:
+
+- [Add preview assets to showcase your app](https://support.google.com/googleplay/android-developer/answer/9866151?hl=en-EN)
+- [Store listing practices](https://support.google.com/googleplay/android-developer/answer/13393723?hl=en)
+
+## Capture Setup
+
+- Build and install the release candidate that will be submitted, or an
+  equivalent signed build from the same commit and environment.
+- Use the shipped localization that the screenshot will represent. If the
+  listing has Korean and English localized screenshots, capture each language
+  separately.
+- Use realistic but non-sensitive sample data. Do not show personal names,
+  private addresses, phone numbers, access tokens, backend IDs, or real user
+  accounts.
+- Clear unrelated system notifications before capture. Keep the device status
+  bar clean and plausible.
+- Keep the app name, icon, and visible copy consistent with `OnTime` and
+  `docs/Google-Play-Listing-Copy.md`.
+
+## Play Asset Constraints
+
+Confirm current Play Console requirements again at upload time. As of the last
+check above, screenshots must satisfy:
+
+- At least 2 screenshots across device types are required to publish the store
+  listing.
+- Up to 8 screenshots can be uploaded for each supported device type.
+- Accepted formats are JPEG or 24-bit PNG with no alpha channel.
+- Each screenshot must have a minimum dimension of 320 px and a maximum
+  dimension of 3840 px.
+- The longest side cannot be more than twice the shortest side.
+- For app recommendation eligibility, provide at least 4 app screenshots at
+  minimum 1080 px resolution. Portrait screenshots should be 9:16, with
+  1080 x 1920 px or higher.
+
+## Required Capture Set
+
+Capture at least these five app states. If the Play Console or product/design
+owner wants fewer uploads, keep these as the source set and select the best
+ordered subset after review.
+
+| Order | App state | Route or flow | Capture requirements |
+| --- | --- | --- | --- |
+| 1 | Onboarding or permission request | `/onboarding/start`, `/onboarding`, or `/allowNotification` | Show the actual first-run setup or notification permission explanation. The text must match shipped localization. |
+| 2 | Schedule creation | `/scheduleCreate` | Show a realistic appointment being created with date, time, place, travel time, spare time, and preparation steps where possible. |
+| 3 | Alarm and preparation flow | `/scheduleStart` and `/alarmScreen` | Show the early-start prompt or active preparation checklist/timer for a real schedule. Do not fake alarm state with debug-only overlays. |
+| 4 | Calendar or Home | `/home` or `/calendar` | Show upcoming schedules on Home or the monthly calendar with realistic non-sensitive schedule names. |
+| 5 | My Page and account controls | `/myPage` | Show account/settings controls, including notification or default preparation settings if available. Avoid exposing a real email address. |
+
+Optional additional screenshots:
+
+- Preparation completion or early/late result at `/earlyLate`.
+- Default preparation and spare time settings at
+  `/defaultPreparationSpareTimeEdit`.
+- Schedule edit flow at `/scheduleEdit/:scheduleId`.
+
+## Quality Review
+
+- Confirm every screenshot reflects the release candidate behavior.
+- Confirm text, dates, and labels match the shipped localization.
+- Confirm screenshots do not imply unsupported sharing, collaboration,
+  location-tracking, map navigation, or other features not present in the app.
+- Confirm screenshots do not contain debugging UI, emulator overlays, test
+  banners, unfinished placeholders, or mock-only copy.
+- Confirm image dimensions and file formats are accepted by Play Console before
+  marking issue #449 complete.
+- Record the build commit, build variant, device model, OS version, locale,
+  screenshot filenames, and reviewer in the evidence log below.
+
+## Evidence Log
+
+Complete this table when screenshots are captured.
+
+| Field | Value |
+| --- | --- |
+| Build commit | |
+| Build variant | |
+| Device or emulator | |
+| Android version | |
+| Locale(s) | |
+| Screenshot filenames | |
+| Dimension check result | |
+| Product/design reviewer | |
+| Play Console upload result | |
+| Notes or follow-up issues | |

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -12,6 +12,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections
+- [Google Play Release Screenshots](./Google-Play-Release-Screenshots.md) - Capture checklist and evidence log for real release screenshots
 
 ### Technical Deep Dives
 - [Error Handling System](./Error-Handling-Result-System.md) - Result-based error handling architecture

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -75,6 +75,8 @@ OnTime.
   support contact, privacy policy, and category are ready for the target stores.
 - Use `docs/Google-Play-Listing-Copy.md` as the draft source for Google Play
   short and full descriptions until product/design approve final copy.
+- Use `docs/Google-Play-Release-Screenshots.md` to capture and review release
+  screenshots from real app screens before uploading them to Play Console.
 - Track any brand, icon, screenshot, or store copy gaps before submission.
 
 ## Content Category and UGC

--- a/handoff/449-release-screenshots.md
+++ b/handoff/449-release-screenshots.md
@@ -1,0 +1,28 @@
+# Handoff: Issue #449 Release Screenshots
+
+Issue #449 is advanced but not solved. The remaining work requires a
+release-like build, device or emulator screenshot environment, and Play Console
+or product/design validation.
+
+## Status
+
+- Added `docs/Google-Play-Release-Screenshots.md` with capture setup, current
+  Play screenshot constraints, required screen coverage, quality review checks,
+  and an evidence log.
+- Linked the guide from `docs/Release-Checklist.md` and `docs/Home.md`.
+- Added `plans/449-release-screenshots-plan.md` for traceability.
+
+## Blockers
+
+- Final screenshots cannot be captured or accepted from this repo-only thread.
+- Current issue acceptance requires release-like build/device access and Play
+  Console dimension validation.
+
+## Next Steps
+
+1. Build and install the release candidate or equivalent signed build.
+2. Capture screenshots for onboarding/permission, schedule creation,
+   alarm/preparation, calendar/home, and My Page/account controls.
+3. Verify file format and dimensions in Play Console.
+4. Complete the evidence log in `docs/Google-Play-Release-Screenshots.md`.
+5. Close #449 only after product/design and Play Console validation.

--- a/plans/449-release-screenshots-plan.md
+++ b/plans/449-release-screenshots-plan.md
@@ -1,0 +1,38 @@
+# Issue #449 Release Screenshot Plan
+
+Issue: [#449](https://github.com/DevKor-github/OnTime-front/issues/449)
+Parent track: [#466](https://github.com/DevKor-github/OnTime-front/issues/466)
+
+## Decision
+
+Issue #449 is externally blocked for completion because final screenshots must
+be captured from a release-like build on a device or release-equivalent
+environment. The repo-side action that advances the issue is to provide a
+capture checklist, Play asset constraints, required screen matrix, and evidence
+log for the human/device capture pass.
+
+## Ordered Work
+
+1. Confirm parent-track state:
+   #446, #447, and #460 are closed; #448 and #449 remain open manual items.
+2. Confirm #449 scope:
+   capture real release screenshots covering onboarding/permission, schedule
+   creation, alarm/preparation, calendar/home, and My Page/account controls.
+3. Add a repository guide:
+   `docs/Google-Play-Release-Screenshots.md` documents setup, current Play
+   constraints, capture matrix, quality review, and evidence log.
+4. Link the guide from release docs:
+   update `docs/Release-Checklist.md` and `docs/Home.md`.
+5. Do not generate or fake screenshots:
+   completion requires human/device access and Play Console validation.
+6. Verify documentation only:
+   run a markdown/reference smoke check and inspect git diff.
+
+## Human Completion Criteria
+
+- Capture screenshots from the release candidate or equivalent signed build.
+- Validate every uploaded file in Play Console for format and dimensions.
+- Have product/design approve the selected screenshot set.
+- Update the evidence log with build, device, locale, filenames, reviewer, and
+  upload result.
+- Close #449 only after the actual screenshots are accepted for the listing.


### PR DESCRIPTION
## Summary
- Adds a Google Play release screenshot capture guide for issue #449 with setup, required screen coverage, Play asset constraints, quality checks, and an evidence log.
- Links the guide from the release checklist and docs home.
- Adds a scoped plan and handoff note because final screenshot capture remains manual.

Advances #449.
References parent track #466.

## Verification
- `git diff --check`
- Documentation-only change; Flutter tests were not run.

## Remaining human tasks
- Build and install the release candidate or equivalent signed build.
- Capture screenshots from real app screens for onboarding/permission, schedule creation, alarm/preparation, calendar/home, and My Page/account controls.
- Validate screenshot format and dimensions in Play Console.
- Have product/design approve the selected screenshot set.
- Complete the evidence log before closing #449.