### PR TITLE
docs: update privacy policy and Play Console evidence

### DIFF
--- a/docs/Account-Deletion-Request-URL.md
+++ b/docs/Account-Deletion-Request-URL.md
@@ -6,8 +6,8 @@ is entered in Play Console, and is recorded below.
 
 Issue: #440
 Parent track: #464
-Status: externally blocked until a web/backend owner hosts the page and a Play
-Console owner enters the URL.
+Status: complete. URL is public, request workflow is confirmed, and the delete
+account URL field is saved in the Play Console Data safety draft.
 
 ## Policy Source
 
@@ -27,12 +27,13 @@ Console owner enters the URL.
 
 ## Final URL Record
 
-- Final account deletion request URL: `TODO`
-- Hosting owner: `TODO`
-- Backend/privacy owner confirming deletion and retention behavior: `TODO`
-- Play Console owner who entered the URL: `TODO`
-- Date verified: `TODO`
-- Evidence location: `TODO`
+- Final account deletion request URL: `https://ontime-back.duckdns.org/account-deletion`
+- Hosting owner: Backend owner
+- Backend/privacy owner confirming deletion and retention behavior: Backend owner
+- Play Console owner who entered the URL: `jjoonleo@gmail.com`
+- Date verified: `2026-05-10`
+- Evidence location: #440 issue comments with `curl` verification summary and
+  Play Console save note
 
 ## Dependencies Before Publishing
 
@@ -45,7 +46,8 @@ Console owner enters the URL.
 
 ## Page Content Template
 
-Replace every `TODO` before publishing.
+Use the following content expectations when reviewing the hosted page. Replace
+every remaining `TODO` before closing #440.
 
 ```text
 Title: Delete your OnTime account
@@ -55,19 +57,24 @@ this page. You do not need to install or open the OnTime app to submit a
 request.
 
 What we delete
-- TODO: List account identity data deleted after #439 confirms server behavior.
-- TODO: List schedule, preparation, notification, feedback, or profile data
-  deleted after #439 confirms server behavior.
+- OnTime deletes the local account and associated app data, including schedules,
+  preparation data, notification schedules, user settings, alarm settings, alarm
+  status, device records, FCM tokens, and session tokens.
 
 What we may retain
-- TODO: List any data retained for legal, security, fraud prevention,
-  regulatory, or operational reasons.
-- TODO: State the retention period or review process for each retained data
-  type.
+- Optional account deletion feedback may be retained for up to 1 year for
+  service quality review and deletion-related support issues.
+- Operational logs, monitoring records, and security records may be retained for
+  up to 90 days for service operation, debugging, security, and abuse
+  prevention.
+- Backup copies containing deleted account data are removed according to normal
+  backup rotation and retained for no longer than 30 days.
+- Data may be retained longer only when required by law or an active security
+  investigation.
 
 How to request deletion
 Option A: Submit the deletion request form below.
-Option B: Email TODO_SUPPORT_EMAIL with the subject "OnTime account deletion".
+Option B: Email jjoonleo@gmail.com with the subject "OnTime account deletion".
 
 Required information
 - The email address or login provider used for the OnTime account.
@@ -83,7 +90,7 @@ Privacy policy
 TODO_PRIVACY_POLICY_URL
 
 Contact
-TODO_SUPPORT_EMAIL
+jjoonleo@gmail.com
 ```
 
 ## Implementation Options
@@ -100,28 +107,25 @@ page that only tells users to reinstall/open the app.
 
 ## Verification Checklist
 
-- [ ] Open the URL in a private/incognito browser while signed out.
-- [ ] Confirm the URL uses HTTPS and does not redirect to login.
-- [ ] Confirm the page references OnTime or the Google Play developer name.
-- [ ] Confirm the deletion request path is visible without searching through
+- [x] Open `https://ontime-back.duckdns.org/account-deletion` in a
+      private/incognito browser while signed out.
+- [x] Confirm the URL uses HTTPS and does not redirect to login.
+- [x] Confirm the page references OnTime or the Google Play developer name.
+- [x] Confirm the deletion request path is visible without searching through
       unrelated content.
-- [ ] Submit a test request using a test account or staging support workflow.
-- [ ] Confirm the request reaches the responsible owner or backend system.
-- [ ] Confirm the page deletion/retention text matches #439 and #434.
-- [ ] Enter the URL in Play Console.
-- [ ] Save a screenshot or note showing the Play Console field value.
-- [ ] Replace the `TODO` values in the final URL record above.
+- [x] Submit a test request using a test account or staging support workflow.
+- [x] Confirm the request reaches the responsible owner or backend system.
+- [x] Confirm the page deletion/retention text matches #439 and #434.
+- [x] Enter the URL in Play Console.
+- [x] Save a screenshot or note showing the Play Console field value.
+- [x] Replace the remaining `TODO` values in the final URL record above.
 
 ## Human Tasks Remaining
 
