### PR TITLE
[codex] Add Play listing graphics checklist

### DIFF
--- a/docs/Google-Play-Listing-Graphics.md
+++ b/docs/Google-Play-Listing-Graphics.md
@@ -1,0 +1,105 @@
+# Google Play Listing Graphics
+
+Checklist status: prepared for design/product completion before Play Console
+upload.
+
+This document covers release issue #448. It does not create final artwork. Use
+it to brief the designer or release owner, validate exported assets, and confirm
+that launcher and Play listing graphics stay consistent.
+
+References checked on 2026-05-10:
+
+- [Add preview assets to showcase your app - Play Console Help](https://support.google.com/googleplay/android-developer/answer/9866151?hl=en)
+- [Metadata - Play Console Help](https://support.google.com/googleplay/android-developer/answer/9898842?hl=en)
+- [Manage your store listing, experiment, and event graphics with the Asset Library - Play Console Help](https://support.google.com/googleplay/android-developer/answer/16386748?hl=en)
+
+## Current Repo Source
+
+- Public app name: `OnTime`.
+- Android application ID: `club.devkor.ontime`.
+- Launcher source image: `assets/icons/app_icon.png`.
+- Launcher generation config: `flutter_launcher_icons.yaml`.
+- Android adaptive icon background: `#5C79FB`.
+- Generated Android launcher outputs:
+  - `android/app/src/main/res/mipmap-mdpi/ic_launcher.png` - 48 x 48, alpha.
+  - `android/app/src/main/res/mipmap-hdpi/ic_launcher.png` - 72 x 72, alpha.
+  - `android/app/src/main/res/mipmap-xhdpi/ic_launcher.png` - 96 x 96, alpha.
+  - `android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png` - 144 x 144, alpha.
+  - `android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png` - 192 x 192, alpha.
+
+## Required Asset Package
+
+Prepare these assets from the approved design source before opening the Play
+Console main store listing.
+
+| Asset | Required export | Current owner |
+| --- | --- | --- |
+| App icon | 512 x 512, 32-bit PNG with alpha, maximum 1024 KB | Design/release owner |
+| Feature graphic | 1024 x 500, JPEG or 24-bit PNG with no alpha | Design/release owner |
+| Phone screenshots | Owned by #449; minimum two screenshots, JPEG or 24-bit PNG with no alpha, each side 320-3840 px and long side no more than twice the short side | #449 owner |
+
+For better Play recommendation eligibility, prepare at least four app
+screenshots at 9:16 portrait 1080 x 1920 or 16:9 landscape 1920 x 1080. Final
+screenshots must come from real release screens under #449.
+
+## Visual Consistency Checklist
+
+- Use the approved `OnTime` launcher mark for the Play app icon.
+- Confirm the Play app icon and the installed Android launcher icon are the
+  same brand mark, colors, and shape treatment. The Play icon can be higher
+  fidelity, but it must not look like a different product.
+- If `assets/icons/app_icon.png` changes, regenerate launcher icons before
+  release:
+
+```sh
+flutter pub get
+dart run flutter_launcher_icons
+```
+
+- Re-check generated Android icons in `android/app/src/main/res/mipmap-*` and
+  `android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml`.
+- Keep the feature graphic visually related to the app icon and in-app style,
+  but do not make it a large duplicate of the icon.
+- Avoid fine details, tiny text, or edge-critical content in the feature
+  graphic because Play surfaces may crop or scale it.
+- Keep key feature graphic content near the center and background-only elements
+  near the edges.
+- Do not include store badges, ranking claims, promotional pricing, calls to
+  action, unsupported features, or third-party marks without permission.
+- Match claims to shipped functionality listed in
+  `docs/Google-Play-Listing-Copy.md`.
+- Provide Play Console alt text for the feature graphic and screenshots using
+  concise descriptions of the actual content.
+
+## Human Completion Steps
+
+1. Get design/product approval for the final launcher mark and feature graphic.
+2. Export the Play app icon and feature graphic in the required formats.
+3. Capture final screenshots through #449.
+4. Compare the uploaded Play app icon against an installed release build icon.
+5. Confirm graphics do not imply unsupported features, social/UGC behavior,
+   awards, rankings, discounts, or platform affiliations.
+6. Upload approved assets in Play Console under
+   `Grow users > Store presence > Main store listing`.
+7. Store the final source design files and upload-ready exports in the team's
+   agreed design or release asset location, and record that location in the
+   release checklist or issue comment.
+
+## Completion Evidence Template
+
+Paste this into #448 after the human work is done:
+
+```md
+## Play listing graphics completion evidence
+
+- Design source location:
+- Upload-ready asset location:
+- Play app icon: 512 x 512 PNG with alpha, <= 1024 KB: yes/no
+- Feature graphic: 1024 x 500 JPEG or 24-bit PNG without alpha: yes/no
+- Launcher icon consistency checked against installed release build: yes/no
+- Screenshots supplied by #449: yes/no
+- Unsupported feature / ranking / promotional claim review: pass/fail
+- Play Console upload completed by:
+- Date:
+- Notes:
+```

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -75,6 +75,9 @@ OnTime.
   support contact, privacy policy, and category are ready for the target stores.
 - Use `docs/Google-Play-Listing-Copy.md` as the draft source for Google Play
   short and full descriptions until product/design approve final copy.
+- Use `docs/Google-Play-Listing-Graphics.md` as the checklist for Play app
+  icon, feature graphic, screenshot asset requirements, and launcher-icon
+  consistency evidence.
 - Track any brand, icon, screenshot, or store copy gaps before submission.
 
 ## Content Category and UGC

--- a/plans/448-play-listing-graphics-plan.md
+++ b/plans/448-play-listing-graphics-plan.md
@@ -1,0 +1,55 @@
+# Issue 448 Play Listing Graphics Plan
+
+## Goal
+
+Prepare the repo-side checklist and verification path for Play listing graphics
+under release issue #448 and parent track #466.
+
+## Context
+
+- Parent issue #466 orders this after #446 app identity and #447 Play listing
+  copy.
+- Issue #448 is labeled `manual`.
+- #446 is closed and confirms the public app name is `OnTime` and Android
+  application ID is `club.devkor.ontime`.
+- #447 is closed and adds `docs/Google-Play-Listing-Copy.md` as the listing
+  copy source.
+- Current launcher source is `assets/icons/app_icon.png`, and
+  `flutter_launcher_icons.yaml` generates Android launcher icons from that
+  source with adaptive background `#5C79FB`.
+
+## Decisions
+
+- Treat final graphic production and Play Console upload as external manual
+  work because the issue requires final design/product assets or design-owner
+  input.
+- Do not fabricate feature graphics, screenshots, or Play Console assets.
+- Provide a checklist that names the current Google Play size and format
+  requirements checked on 2026-05-10, the repo launcher-icon source of truth,
+  and the consistency checks a human must run before submission.
+- Keep release screenshots out of scope except to point to #449, because that
+  sub-issue owns capturing real release screenshots.
+
+## Steps
+
+1. Inspect #466 and #448 metadata, labels, prerequisites, and comments.
+2. Confirm the active branch is `codexd/448-play-listing-graphics`.
+3. Review current launcher icon configuration and generated Android icon files.
+4. Confirm current Play listing graphic requirements from official Google Play
+   documentation.
+5. Add a scoped Play listing graphics checklist under `docs/`.
+6. Link the checklist from `docs/Release-Checklist.md`.
+7. Verify the documentation diff and commit only #448-related files.
+
+## Validation
+
+- `git diff --check`
+- `sips -g pixelWidth -g pixelHeight -g hasAlpha assets/icons/app_icon.png web/icons/Icon-512.png web/icons/Icon-192.png android/app/src/main/res/mipmap-mdpi/ic_launcher.png android/app/src/main/res/mipmap-hdpi/ic_launcher.png android/app/src/main/res/mipmap-xhdpi/ic_launcher.png android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png`
+- Manual review of `docs/Google-Play-Listing-Graphics.md` against #448
+  acceptance criteria.
+
+## Blockers
+
+- Final feature graphic and listing art require design-owner approval.
+- Play Console upload and visual comparison require human Play Console access.
+- Screenshot capture remains covered by #449.


### PR DESCRIPTION
Advances #448.

Parent track: #466.

## Summary
- Added a scoped #448 plan under `plans/`.
- Added `docs/Google-Play-Listing-Graphics.md` with current Google Play graphic requirements, launcher-icon consistency checks, and a completion evidence template.
- Linked the graphics checklist from `docs/Release-Checklist.md`.

## Verification
- `git diff --check`
- `git diff --cached --check`
- `sips -g pixelWidth -g pixelHeight -g hasAlpha assets/icons/app_icon.png web/icons/Icon-512.png web/icons/Icon-192.png android/app/src/main/res/mipmap-mdpi/ic_launcher.png android/app/src/main/res/mipmap-hdpi/ic_launcher.png android/app/src/main/res/mipmap-xhdpi/ic_launcher.png android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png`
- Confirmed current Play graphic requirements against official Google Play Console Help pages on 2026-05-10.

## Remaining human tasks
- Design/product owner must approve or produce the final Play app icon and feature graphic.
- Release owner must capture final real-app screenshots through #449.
- Release owner must compare the uploaded Play app icon against an installed release build launcher icon.
- Release owner must upload approved assets in Play Console and record the design/release asset location.

## Track status
- This PR advances the manual #448 workflow but does not close it because final art approval and Play Console upload require human access.