### PR TITLE
[codex] Hide schedule marker on selected date

### DIFF
--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -13,6 +13,7 @@ import 'package:on_time_front/presentation/calendar/component/schedule_detail.da
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_create_screen.dart';
 import 'package:on_time_front/presentation/schedule_create/screens/schedule_edit_screen.dart';
 import 'package:on_time_front/presentation/shared/components/calendar/centered_calendar_header.dart';
+import 'package:on_time_front/presentation/shared/components/calendar/schedule_marker_builder.dart';
 import 'package:on_time_front/presentation/shared/components/two_button_delete_dialog.dart';
 import 'package:on_time_front/presentation/shared/theme/calendar_theme.dart';
 import 'package:on_time_front/presentation/shared/theme/theme.dart';
@@ -293,6 +294,13 @@ class _CalendarScreenState extends State<CalendarScreen> {
                                         .headerStyle.leftChevronIcon,
                                     rightIcon: calendarTheme
                                         .headerStyle.rightChevronIcon,
+                                  );
+                                },
+                                markerBuilder: (context, day, events) {
+                                  return selectedDayScheduleMarkerBuilder(
+                                    selectedDay: _selectedDate,
+                                    day: day,
+                                    events: events,
                                   );
                                 },
                                 selectedBuilder: (context, day, focusedDay) {

--- a/lib/presentation/home/components/month_calendar.dart
+++ b/lib/presentation/home/components/month_calendar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:on_time_front/presentation/calendar/bloc/monthly_schedules_bloc.dart';
 import 'package:on_time_front/presentation/shared/components/calendar/centered_calendar_header.dart';
+import 'package:on_time_front/presentation/shared/components/calendar/schedule_marker_builder.dart';
 import 'package:on_time_front/presentation/shared/theme/calendar_theme.dart';
 import 'package:table_calendar/table_calendar.dart';
 
@@ -167,6 +168,13 @@ class _MonthCalendarState extends State<MonthCalendar> {
                   titleTextStyle: calendarTheme.headerStyle.titleTextStyle,
                   leftIcon: calendarTheme.headerStyle.leftChevronIcon,
                   rightIcon: calendarTheme.headerStyle.rightChevronIcon,
+                );
+              },
+              markerBuilder: (context, day, events) {
+                return selectedDayScheduleMarkerBuilder(
+                  selectedDay: _selectedDay,
+                  day: day,
+                  events: events,
                 );
               },
               selectedBuilder: (context, day, focusedDay) {

--- a/lib/presentation/shared/components/calendar/schedule_marker_builder.dart
+++ b/lib/presentation/shared/components/calendar/schedule_marker_builder.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+Widget? selectedDayScheduleMarkerBuilder<T>({
+  required DateTime selectedDay,
+  required DateTime day,
+  required List<T> events,
+}) {
+  if (events.isNotEmpty && isSameDay(selectedDay, day)) {
+    return const SizedBox.shrink();
+  }
+
+  return null;
+}

--- a/test/presentation/shared/components/calendar/schedule_marker_builder_test.dart
+++ b/test/presentation/shared/components/calendar/schedule_marker_builder_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/presentation/shared/components/calendar/schedule_marker_builder.dart';
+
+void main() {
+  test('hides schedule marker when the day is selected', () {
+    final marker = selectedDayScheduleMarkerBuilder(
+      selectedDay: DateTime(2026, 5, 11),
+      day: DateTime(2026, 5, 11, 9),
+      events: const [Object()],
+    );
+
+    expect(marker, isA<SizedBox>());
+  });
+
+  test('uses the default marker when a scheduled day is not selected', () {
+    final marker = selectedDayScheduleMarkerBuilder(
+      selectedDay: DateTime(2026, 5, 11),
+      day: DateTime(2026, 5, 12),
+      events: const [Object()],
+    );
+
+    expect(marker, isNull);
+  });
+
+  test('uses the default empty-day behavior when there are no events', () {
+    final marker = selectedDayScheduleMarkerBuilder<Object>(
+      selectedDay: DateTime(2026, 5, 11),
+      day: DateTime(2026, 5, 11),
+      events: const [],
+    );
+
+    expect(marker, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Hide the schedule indicator marker when its calendar day is selected.
- Reuse the same marker rule in the calendar screen and home month calendar.
- Add focused unit coverage for selected, unselected, and empty event marker behavior.

## Root cause
TableCalendar still rendered its event marker on selected day cells, so the schedule dot overlapped the blue selected-date highlight and made the calendar UI look broken.

Fixes #432

## Validation
- flutter analyze
- flutter test test/presentation/shared/components/calendar/schedule_marker_builder_test.dart test/presentation/calendar/screens/calendar_screen_test.dart