### PR TITLE
docs: add backend deletion verification checklist

### DIFF
--- a/handoff/issue-439-backend-deletion-verification.md
+++ b/handoff/issue-439-backend-deletion-verification.md
@@ -1,0 +1,92 @@
+# Issue 439 Backend Deletion Verification Handoff
+
+Issue: #439, parent track #464
+Branch: `codexd/439-backend-deletion-verification`
+Status: externally blocked
+Date: 2026-05-10
+
+## Summary
+
+Repo-side review found no frontend code change that can honestly complete #439.
+The release client already routes account deletion by provider, and the remaining
+acceptance criteria require backend owner confirmation of real server-side
+deletion and retention behavior.
+
+Use this document as the evidence form for the backend owner, privacy owner, and
+release QA owner. Treat all filled-in values as release evidence.
+
+## Repo-Side Evidence Already Available
+
+- Normal account deletion uses `DELETE /users/me/delete`.
+- Google account deletion uses `DELETE /oauth2/google/me`.
+- Apple account deletion uses `DELETE /oauth2/apple/me`.
+- Optional deletion feedback is sent in the deletion request body when present.
+- The app chooses the endpoint from `GET /users/me` `socialType`.
+- PR #378 added deletion endpoint routing and tests.
+- PR #471 verified in-app deletion UX and success/failure behavior.
+
+## Backend Verification Prerequisites
+
+- Backend owner or environment operator with access to the release backend data
+  store.
+- Test accounts for every auth provider enabled in the release build:
+  - Normal account
+  - Google account
+  - Apple account
+- Agreement on the environment to verify, for example staging release candidate
+  or production-equivalent backend.
+- Privacy/product owner available to compare the verified behavior against the
+  privacy policy draft.
+
+## Provider Evidence
+
+Fill one row per auth provider that is enabled in the release build. Do not add
+Kakao unless it is active in the release build.
+
+| Provider | Endpoint Called | Environment | Test Account ID | Request Time | Response | Re-login Fails? | Owner | Evidence Link |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Normal | `DELETE /users/me/delete` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Google | `DELETE /oauth2/google/me` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| Apple | `DELETE /oauth2/apple/me` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Data Deletion and Retention Matrix
+
+Backend owner must replace `TBD` values with verified behavior. If a row is not
+part of the backend data model, mark it `N/A` and explain why.
+
+| Data Category | Backend Location | Deleted, Anonymized, Retained, or N/A | Retention Duration | Retention Reason | Verification Method | Owner |
+| --- | --- | --- | --- | --- | --- | --- |
+| User profile fields such as email, name, and social identity | TBD | TBD | TBD | TBD | TBD | TBD |
+| Password or auth credentials for normal accounts | TBD | TBD | TBD | TBD | TBD | TBD |
+| OAuth provider linkage or revoke state for Google | TBD | TBD | TBD | TBD | TBD | TBD |
+| OAuth provider linkage or revoke state for Apple | TBD | TBD | TBD | TBD | TBD | TBD |
+| Access and refresh tokens | TBD | TBD | TBD | TBD | TBD | TBD |
+| Device records and FCM tokens | TBD | TBD | TBD | TBD | TBD | TBD |
+| Alarm settings and alarm status | TBD | TBD | TBD | TBD | TBD | TBD |
+| Default preparation settings | TBD | TBD | TBD | TBD | TBD | TBD |
+| Schedules | TBD | TBD | TBD | TBD | TBD | TBD |
+| Schedule preparation steps | TBD | TBD | TBD | TBD | TBD | TBD |
+| Spare time setting | TBD | TBD | TBD | TBD | TBD | TBD |
+| General feedback sent through `/feedback` | TBD | TBD | TBD | TBD | TBD | TBD |
+| Account deletion feedback sent in delete request body | TBD | TBD | TBD | TBD | TBD | TBD |
+| Operational logs, audit logs, crash logs, analytics, or monitoring events | TBD | TBD | TBD | TBD | TBD | TBD |
+| Backups or disaster recovery snapshots | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Privacy Policy Cross-Check
+
+Before closing #439, confirm the privacy policy draft states:
+
+- Which account and app data is deleted after account deletion.
+- Which data is retained, why it is retained, and for how long.
+- Whether deletion feedback or support messages may be retained.
+- Whether logs or backups retain account-related data temporarily.
+- Which auth providers are supported in the release build.
+
+## Exact Remaining Human Tasks
+
+- Backend owner completes the provider evidence table.
+- Backend owner completes the data deletion and retention matrix.
+- Privacy/product owner reconciles the completed evidence with the privacy
+  policy draft for #434.
+- Release owner updates #439 with the completed evidence and decides whether the
+  backend behavior satisfies the acceptance criteria.