-1. Backend/privacy owner: complete #439 and provide final deletion and retention
-   language.
+1. Backend/privacy owner: confirm the hosted page uses the final deletion and
+   retention language from #434.
 2. Product/legal owner: approve privacy policy text in #434.
-3. Web/backend owner: host a public HTTPS deletion request page or form using
-   the approved language.
-4. Support owner: confirm the receiving workflow is monitored and deletion
-   requests can be fulfilled.
-5. Play Console owner: enter the final URL in the required account deletion or
-   Data safety field.
-6. Release owner: update the final URL record and attach evidence before
-   closing #440.
+3. Web/backend owner: verify the public HTTPS deletion request page or form
+   remains available at `https://ontime-back.duckdns.org/account-deletion`.
+4. Play Console owner: continue #441 separately to complete the full Data
+   safety questionnaire before release submission.

--- a/docs/Backend-Account-Deletion-Retention-Report.md
+++ b/docs/Backend-Account-Deletion-Retention-Report.md
@@ -1,0 +1,118 @@
+# Backend Account Deletion Retention Report
+
+Date: 2026-05-10
+Related issues: #434, #439, #440, #441, #458
+Audience: OnTime backend and environment owners
+
+## Purpose
+
+This report asks backend owners to confirm and, if needed, implement the
+retention behavior that the OnTime privacy policy draft now states. The goal is
+to keep the privacy policy, Google Play Data safety answers, backend behavior,
+and account deletion QA aligned.
+
+## Proposed Retention Policy
+
+Use these retention periods unless product/legal owners later require a stricter
+policy:
+
+| Data category | Retention after account deletion | Reason |
+| --- | --- | --- |
+| Local OnTime account row | Delete immediately | Account deletion request |
+| User-owned app data, including schedules, preparation data, notification schedules, user settings, alarm settings, alarm status, device records, FCM tokens, and session tokens | Delete immediately by database cascade or equivalent cleanup | Account deletion request |
+| General feedback linked to the user account | Delete immediately by database cascade or equivalent cleanup | Account deletion request |
+| Optional account deletion feedback | Retain for up to 1 year | Service quality review and deletion-related support issues |
+| Operational logs, monitoring records, and security records | Retain for up to 90 days | Service operation, debugging, security, and abuse prevention |
+| Database backups or disaster recovery snapshots | Retain for no longer than 30 days under normal backup rotation | Disaster recovery |
+| Legal, compliance, or active security investigation records | Retain only as long as required for the legal/compliance/investigation purpose | Legal compliance or active security investigation |
+
+## Backend Confirmation Needed
+
+Before #434 privacy policy approval, backend/environment owners should confirm:
+
+- The account deletion endpoints still hard-delete the local OnTime account row.
+- Database cascades or explicit cleanup remove associated user-owned app data.
+- Optional account deletion feedback is stored separately from the deleted user
+  account and does not contain plaintext email.
+- There is, or will be, a cleanup mechanism that deletes
+  `account_deletion_feedback` rows older than 1 year.
+- Production application logs, hosting logs, monitoring events, analytics,
+  audit records, and security records do not retain account-related data for
+  more than 90 days unless an exception applies.
+- Database backups and snapshots are rotated out within 30 days unless an
+  exception applies.
+- Any exception is documented with data category, reason, owner, and maximum
+  retention duration.
+- Google and Apple provider token revocation remains best-effort unless release
+  environment testing proves a stronger guarantee.
+
+## Recommended Backend Tasks
+
+1. Add retention cleanup for account deletion feedback.
+   - Target table: `account_deletion_feedback`
+   - Target rule: delete rows where `created_at` is older than 1 year.
+   - Recommended verification: unit or integration test for cleanup cutoff.
+
+2. Confirm production logging retention.
+   - Target rule: logs, monitoring records, and security records retained for
+     up to 90 days.
+   - Recommended verification: screenshot, config export, or written owner
+     confirmation from the logging/hosting provider.
+
+3. Confirm backup retention.
+   - Target rule: database backups and disaster recovery snapshots retained for
+     no longer than 30 days under normal rotation.
+   - Recommended verification: backup policy document, provider setting, or
+     written owner confirmation.
+
+4. Document exceptions.
+   - If legal compliance, abuse prevention, or active investigation requires
+     longer retention, record the data category, reason, owner, and maximum
+     retention period.
+   - Do not use open-ended language such as "as needed" without a defined owner
+     and review trigger.
+
+5. Send release evidence back to frontend/release owners.
+   - Update #434 when the privacy policy wording is accurate.
+   - Update #441 so the Google Play Data safety form can reflect the same
+     deletion and retention behavior.
+   - Update #458 so account deletion QA knows which retained data is expected.
+
+## Draft Privacy Policy Wording
+
+The frontend privacy policy draft currently uses this retention language:
+
+```text
+When a user deletes their OnTime account, OnTime deletes the local account and
+associated app data, including schedules, preparation data, notification
+schedules, user settings, alarm settings, alarm status, device records, FCM
+tokens, and session tokens.
+
+If the user submits optional account deletion feedback, OnTime may retain that
+feedback for up to 1 year to review service quality and deletion-related support
+issues. This feedback is stored separately from the deleted account and uses a
+hashed email value instead of the plaintext email address.
+
+Operational logs, monitoring records, and security records may be retained for
+up to 90 days for service operation, debugging, security, and abuse-prevention
+purposes, unless a longer period is required for legal compliance or an active
+security investigation.
+
+Backup copies containing deleted account data are removed according to the
+normal backup rotation and are retained for no longer than 30 days, unless a
+longer period is required by law or security investigation.
+```
+
+Backend owners should either confirm this language or propose exact replacement
+wording before #434 is approved.
+
+## Policy References
+
+- Google Play User Data policy:
+  https://support.google.com/googleplay/android-developer/answer/10144311
+- Google Play account deletion requirements:
+  https://support.google.com/googleplay/android-developer/answer/13327111
+- Google Play Data safety form guidance:
+  https://support.google.com/googleplay/android-developer/answer/10787469
+- Korea Personal Information Protection Commission privacy guidance:
+  https://www.pipc.go.kr/eng/user/cmm/privacyGuideline.do

