### PR TITLE
[codex] Add Android release smoke test runbook

### DIFF
--- a/docs/Android-Release-Smoke-Test.md
+++ b/docs/Android-Release-Smoke-Test.md
@@ -1,0 +1,127 @@
+# Android Release Smoke Test
+
+Use this runbook for the release-device smoke test tracked by #456. It must be
+run against a signed release build installed through Google Play Internal
+Testing or another release-equivalent install path after #452 has produced the
+installable artifact.
+
+Do not close #456 from documentation alone. Close it only after a human tester
+records a completed pass with device, build, endpoint, and result evidence.
+
+## Entry Criteria
+
+- #452 is complete and the signed Android release build is available.
+- The tested build uses package `club.devkor.ontime`.
+- The build was installed from Play Internal Testing, a Play-generated APK set,
+  or an equivalent signed release install path agreed by the release owner.
+- The tester has a real Android device, a test account, and access to the
+  release API/backend signal needed to confirm endpoint and token behavior.
+- The release owner has confirmed which API base URL is approved for the smoke
+  test, such as the staging URL for internal testing or the production URL for a
+  tagged production candidate.
+
+## Build And Device Evidence
+
+Record this before testing:
+
+```md
+Issue: #456
+Parent track: #467
+Tester:
+Date:
+Install source: Play Internal Testing / signed release APK / other:
+Artifact or Play release link:
+Package name:
+Version name:
+Version code:
+Git commit or workflow run:
+ENV dart define:
+REST_API_URL value or approved endpoint name:
+Firebase project:
+Device model:
+Android version:
+Network:
+Fresh install: yes / no
+Existing app data cleared before test: yes / no
+```
+
+## Required Smoke Pass
+
+Mark each result `pass`, `fail`, or `blocked`. Attach screenshots, screen
+recordings, logs, backend request IDs, or Play/Firebase evidence for failures
+and for any endpoint verification that cannot be inferred from the app UI.
+
+| Area | Steps | Expected result | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| Install | Install the signed release build from the approved release-equivalent path. | App installs without sideload, signing, package, or Play Protect errors. | | |
+| First launch | Launch the app from a fresh install. | App opens without a crash, blank screen, Firebase init error, or missing config error. | | |
+| Login | Sign in with the test account using the release build. | Login succeeds and lands on the expected authenticated screen. | | |
+| Endpoint | Confirm the build is using the approved release API endpoint. | Backend logs, request IDs, or app configuration evidence match the approved endpoint. | | |
+| FCM token | Confirm fresh install token registration reaches the backend if backend access is available. | Backend receives token registration for the tested account/device. | | |
+| Schedule create | Create a schedule with a place, moving time, preparation, and future start time. | The schedule is saved and visible in the app. | | |
+| Schedule edit | Edit the created schedule. | Updated values persist after returning to the schedule list/detail. | | |
+| Schedule delete | Delete the created schedule. | The schedule is removed and does not reappear after refresh or app restart. | | |
+| My Page | Open My Page and review visible account/settings content. | Screen loads without release-only errors and expected content is present. | | |
+| Privacy policy | Open the privacy policy link from the app. | The link opens the approved privacy policy URL without a broken or placeholder page. | | |
+| Logout | Log out, then relaunch the app. | Session is cleared and the app returns to the signed-out flow. | | |
+| Relaunch | Force close and reopen after the smoke flow. | App starts cleanly and remains in the expected auth state. | | |
+
+## Failure Notes
+
+For every failed or blocked row, record:
+
+```md
+Area:
+Observed behavior:
+Expected behavior:
+Reproduction steps:
+Device and Android version:
+Version name and version code:
+Timestamp with timezone:
+Screenshots or recording:
+Relevant logs:
+Backend request ID or dashboard link:
+Decision: retest after fix / accept risk / block release
+Owner:
+```
+
+## Completion Note Template
+
+Post a completion note on #456 with this structure:
+
+```md
+Android release smoke test result: pass / failed / blocked
+
+Build:
+- Version name:
+- Version code:
+- Commit or workflow run:
+- Install source:
+- Artifact or Play release link:
+- ENV:
+- REST_API_URL value or approved endpoint name:
+
+Device:
+- Model:
+- Android version:
+- Network:
+
+Results:
+- Install:
+- First launch:
+- Login:
+- Endpoint verification:
+- FCM token registration:
+- Schedule create/edit/delete:
+- My Page:
+- Privacy policy link:
+- Logout:
+- Relaunch:
+
+Issues found:
+- None, or link issue numbers with reproduction notes.
+
+Evidence:
+- Screenshots/recordings/log links:
+- Backend/Play/Firebase evidence:
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -10,6 +10,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Git Workflow](./Git.md) - Git strategy and commit message formats
 - [Android Release Signing](./Android-Release-Signing.md) - Required keystore inputs and release signing validation
 - [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
+- [Android Release Smoke Test](./Android-Release-Smoke-Test.md) - Device smoke-test runbook and evidence template for signed Android release builds
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections
 

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -50,6 +50,9 @@ OnTime.
   upload key.
 - Keep keystores, passwords, and `key.properties` out of git.
 - Verify the release build fails clearly when signing secrets are missing.
+- After a signed release build is available, run the device smoke test from
+  `docs/Android-Release-Smoke-Test.md` and record the tested device, Android
+  version, build version, approved API endpoint, and pass/fail evidence.
 
 ## iOS
 

--- a/plans/issue-456-android-release-smoke-test.md
+++ b/plans/issue-456-android-release-smoke-test.md
@@ -1,0 +1,34 @@
+# Issue 456 Android Release Smoke Test Plan
+
+## Scope
+
+Issue #456 is limited to proving that a signed Android release build works on a
+real Android device before Play review. The required flow covers install, first
+launch, login, logout, schedule create/edit/delete, My Page, privacy policy
+link, approved release API endpoint verification, and recording device/build
+evidence.
+
+## Current Decision
+
+The issue remains externally blocked. The direct prerequisite, #452, is open and
+blocked until #453 locks production versioning. Without a signed release AAB or
+release-equivalent install path, a real Android device, release API/backend
+visibility, and Play/internal-testing access, this thread cannot honestly
+complete the smoke test.
+
+## Repo-Side Action
+
+Add a release smoke-test runbook and evidence template so the human tester can
+complete #456 as soon as #452 produces the signed build. Keep implementation to
+documentation; do not alter app behavior or release workflows for this issue.
+
+## Human Completion Steps
+
+1. Complete #453 and then #452 so a signed installable Android release build is
+   available.
+2. Install the build through Play Internal Testing or another approved
+   release-equivalent path.
+3. Run `docs/Android-Release-Smoke-Test.md` on a real Android device.
+4. Record device, Android version, version name, version code, install source,
+   endpoint evidence, and pass/fail results on #456.
+5. Open follow-up bugs for any failed smoke-test row before Play review.


### PR DESCRIPTION
## Summary
- Adds a #456 Android release smoke-test runbook with entry criteria, required smoke rows, failure notes, and a completion-note template.
- Links the runbook from the docs index and release checklist.
- Records the issue-specific plan under plans/.

Advances #456
Refs #467

## Verification
- git diff --check
- git diff --cached --check
- rg -n "Android Release Smoke Test|Issue 456|#456|Parent track|REST_API_URL|release-equivalent" docs/Android-Release-Smoke-Test.md docs/Home.md docs/Release-Checklist.md plans/issue-456-android-release-smoke-test.md

## Remaining human tasks
- Complete #453, then complete #452 to produce the signed release AAB or release-equivalent install path.
- Install the signed release build through Play Internal Testing or another approved release-equivalent path on a real Android device.
- Run docs/Android-Release-Smoke-Test.md and record device model, Android version, version name/code, install source, approved API endpoint evidence, smoke-test results, and any failure evidence on #456.

## Blocked status
This PR does not close #456. The actual smoke test remains externally blocked until signed-build, Play/internal-testing or equivalent install, device, test account, and backend/API evidence access are available.