### PR TITLE
[codex] Require manual Android Play version codes

### DIFF
--- a/.github/workflows/android-play-internal.yml
+++ b/.github/workflows/android-play-internal.yml
@@ -1,11 +1,12 @@
 name: Android Play Internal Deploy
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
+      android_version_code:
+        description: Must be greater than every Android version code already uploaded to Google Play.
+        required: true
+        type: number
       release_notes:
         description: Optional Google Play release notes for en-US.
         required: false
@@ -26,12 +27,39 @@ jobs:
       REST_API_URL: ${{ vars.REST_API_URL }}
 
     steps:
-      - name: Require main branch
+      - name: Validate workflow inputs
+        env:
+          ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+          ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
+          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           if [ "$GITHUB_REF" != "refs/heads/main" ]; then
             echo "Android Play Internal Deploy must be run from main." >&2
             exit 1
           fi
+
+          if ! [[ "$ANDROID_VERSION_CODE" =~ ^[1-9][0-9]*$ ]]; then
+            echo "android_version_code must be a positive integer." >&2
+            exit 1
+          fi
+
+          missing=0
+          for name in \
+            ANDROID_GOOGLE_SERVICES_JSON_B64 \
+            ANDROID_UPLOAD_KEYSTORE_B64 \
+            ANDROID_KEYSTORE_PASSWORD \
+            ANDROID_KEY_ALIAS \
+            ANDROID_KEY_PASSWORD \
+            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON \
+            REST_API_URL
+          do
+            if [ -z "${!name}" ]; then
+              echo "$name is required for Android Play internal deploy." >&2
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       - uses: actions/checkout@v4
 
@@ -51,29 +79,6 @@ jobs:
 
       - name: Install native test dependencies
         run: sudo apt-get update && sudo apt-get install -y sqlite3 libsqlite3-dev
-
-      - name: Validate release configuration
-        env:
-          ANDROID_GOOGLE_SERVICES_JSON_B64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_B64 }}
-          ANDROID_UPLOAD_KEYSTORE_B64: ${{ secrets.ANDROID_UPLOAD_KEYSTORE_B64 }}
-          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-        run: |
-          missing=0
-          for name in \
-            ANDROID_GOOGLE_SERVICES_JSON_B64 \
-            ANDROID_UPLOAD_KEYSTORE_B64 \
-            ANDROID_KEYSTORE_PASSWORD \
-            ANDROID_KEY_ALIAS \
-            ANDROID_KEY_PASSWORD \
-            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON \
-            REST_API_URL
-          do
-            if [ -z "${!name}" ]; then
-              echo "$name is required for Android Play internal deploy." >&2
-              missing=1
-            fi
-          done
-          exit "$missing"
 
       - name: Decode Android Firebase config
         env:
@@ -120,12 +125,12 @@ jobs:
         run: |
           flutter build appbundle --release \
             --build-name="$ANDROID_BUILD_NAME" \
-            --build-number="${{ github.run_number }}" \
+            --build-number="${{ inputs.android_version_code }}" \
             --dart-define=ENV=staging \
             --dart-define=REST_API_URL="$REST_API_URL"
 
       - name: Prepare Play release notes
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_notes != '' }}
+        if: ${{ inputs.release_notes != '' }}
         env:
           RELEASE_NOTES: ${{ inputs.release_notes }}
         run: |
@@ -141,7 +146,7 @@ jobs:
           retention-days: 14
 
       - name: Upload internal testing draft with release notes
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_notes != '' }}
+        if: ${{ inputs.release_notes != '' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
@@ -152,7 +157,7 @@ jobs:
           whatsNewDirectory: distribution/whatsnew
 
       - name: Upload internal testing draft
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.release_notes == '' }}
+        if: ${{ inputs.release_notes == '' }}
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}

--- a/docs/Android-Release-Configuration.md
+++ b/docs/Android-Release-Configuration.md
@@ -14,8 +14,9 @@ The decoded file must include an Android client whose package name is `club.devk
 
 Use the `Android Play Internal Deploy` GitHub Actions workflow to build a signed
 Android App Bundle and upload it to the Google Play Internal Testing track as a
-draft release. The workflow runs automatically on pushes to `main` and can also
-be dispatched manually from `main`.
+draft release. The workflow is dispatched manually from `main` and requires an
+`android_version_code` input greater than every Android version code already
+uploaded to Google Play.
 
 Configure a GitHub environment named `staging` for internal test distribution.
 Store these environment secrets there:
@@ -36,12 +37,12 @@ Store this environment variable in `staging`:
 The deploy workflow runs package install, code generation, generated-file drift
 checking, analysis, tests, and then `flutter build appbundle --release`. It
 derives Android `versionName` from the `pubspec.yaml` version name and supplies
-`${{ github.run_number }}` as Android `versionCode`:
+the manual `android_version_code` workflow input as Android `versionCode`:
 
 ```sh
 flutter build appbundle --release \
   --build-name=<version name from pubspec.yaml> \