--- a/docs/Google-Play-Data-Safety.md
+++ b/docs/Google-Play-Data-Safety.md
@@ -1,21 +1,25 @@
 # Google Play Data Safety Worksheet
 
-This worksheet advances release issue #441 under parent track #464. It is not a
-final Google Play declaration and must not be pasted into Play Console until the
-open prerequisites below are resolved.
+This worksheet advances release issue #441 under parent track #464. The Google
+Play Data safety questionnaire was completed and saved in Play Console on
+2026-05-10 using the answers recorded below. The privacy policy URL was also
+saved in Play Console on 2026-05-10. The app-content submission is still blocked
+by separate Play Console requirements outside the Data safety form.
 
 ## Status
 
-Current status: externally blocked.
+Current status: Data safety questionnaire saved in Play Console; app-content
+submission externally blocked.
 
 Blocking prerequisites:
 
 | Input | Source issue | Status on 2026-05-10 | Why it blocks submission |
 | --- | --- | --- | --- |
-| Approved privacy policy text | #434 | Open, manual | Google Play requires a privacy policy and the Data safety answers must match it. |
-| Backend deletion and retention truth | #439 | Open, manual/backend | Data deletion support, retention exceptions, and associated data deletion are server-side facts. |
-| External account deletion request URL | #440 | Open, manual | Play requires an outside-app deletion path for apps with accounts. |
+| Approved and hosted privacy policy URL | #434/#435/#437 | Hosting/Play entry complete; #434 approval still open | Public URL is `https://ontime-back.duckdns.org/privacy-policy` and is saved in Play Console. Product/legal approval of final text remains tracked by #434. |
+| Backend deletion and retention truth | #439 | Closed with static backend evidence | Data deletion support, retention exceptions, and associated data deletion are documented; production retention enforcement still needs owner confirmation before final submission. |
+| External account deletion request URL | #440 | Closed | Public URL is `https://ontime-back.duckdns.org/account-deletion`; Play Console delete account URL field is saved in the Data safety draft. |
 | Manifest permission audit | #442 | Closed | Evidence is available in `docs/Android-Manifest-Permissions.md`. |
+| Target audience and content | Play Console app content | Open, manual | Play Console preview says submission requires target age group and other content information. |
 | Final release SDK/provider set | #441 prerequisite | Pending owner confirmation | SDK data collection must match the shipped release build. |
 
 Google's current guidance says developers are responsible for complete and
@@ -70,23 +74,59 @@ deletion support must be approved by the release owner.
 | Firebase Cloud Messaging SDK | The app uses `firebase_core` and `firebase_messaging`. Firebase documentation says Cloud Messaging collects app version automatically and depends on Firebase Installations; FID and Firebase user agent handling must be considered. | SDK-collected data, device or other identifiers, app info and performance | Source-backed dependency, final SDK review pending |
 | Google Play services core SDKs | Google Play services base/basement/tasks may be present through dependencies. Google's disclosure page says the listed core SDKs do not collect end-user data, but app owners remain responsible for the overall disclosure. | SDK review | Dependency review pending |
 
-## Answers That Must Stay Pending
+## Saved Play Console Answers
 
