### PR TITLE
[Release] Add Play pre-launch report runbook

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -10,6 +10,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Git Workflow](./Git.md) - Git strategy and commit message formats
 - [Android Release Signing](./Android-Release-Signing.md) - Required keystore inputs and release signing validation
 - [iOS Release Configuration](./iOS-Release-Configuration.md) - Required Dart defines and archive validation
+- [Play Pre-Launch Report](./Play-Pre-Launch-Report.md) - Google Play report runbook, triage gate, and evidence template
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections
 

--- a/docs/Play-Pre-Launch-Report.md
+++ b/docs/Play-Pre-Launch-Report.md
@@ -1,0 +1,96 @@
+# Play Pre-Launch Report
+
+Use this runbook after a signed Android App Bundle has been uploaded to Google
+Play Internal Testing or Closed Testing. It is the release gate for issue #459.
+
+## Prerequisites
+
+- #452 is complete: a signed release AAB has been uploaded to an internal or
+  closed testing track for `club.devkor.ontime`.
+- The uploaded build uses the intended version name and Play `versionCode`.
+- The release owner has Google Play Console access for the app.
+- The release owner can file or assign follow-up issues for any blocking
+  findings.
+
+Do not close #459 before the actual Play Console report exists. Codex may help
+triage exported report text, screenshots, or issue details, but cannot run the
+report without Play Console access.
+
+## Run The Report
+
+1. Open Google Play Console for `club.devkor.ontime`.
+2. Confirm the internal or closed testing release contains the intended AAB.
+3. Open the release or testing track pre-launch report.
+4. If the report has not finished, wait for completion before making the
+   release decision.
+5. Save the report URL or screenshots in the release tracking thread.
+6. Record the devices, Android versions, locales, and test account state covered
+   by the report when Play Console exposes them.
+
+## Triage Expectations
+
+Treat these as release-blocking unless the release owner explicitly accepts the
+risk in writing:
+
+- Crash on launch, login, notification permission flow, schedule creation,
+  schedule edit/delete, My Page, or privacy policy navigation.
+- ANR during startup, authentication, schedule/preparation flows, notification
+  prompts, or alarm-related flows.
+- Policy warning, app content warning, SDK warning, permission warning, or
+  Play account warning tied to the uploaded build.
+- Severe accessibility finding that prevents core navigation, authentication,
+  schedule management, or required disclosure access.
+- Device-specific failure on a common Android version or device profile that is
+  likely to affect real testers.
+
+Non-blocking findings still need a recorded owner decision. Prefer follow-up
+issues for cosmetic accessibility warnings, device-specific rendering glitches,
+or low-risk warnings that do not prevent internal testing.
+
+## Evidence Template
+
+Use this template in the release tracking thread, PR, or issue comment before
+closing #459:
+
+```md
+Pre-launch report evidence
+
+App:
+Package:
+Track:
+Version name:
+Version code:
+AAB source:
+Play Console report URL:
+Report completed at:
+Release owner:
+
+Summary:
+- Crashes:
+- ANRs:
+- Policy/app content warnings:
+- Severe accessibility warnings:
+- Device or OS-specific failures:
+
+Blocking findings:
+- None / <link issue, owner, and decision>
+
+Accepted risks:
+- None / <finding, reason, owner approval>
+
+Follow-up issues:
+- None / <issue links>
+
+Release decision:
+- Continue internal testing / hold release / upload fixed build
+```
+
+## Closure Checklist
+
+- The report completed for the intended uploaded build.
+- Crashes and ANRs are reviewed.
+- Policy and app content warnings are reviewed.
+- Severe accessibility warnings are reviewed.
+- Release-blocking findings are fixed in a new build or explicitly accepted by
+  the release owner.
+- Evidence is recorded in the release tracking thread or #459.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -50,6 +50,9 @@ OnTime.
   upload key.
 - Keep keystores, passwords, and `key.properties` out of git.
 - Verify the release build fails clearly when signing secrets are missing.
+- After the signed AAB is uploaded to internal or closed testing, run the Google
+  Play pre-launch report and record evidence using
+  `docs/Play-Pre-Launch-Report.md` before widening release availability.
 
 ## iOS
 

--- a/plans/459-pre-launch-report-plan.md
+++ b/plans/459-pre-launch-report-plan.md
@@ -1,0 +1,40 @@
+# Issue 459 Pre-Launch Report Plan
+
+Issue: #459 - Run Play Console pre-launch report and resolve blockers
+Parent track: #467 - Android release build and Play setup
+
+## Current Decision
+
+#459 is externally blocked, not repo-solvable, until a signed Android App Bundle
+has been uploaded to a Google Play internal or closed testing track. The direct
+prerequisite #452 is still open, and #452 also depends on #453 versioning.
+
+Codex cannot run the Play Console pre-launch report without Play Console access
+and an uploaded release artifact. The useful repo-side work is to provide a
+repeatable release-owner runbook and evidence template for the report.
+
+## Scope
+
+- Add documentation for running the Play Console pre-launch report.
+- Define the evidence to record before closing #459.
+- Define release-blocking triage expectations for crashes, ANRs, policy
+  warnings, and severe accessibility findings.
+- Keep signed AAB production, Play upload, device smoke testing, and actual
+  report execution out of scope.
+
+## Implementation Steps
+
+1. Add `docs/Play-Pre-Launch-Report.md`.
+2. Link the new runbook from `docs/Home.md`.
+3. Add a release-checklist pointer for the Play pre-launch report gate.
+4. Verify documentation changes with `git diff --check`.
+
+## Human Tasks Remaining
+
+- Complete #453 and #452 so a signed release AAB exists and is uploaded to
+  internal or closed testing.
+- Use Play Console access to run or wait for the pre-launch report for the
+  uploaded build.
+- Record report evidence using the template in the runbook.
+- Fix release-blocking app findings in follow-up issues or explicitly accept
+  non-blocking findings as the release owner.


### PR DESCRIPTION
Advances #459.
Refs #467.

## Summary
- Add a Play Console pre-launch report runbook for the #459 release gate.
- Add an evidence template covering report URL, build identity, crashes, ANRs, policy warnings, severe accessibility warnings, accepted risks, and follow-up issues.
- Link the runbook from the docs index and release checklist.
- Record the issue-specific plan under `plans/`.

## Verification
- `git diff --check`

## Remaining human tasks
- Complete #453 and #452 so the signed release AAB exists and is uploaded to Google Play Internal Testing or Closed Testing.
- Use Play Console access to run or wait for the pre-launch report for the uploaded build.
- Record evidence using `docs/Play-Pre-Launch-Report.md`.
- Fix release-blocking findings in follow-up issues or explicitly accept non-blocking findings as the release owner.

## Status
This PR advances #459 with the repo artifact Codex can produce, but #459 remains externally blocked until Play Console access and the uploaded AAB are available.