--- a/plans/issue-439-backend-deletion-verification.md
+++ b/plans/issue-439-backend-deletion-verification.md
@@ -1,0 +1,65 @@
+# Issue 439 Backend Deletion Verification Plan
+
+Issue: #439, parent track #464
+Status: externally blocked by backend owner or environment access
+Date: 2026-05-10
+
+## Goal
+
+Verify that backend account deletion removes or retains OnTime user data exactly
+as the release privacy policy will describe.
+
+## Current Repo Facts
+
+- The release track orders #439 immediately after #438.
+- #438 is closed by PR #471, which verified the in-app deletion UX.
+- PR #378 routes deletion requests through the release client endpoints and
+  includes tests for optional feedback payloads and auth-provider routing.
+- The client deletion endpoints currently used by the app are:
+  - Normal account: `DELETE /users/me/delete`
+  - Google account: `DELETE /oauth2/google/me`
+  - Apple account: `DELETE /oauth2/apple/me`
+- The app checks `GET /users/me` for `socialType` before choosing the deletion
+  endpoint.
+
+These facts verify client behavior only. They do not verify server-side data
+deletion, third-party token revocation, audit logging, backups, or retention.
+
+## Decision-Complete Plan
+
+1. Backend owner identifies every persisted data category tied to a user in the
+   release backend, including user profile, auth identity, tokens, devices, FCM
+   tokens, alarm settings, default preparations, schedules, schedule
+   preparations, feedback, deletion feedback, logs, analytics, and backups.
+2. Backend owner runs deletion for each auth provider supported in the release
+   build: normal, Google, and Apple. Do not test or document Kakao unless it is
+   enabled in the release build.
+3. For each provider, backend owner records the deletion endpoint called,
+   environment, account identifier, timestamp, response, and post-deletion
+   database/API evidence.
+4. For each data category, backend owner records whether it is deleted,
+   anonymized, retained, or not applicable, plus the retention reason and
+   duration when retained.
+5. Product or privacy owner compares the verified backend behavior with the
+   privacy policy draft before approving #434.
+6. If backend behavior and policy text diverge, fix the backend or update the
+   policy before closing #439.
+7. Once verified, use the #439 evidence to unblock #441 Data safety and #458
+   account deletion end-to-end QA.
+
+## Acceptance Mapping
+
+- Backend behavior verified for each release auth provider: requires backend
+  owner evidence for normal, Google, and Apple accounts.
+- Associated user data deletion confirmed by data type: use the evidence matrix
+  in `handoff/issue-439-backend-deletion-verification.md`.
+- Retained data and retention reason documented: use the retention columns in
+  the handoff matrix.
+- Privacy policy text matches backend behavior: complete only after #434 has a
+  policy draft and owner review against this evidence.
+
+## Exit Criteria
+
+#439 can be closed only after a backend owner or environment operator provides
+the completed evidence matrix and a product/privacy owner confirms that the
+privacy policy text matches the verified behavior.


### PR DESCRIPTION
## Summary
- Advances #439 and references parent track #464.
- Adds a decision-complete plan for backend account/data deletion verification.
- Adds a backend-owner handoff checklist with provider evidence, data deletion/retention matrix, and privacy policy cross-check tasks.

## Verification
- `git diff --cached --check` - passed before commit.
- No Flutter tests run; documentation-only change.

## Remaining Human Tasks
- Backend owner must complete provider verification for normal, Google, and Apple release auth flows.
- Backend owner must document deletion/retention behavior for each data category.
- Privacy/product owner must reconcile verified backend behavior with the privacy policy draft before #439 can close.

## Status
This PR advances #439 but does not close it because server-side deletion truth requires backend/environment access.