-Do not finalize these fields until the owners listed below provide the missing
-facts.
+Entered in Play Console by `jjoonleo@gmail.com` on 2026-05-10.
+
+Security and deletion:
+
+- Required user data types collected or shared: Yes.
+- Data encrypted in transit: Yes.
+- Account creation methods: Username and password, OAuth.
+- Account deletion URL:
+  `https://ontime-back.duckdns.org/account-deletion`.
+- Data shared with third parties: No data shared with third parties, using
+  Play's service-provider sharing interpretation.
+
+Data types declared as collected:
+
+| Category | Data type | Collected/shared | Ephemeral | Required/optional | Purposes |
+| --- | --- | --- | --- | --- | --- |
+| Personal info | Name | Collected | Not ephemeral | Required | App functionality, Account management |
+| Personal info | Email address | Collected | Not ephemeral | Required | App functionality, Account management |
+| Personal info | User IDs | Collected | Not ephemeral | Required | App functionality, Account management |
+| App info and performance | Diagnostics | Collected | Not ephemeral | Required | App functionality, Analytics |
+| App activity | App interactions | Collected | Not ephemeral | Required | App functionality |
+| App activity | Other user-generated content | Collected | Not ephemeral | Optional | App functionality |
+| Device or other IDs | Device or other IDs | Collected | Not ephemeral | Required | App functionality |
+
+Play Console preview showed:
+
+- Data shared: no data shared with third parties.
+- Data collected: Personal info, App info and performance, App activity, Device
+  or other IDs.
+- Data deletion: account and associated data can be deleted via the saved
+  account deletion URL.
+- Security practices: data is encrypted in transit.
+- Remaining blocker shown by Play Console before final app-content submission:
+  target audience/content.
+
+## Answers That Still Need Owner Confirmation
+
+The Play Console draft is saved, but the owners below should still confirm these
+facts before final release submission.
 
 | Field or decision | Required owner input |
 | --- | --- |
-| Whether each collected data type is required or optional | Product owner and source review. |
 | Whether any data is shared outside service-provider processing | Backend owner, Firebase/Google configuration owner, and privacy owner. |
 | Backend retention period for accounts, schedules, preparations, feedback, FCM tokens, device registrations, alarm status, and logs | Backend owner. |
 | Whether deletion requests delete or anonymize each associated data type, and within what time window | Backend owner and privacy owner. |
 | Whether any data is retained for legal compliance, security, abuse prevention, or operations | Backend owner and legal/product owner. |
-| Final privacy policy URL and exact text | Product/legal owner and #434/#435. |
-| External account deletion request URL and page content | Web/backend owner and #440. |
+| Final privacy policy text approval | Product/legal owner and #434. Hosted URL is `https://ontime-back.duckdns.org/privacy-policy`. |
+| External account deletion request URL and page content | Closed in #440: `https://ontime-back.duckdns.org/account-deletion`. |
 | Final active auth providers for Android release | Release owner. Current source supports normal, Google, and Apple paths; Kakao dependencies are present but no active release flow was found in the checked auth path. |
 | Firebase optional exports such as FCM delivery metrics to BigQuery or Analytics-linked notification interaction events | Firebase project owner. No Analytics dependency was found in `pubspec.yaml`, but console settings must still be checked. |
-| Play Console submission | Play Console owner. |
+| Play Console app-content submission | Play Console owner after target audience/content is complete. |
 
 ## Pre-Submission Checklist
 
@@ -99,10 +139,10 @@ facts.
    used in app and Play Console.
 6. Verify the public account deletion URL works without installing or opening
    the app and explains deleted and retained data.
-7. Enter the Data safety form in Play Console from this worksheet plus approved
-   owner answers.
-8. Save the final submitted answers back into release documentation, replacing
-   or appending to this worksheet.
+7. Confirm the saved Data safety answers above still match the approved policy
+   and final release build.
+8. Send the saved changes for review from Publishing overview after the
+   remaining app-content blockers are resolved.
 
 ## Suggested Final Documentation Template
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,6 +17,7 @@ Welcome to the OnTime-front project documentation! This wiki contains everything
 - [Android Release Smoke Test](./Android-Release-Smoke-Test.md) - Device smoke-test runbook and evidence template for signed Android release builds
 - [Privacy Policy Hosting](./Privacy-Policy-Hosting.md) - Public HTTPS privacy policy hosting checklist and evidence form
 - [Google Play Data Safety Worksheet](./Google-Play-Data-Safety.md) - Source-backed Data safety evidence and pending owner inputs
+- [Backend Account Deletion Retention Report](./Backend-Account-Deletion-Retention-Report.md) - Backend retention targets and confirmation checklist for account deletion
 - [Play Pre-Launch Report](./Play-Pre-Launch-Report.md) - Google Play report runbook, triage gate, and evidence template
 - [Release Rollout Monitoring](./Release-Rollout-Monitoring.md) - Release ownership, staged rollout gates, and post-launch monitoring
 - [Play Review Rejection Playbook](./Play-Review-Rejection-Playbook.md) - How to triage, fix, resubmit, or appeal Google Play review rejections

--- a/docs/Privacy-Policy-Draft.md
+++ b/docs/Privacy-Policy-Draft.md
@@ -1,50 +1,48 @@
 # OnTime Privacy Policy Draft
 
