### PR TITLE
[codex] Log Google Play draft upload phases

### DIFF
--- a/.github/scripts/upload_google_play_draft.js
+++ b/.github/scripts/upload_google_play_draft.js
@@ -81,7 +81,10 @@ const main = async () => {
       throw new Error('Uploaded Android App Bundle did not return a versionCode.');
     }
 
+    console.log(`Uploaded Android App Bundle versionCode ${versionCode}`);
+
     const release = {
+      name: `${process.env.ANDROID_BUILD_NAME || 'Android'} (${versionCode})`,
       status: 'draft',
       versionCodes: [String(versionCode)],
     };
@@ -90,6 +93,7 @@ const main = async () => {
       release.releaseNotes = releaseNotes;
     }
 
+    console.log(`Updating track "${track}" with draft release ${release.name}`);
     await publisher.edits.tracks.update({
       packageName,
       editId,
@@ -100,6 +104,7 @@ const main = async () => {
       },
     });
 
+    console.log(`Committing Google Play edit ${editId}`);
     const commitResponse = await publisher.edits.commit({
       packageName,
       editId,


### PR DESCRIPTION
## Summary
- Add clearer logging around Google Play draft upload phases.
- Add a release name to the draft release payload.

## Validation
- Ran `node --check .github/scripts/upload_google_play_draft.js`.
- Ran `git diff --check` before pushing the commit.

## Notes
- This follows up after #506 was merged before this logging commit landed.
