### PR TITLE
[codex] Fix Google login session flow

### DIFF
--- a/lib/data/repositories/user_repository_impl.dart
+++ b/lib/data/repositories/user_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/logging/app_logger.dart';
@@ -15,6 +16,8 @@ import 'package:rxdart/subjects.dart';
 
 @Singleton(as: UserRepository)
 class UserRepositoryImpl implements UserRepository {
+  static const _googleIosClientId =
+      '456571312261-r35ah9qi0qaq7al007e2db0e0jmjcmb4.apps.googleusercontent.com';
   static const _googleServerClientId =
       '456571312261-5kuf2r6i5i7lqjr7qealv06sdgkn3hcp.apps.googleusercontent.com';
   static const _googleScopes = ['email', 'profile'];
@@ -45,17 +48,10 @@ class UserRepositoryImpl implements UserRepository {
   }
 
   Future<void> _initializeGoogleSignIn() async {
-    await _googleSignIn.initialize(serverClientId: _googleServerClientId);
-    final lightweightAuthentication = _googleSignIn
-        .attemptLightweightAuthentication();
-    if (lightweightAuthentication != null) {
-      unawaited(
-        lightweightAuthentication.catchError((Object error) {
-          AppLogger.debug('Google lightweight sign-in failed: $error');
-          return null;
-        }),
-      );
-    }
+    await _googleSignIn.initialize(
+      clientId: _googleClientId,
+      serverClientId: _googleServerClientId,
+    );
   }
 
   @override
@@ -241,4 +237,11 @@ class UserRepositoryImpl implements UserRepository {
   @override
   Stream<UserEntity> get userStream =>
       _userStreamController.asBroadcastStream();
+
+  String? get _googleClientId {
+    if (kIsWeb) return null;
+    return defaultTargetPlatform == TargetPlatform.iOS
+        ? _googleIosClientId
+        : null;
+  }
 }

--- a/lib/presentation/login/components/google_sign_in_button/google_sign_in_button_mobile.dart
+++ b/lib/presentation/login/components/google_sign_in_button/google_sign_in_button_mobile.dart
@@ -1,31 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/core/logging/app_logger.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
+import 'package:on_time_front/presentation/app/bloc/auth/auth_bloc.dart';
 
-class GoogleSignInButton extends StatelessWidget {
+class GoogleSignInButton extends StatefulWidget {
   const GoogleSignInButton({super.key});
+
+  @override
+  State<GoogleSignInButton> createState() => _GoogleSignInButtonState();
+}
+
+class _GoogleSignInButtonState extends State<GoogleSignInButton> {
+  bool _isSigningIn = false;
 
   @override
   Widget build(BuildContext context) {
     final UserRepository authenticationRepository = getIt.get<UserRepository>();
+    final canSignIn = context.select<AuthBloc, bool>(
+      (bloc) => bloc.state.status == AuthStatus.unauthenticated,
+    );
 
     return SizedBox(
       width: 358,
       height: 54,
       child: ElevatedButton(
-        onPressed: () async {
-          try {
-            final googleAccount = await authenticationRepository
-                .authenticateWithGoogle();
-            await authenticationRepository.signInWithGoogle(googleAccount);
-          } catch (error) {
-            AppLogger.debug(
-              'Google Sign-In button failed errorType=${error.runtimeType}',
-            );
-          }
-        },
+        onPressed: !canSignIn || _isSigningIn
+            ? null
+            : () async {
+                setState(() {
+                  _isSigningIn = true;
+                });
+                try {
+                  final googleAccount = await authenticationRepository
+                      .authenticateWithGoogle();
+                  await authenticationRepository.signInWithGoogle(
+                    googleAccount,
+                  );
+                } catch (error) {
+                  AppLogger.debug(
+                    'Google Sign-In button failed errorType=${error.runtimeType}',
+                  );
+                } finally {
+                  if (mounted) {
+                    setState(() {
+                      _isSigningIn = false;
+                    });
+                  }
+                }
+              },
         style: ElevatedButton.styleFrom(
           backgroundColor: Colors.white,
           foregroundColor: Colors.black,


### PR DESCRIPTION
## Summary
- initialize Google Sign-In with the iOS client ID while keeping the web/server client ID
- remove background lightweight Google auth during initialization to avoid overlapping native auth flows
- guard the mobile Google button against duplicate taps and against taps while auth is already loading/authenticated

## Root Cause
The app could start background lightweight Google auth and then immediately start interactive auth, which made the native flow flaky. The login screen could also remain briefly tappable after a saved session had already authenticated, causing an unnecessary Google prompt.

## Validation
- `flutter analyze lib/data/repositories/user_repository_impl.dart lib/presentation/login/components/google_sign_in_button/google_sign_in_button_mobile.dart`