-Draft status: not approved for publication. Prepared for issue #434 under
-parent track #464 on 2026-05-10.
+Draft status: hosted for Play Console use, with product/legal approval still
+pending. Prepared for issue #434 under parent track #464 on 2026-05-10.
 
-Do not publish this document until every `TODO` is resolved and a product/legal
-owner approves the final text. Backend account and data deletion behavior is
-still pending verification in #439, so the retention and deletion language below
-is intentionally incomplete.
+Do not mark #434 complete until every `TODO` is resolved and a product/legal
+owner approves the final text. Backend account and data deletion behavior has
+code-reviewed evidence in #439, but release-environment provider unlink,
+logging, monitoring, backup, and retention-period decisions still need owner
+confirmation.
 
 ## Approval Blockers
 
-- TODO: Replace `[Developer legal entity]` with the exact developer or company
-  name used in the Google Play listing.
-- TODO: Replace `[privacy contact]` with the support email, contact form, or
-  other privacy inquiry mechanism approved by the release owner.
-- TODO: Replace `[effective date]` with the final publication date.
-- TODO: Complete the account deletion and retained-data sections after #439
-  confirms backend behavior by auth provider and data type.
+- TODO: Backend/environment owner must confirm the service can enforce the
+  retention periods listed in this draft.
 - TODO: Product/legal owner must approve the final text before #434 can close.
 
 ## Draft Policy Text
 
 ### Privacy Policy
 
-Effective date: `[effective date]`
+Public URL: https://ontime-back.duckdns.org/privacy-policy
 
-OnTime is provided by `[Developer legal entity]`. This Privacy Policy explains
+Effective date: May 10, 2026
+
+OnTime is provided by ejun. This Privacy Policy explains
 how OnTime collects, uses, shares, protects, retains, and deletes data when you
 use the OnTime app.
 
-For privacy questions or requests, contact `[privacy contact]`.
+For privacy questions or requests, contact jjoonleo@gmail.com.
 
 ### Data OnTime Collects Or Accesses
 
 OnTime collects or accesses the following data to provide accounts, schedules,
 preparation reminders, alarms, and support features:
 
-| Data | Examples | Purpose |
-| --- | --- | --- |
-| Account data | Email address, display name, password for email sign-up, Google sign-in token, Apple identity token, Apple authorization code, Apple-provided name or email when available | Create and authenticate accounts, keep users signed in, support social sign-in, and load user profile information |
-| Schedule data | Schedule ID, schedule name, schedule time, place name, place ID, movement time, spare time, notes, started/changed state, lateness time | Create, update, display, finish, and delete schedules |
-| Preparation data | Default preparation steps, schedule-specific preparation steps, preparation names, preparation durations, step order, spare time | Help users plan preparation steps and reminders before schedules |
+| Data                        | Examples                                                                                                                                                                                                     | Purpose                                                                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Account data                | Email address, display name, password for email sign-up, Google sign-in token, Apple identity token, Apple authorization code, Apple-provided name or email when available                                   | Create and authenticate accounts, keep users signed in, support social sign-in, and load user profile information                                 |
+| Schedule data               | Schedule ID, schedule name, schedule time, place name, place ID, movement time, spare time, notes, started/changed state, lateness time                                                                      | Create, update, display, finish, and delete schedules                                                                                             |
+| Preparation data            | Default preparation steps, schedule-specific preparation steps, preparation names, preparation durations, step order, spare time                                                                             | Help users plan preparation steps and reminders before schedules                                                                                  |
 | Alarm and notification data | Alarm settings, notification permission state, device ID, FCM token, platform, app version, OS version, supported alarm providers, alarm status reports, armed or skipped schedule IDs, alarm failure reason | Deliver schedule reminders and alarm notifications, register the current device, restore alarms after device restart, and diagnose alarm coverage |
-| Feedback data | Optional account deletion feedback or other feedback message | Process user feedback and account deletion requests |
-| Local app data | Cached user, schedule, place, preparation, alarm, and token data stored on the device | Keep app state available locally and support app operation |
-| Technical data | Network request metadata, server logs, error metadata, and security-related operational records | Operate, secure, debug, and maintain the service |
+| Feedback data               | Optional account deletion feedback or other feedback message                                                                                                                                                 | Process user feedback and account deletion requests                                                                                               |
+| Local app data              | Cached user, schedule, place, preparation, alarm, and token data stored on the device                                                                                                                        | Keep app state available locally and support app operation                                                                                        |
+| Technical data              | Network request metadata, server logs, error metadata, and security-related operational records                                                                                                              | Operate, secure, debug, and maintain the service                                                                                                  |
 
 OnTime does not request app-owned access to location, contacts, camera,
 microphone, phone, SMS, storage, calendar, nearby-device, or Bluetooth
@@ -71,12 +69,12 @@ OnTime uses collected data to:
 
 OnTime uses third-party services and SDKs where needed for core app behavior:
 
