### PR TITLE
docs: add signed AAB blocker plan

### DIFF
--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -6,7 +6,7 @@ Android release builds must include the production Firebase client config so Fir
 
 - `ANDROID_GOOGLE_SERVICES_JSON_B64`: base64-encoded contents of the production Android `google-services.json` for Firebase project `ontime-c63f1`.
 
-The release verification workflow decodes this secret to `android/app/src/release/google-services.json` before running the Android release build. Generated `google-services.json` files are ignored and must not be committed.
+The Android Play Internal Deploy workflow decodes this secret to `android/app/src/release/google-services.json` before running the Android release build. Generated `google-services.json` files are ignored and must not be committed.
 
 The decoded file must include an Android client whose package name is `club.devkor.ontime`. Gradle validates this package match for release builds and through the focused validation task below.
 
@@ -90,4 +90,4 @@ Release SHA-1 and SHA-256 fingerprints must be added to Firebase after the relea
 
 ## Verification
 
-Use the `Android Release Verification` GitHub Actions workflow to confirm CI can reproduce the release build with the configured secret. For production readiness, also install a real Android release build and verify Firebase initializes and FCM token registration reaches the backend.
+Use the `Android Play Internal Deploy` GitHub Actions workflow to confirm CI can reproduce the signed release build with the configured secrets. For production readiness, also install a real Android release build and verify Firebase initializes and FCM token registration reaches the backend.

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -76,8 +76,8 @@ The Gradle build also accepts the legacy `ONTIME_ANDROID_KEYSTORE_PATH`,
 ## Configure CI Release Signing
 
 For GitHub Actions deploys, base64-encode the upload keystore and store it as