-  --build-number=${{ github.run_number }} \
+  --build-number=<android_version_code input> \
   --dart-define=ENV=staging \
   --dart-define=REST_API_URL="$REST_API_URL"
 ```
@@ -53,9 +54,10 @@ input is empty, the workflow uploads without custom release notes.
 Keep `pubspec.yaml` as the source of truth for the manually managed public
 version name, such as `version: 1.0.0+1`. Android CI ignores the checked-in
 build suffix for Play uploads, so do not open PRs only to bump `+2`, `+3`, and
-similar build numbers. The generated `github.run_number` must still be greater
-than every previously uploaded Google Play build for `club.devkor.ontime`;
-duplicate or lower build numbers fail during the Google Play upload step.
+similar build numbers. The manually supplied `android_version_code` must be
+greater than every previously uploaded Google Play build for
+`club.devkor.ontime`; duplicate or lower build numbers fail during the Google
+Play upload step.
 
 ## Local Release Build
 

--- a/docs/Android-Signing-Setup.md
+++ b/docs/Android-Signing-Setup.md
@@ -155,6 +155,6 @@ flutter build appbundle --release \
 ```
 
 Confirm that `pubspec.yaml` has the intended public version name. In GitHub
-Actions deploys, Android `versionCode` comes from `github.run_number`; for any
-manual Play upload, provide a build number greater than every previous Play
-Console upload for `club.devkor.ontime`.
+Actions deploys, Android `versionCode` comes from the manual
+`android_version_code` workflow input. Provide a build number greater than every
+previous Play Console upload for `club.devkor.ontime`.

--- a/docs/Release-Checklist.md
+++ b/docs/Release-Checklist.md
@@ -40,10 +40,10 @@ flutter build appbundle --release
 - For local Android release builds, provide the signing, Firebase, `ENV`, and
   `REST_API_URL` inputs documented in `docs/Android-Release-Configuration.md`
   and `docs/Android-Release-Signing.md`.
-- For CI Play uploads, use the `Android Play Internal Deploy` workflow from
-  `main`; it runs package install, code generation, generated-file drift
-  checking, analysis, tests, AAB build, artifact upload, and internal testing
-  draft upload.
+- For CI Play uploads, dispatch the `Android Play Internal Deploy` workflow
+  from `main` with an explicit `android_version_code`; it runs package install,
+  code generation, generated-file drift checking, analysis, tests, AAB build,
+  artifact upload, and internal testing draft upload.
 - Record any command failure with the failing command, environment, and owner
   before release approval.
 
@@ -60,10 +60,11 @@ flutter build appbundle --release
   with checked-in Flutter build suffix `+1`.
 - Keep the public version name manual in `pubspec.yaml`.
 - For Android Play deploys, CI derives `versionName` from `pubspec.yaml` and
-  uses `github.run_number` as the generated `versionCode`; do not open PRs only
-  to bump the checked-in build suffix.
-- When uploading manually, choose an Android `versionCode` greater than every
-  previously uploaded Play build for `club.devkor.ontime`.
+  uses the manual `android_version_code` workflow input as `versionCode`; do
+  not open PRs only to bump the checked-in build suffix.
+- Choose an Android `versionCode` greater than every previously uploaded Play
+  build for `club.devkor.ontime`, including builds on internal, closed, and
+  production tracks.
 
 ## Generated Files And Dependencies
 


### PR DESCRIPTION
## Summary
- Make the Android internal-testing Play workflow manual-only by removing the `push` trigger.
- Require manual `android_version_code` input for internal-testing uploads, matching the closed-testing workflow.
- Update release docs to describe the manual version-code policy.

## Validation
- Parsed both Play workflow YAML files locally with Ruby.
- Ran `git diff --check`.
- Confirmed no remaining `github.run_number` references in `.github/workflows` or `docs`.

## Notes
- This follows up after #503 was merged.
- The entered Android version code must be greater than every version code already uploaded to Google Play across all tracks.
