### PR TITLE
Require manual Android Play version codes and draft closed testing uploads

### DIFF
--- a/.github/workflows/android-play-closed.yml
+++ b/.github/workflows/android-play-closed.yml
@@ -158,6 +158,7 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           tracks: alpha
           status: draft
+          changesNotSentForReview: true
           whatsNewDirectory: distribution/whatsnew
 
       - name: Upload closed testing draft
@@ -169,3 +170,4 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           tracks: alpha
           status: draft
+          changesNotSentForReview: true

--- a/.github/workflows/android-play-internal.yml
+++ b/.github/workflows/android-play-internal.yml
@@ -154,6 +154,7 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           tracks: internal
           status: draft
+          changesNotSentForReview: true
           whatsNewDirectory: distribution/whatsnew
 
       - name: Upload internal testing draft
@@ -165,3 +166,4 @@ jobs:
           releaseFiles: build/app/outputs/bundle/release/app-release.aab
           tracks: internal
           status: draft
+          changesNotSentForReview: true


### PR DESCRIPTION
## Summary
- Remove the automatic `push` trigger from the Android internal Play workflow so internal uploads are manual-only.
- Require `android_version_code` for both internal and closed testing uploads and use it as the Android `versionCode`.
- Keep both Play workflows on draft releases and explicitly set `changesNotSentForReview: true`.
- Update release docs to reflect the manual version-code workflow.

## Testing
- YAML syntax for both Play workflows parsed successfully.
- Checked the workflow diff for formatting and consistency.
- Verified the release docs no longer refer to `github.run_number` for Play uploads.