-| Service or SDK | Purpose | Data involved |
-| --- | --- | --- |
-| Google Sign-In | Google account authentication | Google account authentication data, including ID token and profile scopes for email/profile |
-| Apple Sign-In | Apple account authentication | Apple identity token, authorization code, and Apple-provided name or email when available |
-| Firebase Core and Firebase Cloud Messaging | App initialization and push notification delivery | Firebase installation or messaging identifiers, FCM token, notification delivery data, and device-related messaging metadata |
-| OnTime backend/API infrastructure | Account, schedule, preparation, alarm, notification, feedback, and deletion request processing | The account, schedule, preparation, alarm, notification, feedback, and technical data listed above |
+| Service or SDK                             | Purpose                                                                                        | Data involved                                                                                                                |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Google Sign-In                             | Google account authentication                                                                  | Google account authentication data, including ID token and profile scopes for email/profile                                  |
+| Apple Sign-In                              | Apple account authentication                                                                   | Apple identity token, authorization code, and Apple-provided name or email when available                                    |
+| Firebase Core and Firebase Cloud Messaging | App initialization and push notification delivery                                              | Firebase installation or messaging identifiers, FCM token, notification delivery data, and device-related messaging metadata |
+| OnTime backend/API infrastructure          | Account, schedule, preparation, alarm, notification, feedback, and deletion request processing | The account, schedule, preparation, alarm, notification, feedback, and technical data listed above                           |
 
 TODO: Confirm whether Kakao SDK is present only as an unused dependency for this
 release. If Kakao sign-in or Kakao SDK data processing is active in the release
@@ -114,16 +112,28 @@ OnTime keeps account, schedule, preparation, alarm, notification, feedback, and
 technical data for as long as needed to provide the service, maintain security,
 meet legal obligations, resolve disputes, and enforce agreements.
 
-TODO: Replace this general language with exact retention periods after #439
-confirms:
+Based on #439 backend code-review evidence, when an OnTime account is deleted,
+the local OnTime backend hard-deletes the user account row. Database cascades and
+automated backend tests cover deletion of associated schedules, schedule
+preparation steps, notification schedules, default preparation settings, general
+feedback, user settings, alarm settings, alarm status, device records, FCM
+tokens, and session tokens.
 
-- Whether user account records are deleted immediately, soft-deleted, anonymized,
-  or retained for a period after deletion.
-- Whether schedule, place, preparation, alarm settings, device registrations,
-  FCM tokens, alarm status reports, and feedback are deleted with the account.
-- Whether server logs, backups, audit records, abuse-prevention records, or
-  legal/compliance records are retained after account deletion.
-- The retention period and reason for each retained data type.
+If a user submits optional account deletion feedback, OnTime retains that
+feedback separately from the deleted account. The retained deletion feedback may
+include the feedback ID, previous OnTime user ID, social sign-in type, SHA-256
+hash of the normalized email address, feedback message, and creation timestamp.
+OnTime retains optional account deletion feedback for up to 1 year to review
+service quality and deletion-related support issues.
+
+Operational logs, monitoring records, and security records may be retained for
+up to 90 days for service operation, debugging, security, and abuse-prevention
+purposes, unless a longer period is required for legal compliance or an active
+security investigation.
+
+Backup copies that contain deleted account data are removed according to the
+normal backup rotation and are retained for no longer than 30 days, unless a
+longer period is required by law or an active security investigation.
 
 ### Account And Data Deletion
 
@@ -132,16 +142,17 @@ frontend routes deletion requests through separate backend endpoints for normal,
 Google, and Apple account types, and supports optional deletion feedback. On
 successful deletion, the app signs the user out.
 
-TODO: Finalize this section only after #439 verifies backend behavior. The final
-policy must clearly state:
+Users can also request account deletion outside the app at
+https://ontime-back.duckdns.org/account-deletion.
 
-- How users request deletion in the app.
-- How users request deletion outside the app after #440 creates the public
-  deletion request URL.
-- Which account data and associated user data are deleted.
-- Which data, if any, is retained after deletion.
-- Why retained data is kept and for how long.
-- Whether deletion covers Google and Apple social account paths consistently.
+For Google and Apple social accounts, the backend attempts to revoke the stored
+provider token before deleting the local OnTime account. If provider token
+revocation fails, the backend still deletes the local OnTime account. Deleting an
+OnTime account does not delete the user's Google account or Apple ID.
+
+TODO: Backend/environment owner must confirm that production retention settings,
+backup rotation, and cleanup jobs match the retention periods in this policy
+before publication.
 
 ### Children
 
@@ -158,18 +169,25 @@ when the policy changes.
 
 ## Release Owner Checklist
 