-the `ANDROID_UPLOAD_KEYSTORE_B64` secret in the protected `release`
-environment:
+the `ANDROID_UPLOAD_KEYSTORE_B64` secret in the protected `staging`
+environment used by the Android Play Internal Deploy workflow:
 
 ```sh
 base64 -i ~/secure/ontime-upload.jks | pbcopy

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -9,6 +9,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Project Architecture](./Architecture.md) - Understanding the project structure
 - [Git Workflow](./Git.md) - Git strategy and commit message formats
 - [Android Release Signing](./Android-Release-Signing.md) - Required keystore inputs and release signing validation
+- [Android Release Configuration](./Android-Release-Configuration.md) - Firebase config, signed AAB workflow, and Play internal deploy setup
 - [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections

--- a/plans/issue-452-signed-release-aab.md
+++ b/plans/issue-452-signed-release-aab.md
@@ -1,0 +1,103 @@
+# Issue #452 Signed Release AAB Plan
+
+Parent track: #467
+Sub-issue: #452 - Build a signed release Android App Bundle
+
+## Current Status
+
+#452 remains externally blocked until all prerequisites are complete and release
+secrets are available to the release owner or the protected GitHub Actions
+environment.
+
+Prerequisite status checked on 2026-05-10:
+
+- #450 release signing ownership and secret process: closed.
+- #451 release Firebase/Google services config process: closed.
+- #453 initial production versioning: open, so #452 must not be closed.
+
+The repository already has Gradle checks for release Firebase config and release
+signing inputs, plus the `Android Play Internal Deploy` workflow that builds a
+signed AAB when the configured environment secrets and variables are present.
+
+## Decision-Complete Plan
+
+1. Wait for #453 to close with the approved public `versionName` and Android
+   `versionCode` rule for the first production upload.
+2. Confirm the `staging` GitHub environment has these secrets:
+   - `ANDROID_GOOGLE_SERVICES_JSON_B64`
+   - `ANDROID_UPLOAD_KEYSTORE_B64`
+   - `ANDROID_KEYSTORE_PASSWORD`
+   - `ANDROID_KEY_ALIAS`
+   - `ANDROID_KEY_PASSWORD`
+   - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+3. Confirm the `staging` GitHub environment has `REST_API_URL` set to the
+   approved release-candidate API base URL.
+4. From `main`, run the `Android Play Internal Deploy` workflow.
+5. Confirm the workflow passes:
+   - `flutter pub get`
+   - `dart run build_runner build --delete-conflicting-outputs`
+   - generated-file drift check
+   - `flutter analyze`
+   - `flutter test`
+   - `flutter build appbundle --release`
+6. Record the signed AAB evidence:
+   - workflow run URL
+   - artifact name: `ontime-android-release-aab`
+   - artifact path inside the run: `build/app/outputs/bundle/release/app-release.aab`
+   - version name
+   - generated Android version code
+   - target environment and `REST_API_URL` ownership confirmation
+7. Keep #452 open if any required secret, environment variable, versioning
+   decision, or Play upload permission is unavailable.
+
+## Local Build Alternative
+
+Use this only when the release owner has local access to the upload keystore,
+passwords, production Firebase config, and approved version values:
+
+```sh
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
+flutter analyze
+flutter test
+
+mkdir -p android/app/src/release
+base64 --decode android-google-services.json.b64 > android/app/src/release/google-services.json
+
+export ANDROID_KEYSTORE_PATH=/absolute/path/to/ontime-upload.jks
+export ANDROID_KEYSTORE_PASSWORD='<keystore-password>'
+export ANDROID_KEY_ALIAS=ontime
+export ANDROID_KEY_PASSWORD='<key-password>'
+
+flutter build appbundle --release \
+  --build-name=<approved version name> \
+  --build-number=<approved monotonic Android versionCode> \
+  --dart-define=ENV=staging \
+  --dart-define=REST_API_URL=<approved release-candidate api url>
+```
+
+On macOS, use `base64 -D` instead of `base64 --decode`.
+
+## Handoff Evidence Template
+
+```text
+#452 signed AAB evidence
+- Workflow run URL:
+- Git commit SHA:
+- Version name:
+- Android version code:
+- Build environment: staging
+- REST_API_URL owner-confirmed: yes/no
+- AAB artifact name: ontime-android-release-aab
+- AAB artifact path: build/app/outputs/bundle/release/app-release.aab
+- Follow-up issue unblocked: #456
+- Remaining blockers, if any:
+```
+
+## Out Of Scope
+
+- Choosing or changing the production version; that belongs to #453.
+- Creating, rotating, or disclosing signing keys.
+- Committing `google-services.json`, keystores, passwords, or generated AABs.
+- Verifying Play App Signing fingerprints; that belongs to #454.
+- Device smoke testing; that belongs to #456.


### PR DESCRIPTION
## Summary
- Advances #452 by adding an issue-scoped signed AAB blocker/runbook plan under plans/.
- Aligns Android release docs with the actual Android Play Internal Deploy workflow and its staging environment.
- Links Android release configuration from the docs index.

Refs #452
Refs #467

## Verification
- git diff --check
- git diff --cached --check
- rg -n 'Android Release Verification|protected `release`|Android Play Internal Deploy|#452|#453|ontime-android-release-aab' docs plans .github/workflows
- flutter pub get
- flutter build appbundle --release: failed as expected before artifact creation because android/app/src/release/google-services.json / ANDROID_GOOGLE_SERVICES_JSON_B64 is unavailable in this checkout.

## Remaining Human Tasks
- Close #453 with the approved first-release versioning decision.
- Configure/confirm protected GitHub environment secrets: ANDROID_GOOGLE_SERVICES_JSON_B64, ANDROID_UPLOAD_KEYSTORE_B64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD, GOOGLE_PLAY_SERVICE_ACCOUNT_JSON.
- Configure/confirm REST_API_URL for the release-candidate environment.
- Run Android Play Internal Deploy from main and record the AAB artifact evidence.

## Status
This PR advances #452 but does not solve or close it. #452 remains blocked until #453 and release secrets/environment access are complete.