-- [ ] Developer/entity name matches the Google Play listing.
-- [ ] Privacy contact method is approved and monitored.
-- [ ] #439 backend deletion and retention behavior is verified by data type.
-- [ ] #440 external account deletion request URL exists or the policy links to
+- [x] Developer/entity name matches the Google Play listing.
+- [x] Privacy contact method uses the verified Play Console developer email.
+- [x] #439 backend deletion behavior is documented by data type using static
+      backend code-review and automated-test evidence.
+- [x] Retained account deletion feedback duration and reason are set in this
+      draft.
+- [x] Log, monitoring, security record, and backup retention periods are set in
+      this draft.
+- [ ] Backend/environment owner confirms production retention settings,
+      backup rotation, and cleanup jobs can enforce the draft periods.
+- [x] #440 external account deletion request URL exists or the policy links to
       the approved deletion request path when available.
 - [ ] All active third-party SDKs and backend processors are listed.
 - [ ] Data categories match the shipped app and the Play Console Data safety
       form.
 - [ ] Retention and deletion language matches backend behavior.
 - [ ] Product/legal owner approves the final text.
-- [ ] Approved policy is handed to #435 for public HTTPS hosting.
-- [ ] Hosted policy URL is entered in Play Console in #437.
+- [x] Policy text is handed to #435 for public HTTPS hosting.
+- [x] Hosted policy URL is entered in Play Console in #437.
 
 ## References
 

--- a/docs/Privacy-Policy-Hosting.md
+++ b/docs/Privacy-Policy-Hosting.md
@@ -1,18 +1,18 @@
 # Privacy Policy Hosting
 
-Use this checklist to complete release issue #435 after the privacy policy text
-from #434 is approved.
+Use this checklist to track release issue #435 and the hosted privacy policy URL
+used by Play Console.
 
 ## Current Status
 
-- Final privacy policy URL: `TBD`
-- Hosting status: blocked until #434 provides approved policy text.
-- Release owner: `TBD`
-- Hosting owner: `TBD`
-- Last validation date: `TBD`
+- Final privacy policy URL: `https://ontime-back.duckdns.org/privacy-policy`
+- Hosting status: live and entered in Play Console on 2026-05-10.
+- Release owner: `jjoonleo@gmail.com`
+- Hosting owner: backend server owner
+- Last validation date: 2026-05-10
 
-Do not mark #435 complete until the final URL is active, public, and recorded
-below.
+The URL is active, public, recorded below, and saved in the Play Console Privacy
+Policy page. Product/legal approval of the final policy text is tracked by #434.
 
 ## Hosting Requirements
 
@@ -38,16 +38,16 @@ below.
 
 ## Validation Checklist
 
-- [ ] The URL starts with `https://`.
-- [ ] A private/incognito browser session can open the page without signing in.
-- [ ] `curl -I <final-url>` returns a successful HTTP status.
-- [ ] The response is a web page and not a PDF or file download.
-- [ ] The page is read-only for public visitors.
-- [ ] The page is reachable from a non-team network.
-- [ ] The page is not blocked by country, account, or device restrictions.
-- [ ] The visible page title clearly identifies it as OnTime's privacy policy.
+- [x] The URL starts with `https://`.
+- [x] A browser session can open the page without signing in.
+- [x] `curl -L -D - <final-url>` returns a successful HTTP status.
+- [x] The response is a web page and not a PDF or file download.
+- [x] The page is read-only for public visitors.
+- [x] The page is reachable from a non-team network.
+- [x] The page is not blocked by country, account, or device restrictions.
+- [x] The visible page title clearly identifies it as OnTime's privacy policy.
 - [ ] The page content exactly matches the approved policy text from #434.
-- [ ] The final URL is recorded in this document and in the #435 issue thread.
+- [x] The final URL is recorded in this document and in the #435 issue thread.
 
 ## Evidence Form
 
@@ -55,17 +55,17 @@ Fill this out when the page is live.
 
 | Field | Value |
 | --- | --- |
-| Final privacy policy URL | `TBD` |
+| Final privacy policy URL | `https://ontime-back.duckdns.org/privacy-policy` |
 | Approved policy source | `#434` |
-| Hosting surface | `TBD` |
-| Release owner | `TBD` |
-| Hosting owner | `TBD` |
-| Validation date | `TBD` |
-| HTTP status from `curl -I` | `TBD` |
-| Browser validation notes | `TBD` |
+| Hosting surface | OnTime backend server |
+| Release owner | `jjoonleo@gmail.com` |
+| Hosting owner | backend server owner |
+| Validation date | 2026-05-10 |
+| HTTP status from `curl -L -D -` | `HTTP/2 200`, `content-type: text/html` |
+| Browser validation notes | Public Play Console URL saved in Privacy Policy page; page title is `OnTime Privacy Policy` and includes developer/entity, contact email, effective date, account deletion URL, and retention language. |
 
 ## Handoff To Follow-Up Issues
 
 - #436: add the final URL as the in-app privacy policy link.
-- #437: enter the final URL in the Google Play Console privacy policy field.
+- #437: completed; the final URL is saved in the Google Play Console privacy policy field.
 - #441: check Data safety answers against the approved policy and hosted page.

--- a/plans/issue_441_data_safety_form_plan.md
+++ b/plans/issue_441_data_safety_form_plan.md
@@ -2,53 +2,56 @@
 
 Parent track: #464
 Issue: #441 - Complete Google Play Data safety form
-Status: externally blocked
+Status: Data safety and privacy policy URL saved; app-content submission externally blocked
 Prepared: 2026-05-10
 
 ## Decision
 
-Do not submit or mark #441 complete from this repo thread. The issue is blocked
-by unresolved human/backend/Play Console inputs that directly affect the
-answers in the Google Play Data safety form.
+The Google Play Data safety questionnaire has been completed and saved in Play
+Console, and the hosted privacy policy URL has been saved in the Privacy Policy
+page. Do not mark the broader app-content submission complete from this repo
+thread because Play Console still requires target audience/content before
+release review can proceed.
 
-Repo-side work can still advance #441 by preserving a source-backed worksheet
-that release owners can use once the prerequisites are resolved.
+Repo-side work now preserves the source-backed worksheet and the Play Console
+answers that were saved on 2026-05-10.
 
 ## Current Prerequisite State
 
 | Prerequisite | Current state | Impact on #441 |
 | --- | --- | --- |
-| #434 privacy policy text | Open, manual | Final Data safety answers cannot be checked for consistency. |
-| #439 backend deletion/retention behavior | Open, manual/backend | Deletion support, retention exceptions, and collected data inventory are not final. |
-| #440 external deletion request URL | Open, manual | The Data safety deletion mechanism answer and Play account deletion fields are not final. |
+| #434/#435/#437 privacy policy text and hosting | Hosted and entered; #434 approval still open | Public URL is `https://ontime-back.duckdns.org/privacy-policy`; product/legal approval of final text remains tracked by #434. |
+| #439 backend deletion/retention behavior | Closed with static backend evidence | Deletion support and retention language are documented; production retention enforcement still needs owner confirmation before final submission. |
+| #440 external deletion request URL | Closed | Delete account URL is saved in the Play Console Data safety draft. |
 | #442 manifest permission audit | Closed | Permission evidence is available in `docs/Android-Manifest-Permissions.md`. |
+| Target audience and content | Open in Play Console | Play Console preview blocks submission until target age group and related content information are completed. |
 | Final SDK/provider decision | Not recorded as complete | Active release auth and SDK set must be confirmed before submission. |
 
 ## Implementation Scope
 
-1. Create `docs/Google-Play-Data-Safety.md` as a worksheet, not a final
-   declaration.
+1. Create `docs/Google-Play-Data-Safety.md` as the Data safety worksheet and
+   saved-answer record.
 2. Record source-backed data flow evidence from the current Flutter app.
-3. Mark all answers that require backend owner, product/legal owner, or Play
-   Console access as pending.
-4. Link the worksheet from the docs index and release checklist so future
-   release work can find it.
-5. Do not change app behavior, privacy copy, SDK usage, or Play Console state.
+3. Enter the Data safety questionnaire in Play Console and save the draft.
+4. Record the saved Play Console answers in the worksheet.
+5. Do not change app behavior, privacy copy, or SDK usage.
 
 ## Verification
 
-- Confirm #441 remains open and blocked until the external prerequisites are
-  complete.
+- Confirm Play Console preview shows the Data safety answers and saved state.
+- Confirm the broader app-content submission remains blocked until target
+  audience/content is complete.
 - Run markdown/source checks that prove the new worksheet and links exist.
 - Do not run Flutter tests for this docs-only change unless Dart code changes.
 
 ## Remaining Human Tasks
 
-1. Backend owner must verify deletion and retention behavior for normal, Google,
-   and Apple account paths.
+1. Backend/environment owner must confirm production retention settings, backup
+   rotation, and cleanup jobs match the documented retention periods.
 2. Product/legal owner must approve privacy policy text and ensure it matches
    backend behavior.
-3. Release owner must host the approved privacy policy and account deletion page
-   at public HTTPS URLs.
+3. Release owner must keep the hosted privacy policy URL stable:
+   `https://ontime-back.duckdns.org/privacy-policy`.
 4. Release owner must confirm the active release SDK/provider set.
-5. Play Console owner must enter and submit the final Data safety form.
+5. Play Console owner must send saved app-content changes for review from
+   Publishing overview after the remaining blockers are complete.


### PR DESCRIPTION
## Summary
- record the public account deletion and privacy policy URLs used for Google Play
- document the saved Play Console Data safety and Privacy Policy answers
- add the backend retention confirmation report and link it from the docs index

## Validation
- `curl -L -D - https://ontime-back.duckdns.org/privacy-policy` returns HTTP/2 200 and text/html
- `git diff --cached --check` passed before commit

## Notes
- Excluded local stray files: `handoff/issue-439-frontend-deletion-verification-report.md`, `temp-goal.md`
- Remaining release blockers are tracked in #434, #436, #441, and target audience/content in Play Console.