### PR TITLE
[codex] Adjust schedule modal dismissal

### DIFF
--- a/lib/presentation/calendar/screens/calendar_screen.dart
+++ b/lib/presentation/calendar/screens/calendar_screen.dart
@@ -74,11 +74,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
           ),
         ),
       )
-      ..add(
-        MonthlySchedulesVisibleDateChanged(
-          date: _selectedDate,
-        ),
-      );
+      ..add(MonthlySchedulesVisibleDateChanged(date: _selectedDate));
   }
 
   void _onLeftArrowTap() {
@@ -124,11 +120,10 @@ class _CalendarScreenState extends State<CalendarScreen> {
   Future<void> _openCreateScheduleSheet(BuildContext context) async {
     final saved = await showModalBottomSheet<bool>(
       context: context,
+      isDismissible: false,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) => ScheduleCreateScreen(
-        initialDate: _selectedDate,
-      ),
+      builder: (context) => ScheduleCreateScreen(initialDate: _selectedDate),
     );
 
     _refreshSchedulesIfSaved(saved);
@@ -142,9 +137,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) => ScheduleEditScreen(
-        scheduleId: scheduleId,
-      ),
+      builder: (context) => ScheduleEditScreen(scheduleId: scheduleId),
     );
 
     _refreshSchedulesIfSaved(saved);
@@ -201,13 +194,15 @@ class _CalendarScreenState extends State<CalendarScreen> {
             ),
           ),
           body: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 18.0) +
+            padding:
+                const EdgeInsets.symmetric(horizontal: 18.0) +
                 EdgeInsets.only(bottom: 12.0),
             child: LayoutBuilder(
               builder: (context, constraints) {
                 final detailGap = _calendarDetailGap(constraints.maxHeight);
-                final selectedDateHeadingGap =
-                    _selectedDateHeadingGap(constraints.maxHeight);
+                final selectedDateHeadingGap = _selectedDateHeadingGap(
+                  constraints.maxHeight,
+                );
 
                 return Column(
                   children: [
@@ -222,119 +217,145 @@ class _CalendarScreenState extends State<CalendarScreen> {
                           vertical: _calendarVerticalPadding,
                           horizontal: _calendarHorizontalPadding,
                         ),
-                        child: BlocBuilder<MonthlySchedulesBloc,
-                            MonthlySchedulesState>(
-                          builder: (context, state) {
-                            if (state.status == MonthlySchedulesStatus.error) {
-                              return Text(AppLocalizations.of(context)!.error);
-                            }
+                        child:
+                            BlocBuilder<
+                              MonthlySchedulesBloc,
+                              MonthlySchedulesState
+                            >(
+                              builder: (context, state) {
+                                if (state.status ==
+                                    MonthlySchedulesStatus.error) {
+                                  return Text(
+                                    AppLocalizations.of(context)!.error,
+                                  );
+                                }
 
-                            return TableCalendar(
-                              locale:
-                                  Localizations.localeOf(context).toString(),
-                              daysOfWeekHeight: _calendarDaysOfWeekHeight,
-                              rowHeight: _calendarRowHeight,
-                              eventLoader: (day) {
-                                day = DateTime(day.year, day.month, day.day);
-                                return state.schedules[day] ?? [];
-                              },
-                              focusedDay: _selectedDate,
-                              selectedDayPredicate: (day) =>
-                                  isSameDay(_selectedDate, day),
-                              firstDay: _firstDay,
-                              lastDay: _lastDay,
-                              calendarFormat: CalendarFormat.month,
-                              headerStyle: calendarTheme.headerStyle,
-                              daysOfWeekStyle: calendarTheme.daysOfWeekStyle,
-                              calendarStyle: calendarTheme.calendarStyle,
-                              onDaySelected: (selectedDay, focusedDay) {
-                                setState(() {
-                                  _selectedDate = _clampDay(
-                                      selectedDay, _firstDay, _lastDay);
-                                });
-                                _monthlySchedulesBloc.add(
-                                  MonthlySchedulesVisibleDateChanged(
-                                    date: _selectedDate,
+                                return TableCalendar(
+                                  locale: Localizations.localeOf(
+                                    context,
+                                  ).toString(),
+                                  daysOfWeekHeight: _calendarDaysOfWeekHeight,
+                                  rowHeight: _calendarRowHeight,
+                                  eventLoader: (day) {
+                                    day = DateTime(
+                                      day.year,
+                                      day.month,
+                                      day.day,
+                                    );
+                                    return state.schedules[day] ?? [];
+                                  },
+                                  focusedDay: _selectedDate,
+                                  selectedDayPredicate: (day) =>
+                                      isSameDay(_selectedDate, day),
+                                  firstDay: _firstDay,
+                                  lastDay: _lastDay,
+                                  calendarFormat: CalendarFormat.month,
+                                  headerStyle: calendarTheme.headerStyle,
+                                  daysOfWeekStyle:
+                                      calendarTheme.daysOfWeekStyle,
+                                  calendarStyle: calendarTheme.calendarStyle,
+                                  onDaySelected: (selectedDay, focusedDay) {
+                                    setState(() {
+                                      _selectedDate = _clampDay(
+                                        selectedDay,
+                                        _firstDay,
+                                        _lastDay,
+                                      );
+                                    });
+                                    _monthlySchedulesBloc.add(
+                                      MonthlySchedulesVisibleDateChanged(
+                                        date: _selectedDate,
+                                      ),
+                                    );
+                                  },
+                                  onPageChanged: (focusedDay) {
+                                    final clampedFocusedDay = _clampDay(
+                                      focusedDay,
+                                      _firstDay,
+                                      _lastDay,
+                                    );
+
+                                    setState(() {
+                                      _selectedDate = clampedFocusedDay;
+                                    });
+
+                                    _monthlySchedulesBloc.add(
+                                      MonthlySchedulesVisibleDateChanged(
+                                        date: _selectedDate,
+                                      ),
+                                    );
+
+                                    _monthlySchedulesBloc.add(
+                                      MonthlySchedulesMonthAdded(
+                                        date: DateTime(
+                                          clampedFocusedDay.year,
+                                          clampedFocusedDay.month,
+                                          clampedFocusedDay.day,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                                  calendarBuilders: CalendarBuilders(
+                                    headerTitleBuilder: (context, date) {
+                                      return CenteredCalendarHeader(
+                                        focusedMonth: date,
+                                        onLeftArrowTap: _onLeftArrowTap,
+                                        onRightArrowTap: _onRightArrowTap,
+                                        titleTextStyle: calendarTheme
+                                            .headerStyle
+                                            .titleTextStyle,
+                                        leftIcon: calendarTheme
+                                            .headerStyle
+                                            .leftChevronIcon,
+                                        rightIcon: calendarTheme
+                                            .headerStyle
+                                            .rightChevronIcon,
+                                      );
+                                    },
+                                    markerBuilder: (context, day, events) {
+                                      return selectedDayScheduleMarkerBuilder(
+                                        selectedDay: _selectedDate,
+                                        day: day,
+                                        events: events,
+                                      );
+                                    },
+                                    selectedBuilder:
+                                        (context, day, focusedDay) {
+                                          return Container(
+                                            margin: const EdgeInsets.all(2.0),
+                                            alignment: Alignment.center,
+                                            decoration: calendarTheme
+                                                .selectedDayDecoration,
+                                            child: Text(
+                                              DateFormat.d(
+                                                Localizations.localeOf(
+                                                  context,
+                                                ).toString(),
+                                              ).format(day),
+                                              style: calendarTheme
+                                                  .selectedDayTextStyle,
+                                            ),
+                                          );
+                                        },
+                                    todayBuilder: (context, day, focusedDay) =>
+                                        Container(
+                                          margin: const EdgeInsets.all(2.0),
+                                          alignment: Alignment.center,
+                                          decoration:
+                                              calendarTheme.todayDecoration,
+                                          child: Text(
+                                            DateFormat.d(
+                                              Localizations.localeOf(
+                                                context,
+                                              ).toString(),
+                                            ).format(day),
+                                            style: calendarTheme.todayTextStyle,
+                                          ),
+                                        ),
                                   ),
                                 );
                               },
-                              onPageChanged: (focusedDay) {
-                                final clampedFocusedDay =
-                                    _clampDay(focusedDay, _firstDay, _lastDay);
-
-                                setState(() {
-                                  _selectedDate = clampedFocusedDay;
-                                });
-
-                                _monthlySchedulesBloc.add(
-                                  MonthlySchedulesVisibleDateChanged(
-                                    date: _selectedDate,
-                                  ),
-                                );
-
-                                _monthlySchedulesBloc.add(
-                                  MonthlySchedulesMonthAdded(
-                                    date: DateTime(
-                                      clampedFocusedDay.year,
-                                      clampedFocusedDay.month,
-                                      clampedFocusedDay.day,
-                                    ),
-                                  ),
-                                );
-                              },
-                              calendarBuilders: CalendarBuilders(
-                                headerTitleBuilder: (context, date) {
-                                  return CenteredCalendarHeader(
-                                    focusedMonth: date,
-                                    onLeftArrowTap: _onLeftArrowTap,
-                                    onRightArrowTap: _onRightArrowTap,
-                                    titleTextStyle: calendarTheme
-                                        .headerStyle.titleTextStyle,
-                                    leftIcon: calendarTheme
-                                        .headerStyle.leftChevronIcon,
-                                    rightIcon: calendarTheme
-                                        .headerStyle.rightChevronIcon,
-                                  );
-                                },
-                                markerBuilder: (context, day, events) {
-                                  return selectedDayScheduleMarkerBuilder(
-                                    selectedDay: _selectedDate,
-                                    day: day,
-                                    events: events,
-                                  );
-                                },
-                                selectedBuilder: (context, day, focusedDay) {
-                                  return Container(
-                                    margin: const EdgeInsets.all(2.0),
-                                    alignment: Alignment.center,
-                                    decoration:
-                                        calendarTheme.selectedDayDecoration,
-                                    child: Text(
-                                      DateFormat.d(
-                                        Localizations.localeOf(context)
-                                            .toString(),
-                                      ).format(day),
-                                      style: calendarTheme.selectedDayTextStyle,
-                                    ),
-                                  );
-                                },
-                                todayBuilder: (context, day, focusedDay) =>
-                                    Container(
-                                  margin: const EdgeInsets.all(2.0),
-                                  alignment: Alignment.center,
-                                  decoration: calendarTheme.todayDecoration,
-                                  child: Text(
-                                    DateFormat.d(
-                                      Localizations.localeOf(context)
-                                          .toString(),
-                                    ).format(day),
-                                    style: calendarTheme.todayTextStyle,
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
+                            ),
                       ),
                     ),
                     SizedBox(height: detailGap),
@@ -357,48 +378,52 @@ class _CalendarScreenState extends State<CalendarScreen> {
                             ),
                             SizedBox(height: selectedDateHeadingGap),
                             Expanded(
-                              child: BlocBuilder<MonthlySchedulesBloc,
-                                  MonthlySchedulesState>(
-                                builder: (context, state) {
-                                  return _SelectedDateSchedulesContent(
-                                    selectedDate: _selectedDate,
-                                    state: state,
-                                    onAddSchedule: () =>
-                                        _openCreateScheduleSheet(context),
-                                    onEditSchedule: (scheduleId) =>
-                                        _openEditScheduleSheet(
-                                      context,
-                                      scheduleId: scheduleId,
-                                    ),
-                                    onDeleteSchedule: (schedule) {
-                                      showTwoButtonDeleteDialog(
-                                        context,
-                                        title: AppLocalizations.of(context)!
-                                            .scheduleDeleteConfirmTitle,
-                                        description: AppLocalizations.of(
-                                                context)!
-                                            .scheduleDeleteConfirmDescription,
-                                        cancelText:
-                                            AppLocalizations.of(context)!
-                                                .cancel,
-                                        confirmText:
-                                            AppLocalizations.of(context)!
-                                                .deleteScheduleConfirmAction,
-                                      ).then((confirmed) {
-                                        if (confirmed != true ||
-                                            !context.mounted) {
-                                          return;
-                                        }
-                                        _monthlySchedulesBloc.add(
-                                          MonthlySchedulesScheduleDeleted(
-                                            schedule: schedule,
-                                          ),
-                                        );
-                                      });
+                              child:
+                                  BlocBuilder<
+                                    MonthlySchedulesBloc,
+                                    MonthlySchedulesState
+                                  >(
+                                    builder: (context, state) {
+                                      return _SelectedDateSchedulesContent(
+                                        selectedDate: _selectedDate,
+                                        state: state,
+                                        onAddSchedule: () =>
+                                            _openCreateScheduleSheet(context),
+                                        onEditSchedule: (scheduleId) =>
+                                            _openEditScheduleSheet(
+                                              context,
+                                              scheduleId: scheduleId,
+                                            ),
+                                        onDeleteSchedule: (schedule) {
+                                          showTwoButtonDeleteDialog(
+                                            context,
+                                            title: AppLocalizations.of(
+                                              context,
+                                            )!.scheduleDeleteConfirmTitle,
+                                            description: AppLocalizations.of(
+                                              context,
+                                            )!.scheduleDeleteConfirmDescription,
+                                            cancelText: AppLocalizations.of(
+                                              context,
+                                            )!.cancel,
+                                            confirmText: AppLocalizations.of(
+                                              context,
+                                            )!.deleteScheduleConfirmAction,
+                                          ).then((confirmed) {
+                                            if (confirmed != true ||
+                                                !context.mounted) {
+                                              return;
+                                            }
+                                            _monthlySchedulesBloc.add(
+                                              MonthlySchedulesScheduleDeleted(
+                                                schedule: schedule,
+                                              ),
+                                            );
+                                          });
+                                        },
+                                      );
                                     },
-                                  );
-                                },
-                              ),
+                                  ),
                             ),
                           ],
                         ),
@@ -465,7 +490,8 @@ class _SelectedDateSchedulesContent extends StatelessWidget {
 
         return BlocBuilder<ScheduleBloc, ScheduleState>(
           builder: (context, scheduleState) {
-            final isEarlyStarted = scheduleState.isEarlyStarted &&
+            final isEarlyStarted =
+                scheduleState.isEarlyStarted &&
                 scheduleState.schedule?.id == schedule.id;
 
             return ScheduleDetail(

--- a/lib/presentation/shared/components/bottom_nav_bar_scaffold.dart
+++ b/lib/presentation/shared/components/bottom_nav_bar_scaffold.dart
@@ -101,6 +101,7 @@ class _BottomNavigationBarScaffoldState extends State<BottomNavBarScaffold> {
           onPressed: () {
             showModalBottomSheet(
               context: context,
+              isDismissible: false,
               isScrollControlled: true,
               backgroundColor: Colors.transparent,
               builder: (context) => const ScheduleCreateScreen(),
@@ -174,10 +175,7 @@ class _HomeIcon extends StatelessWidget {
       semanticsLabel: AppLocalizations.of(context)!.home,
       height: iconTheme.size,
       fit: BoxFit.contain,
-      colorFilter: ColorFilter.mode(
-        iconTheme.color!,
-        BlendMode.srcIn,
-      ),
+      colorFilter: ColorFilter.mode(iconTheme.color!, BlendMode.srcIn),
     );
   }
 }
@@ -194,10 +192,7 @@ class _MyIcon extends StatelessWidget {
       semanticsLabel: AppLocalizations.of(context)!.myPage,
       height: iconTheme.size,
       fit: BoxFit.contain,
-      colorFilter: ColorFilter.mode(
-        iconTheme.color!,
-        BlendMode.srcIn,
-      ),
+      colorFilter: ColorFilter.mode(iconTheme.color!, BlendMode.srcIn),
     );
   }
 }

--- a/lib/presentation/shared/components/cupertino_picker_modal.dart
+++ b/lib/presentation/shared/components/cupertino_picker_modal.dart
@@ -8,10 +8,10 @@ extension ModalBottomSheetExtension on BuildContext {
     required Duration initialValue,
     required CupertinoTimerPickerMode mode,
     required Function(Duration value) onSaved,
-    Function? onDisposed,
+    VoidCallback? onDisposed,
   }) {
     showModalBottomSheet<void>(
-      isDismissible: false,
+      isDismissible: true,
       context: this,
       builder: (BuildContext context) {
         final textTheme = Theme.of(context).textTheme;
@@ -41,18 +41,20 @@ extension ModalBottomSheetExtension on BuildContext {
                     Expanded(
                       flex: 1,
                       child: ElevatedButton(
-                          onPressed: () {
-                            //calling order matters
-                            Navigator.pop(context);
-                            onDisposed?.call();
-                          },
-                          style: ButtonStyle(
-                            backgroundColor: WidgetStatePropertyAll(
-                                Color.fromARGB(255, 220, 227, 255)),
-                            foregroundColor: WidgetStatePropertyAll(
-                                Color.fromARGB(255, 92, 121, 251)),
+                        onPressed: () {
+                          //calling order matters
+                          Navigator.pop(context);
+                        },
+                        style: ButtonStyle(
+                          backgroundColor: WidgetStatePropertyAll(
+                            Color.fromARGB(255, 220, 227, 255),
                           ),
-                          child: Text(AppLocalizations.of(this)!.cancel)),
+                          foregroundColor: WidgetStatePropertyAll(
+                            Color.fromARGB(255, 92, 121, 251),
+                          ),
+                        ),
+                        child: Text(AppLocalizations.of(this)!.cancel),
+                      ),
                     ),
                     SizedBox(width: 20.0),
                     Expanded(
@@ -61,7 +63,6 @@ extension ModalBottomSheetExtension on BuildContext {
                         onPressed: () {
                           Navigator.pop(context);
                           onSaved(duration);
-                          onDisposed?.call();
                         },
                         child: Text(AppLocalizations.of(this)!.ok),
                       ),
@@ -73,17 +74,19 @@ extension ModalBottomSheetExtension on BuildContext {
           ),
         );
       },
-    );
+    ).whenComplete(() {
+      onDisposed?.call();
+    });
   }
 
   void showCupertinoMinutePickerModal({
     required String title,
     required Duration initialValue,
     required Function(Duration value) onSaved,
-    Function? onDisposed,
+    VoidCallback? onDisposed,
   }) {
     showModalBottomSheet<void>(
-      isDismissible: false,
+      isDismissible: true,
       context: this,
       builder: (BuildContext context) {
         final textTheme = Theme.of(context).textTheme;
@@ -92,8 +95,10 @@ extension ModalBottomSheetExtension on BuildContext {
           borderRadius: BorderRadius.vertical(top: Radius.circular(20.0)),
           child: Container(
             color: Theme.of(context).colorScheme.surface,
-            padding:
-                const EdgeInsets.symmetric(horizontal: 29.0, vertical: 28.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 29.0,
+              vertical: 28.0,
+            ),
             child: SizedBox(
               height: 334,
               child: Column(
@@ -106,16 +111,19 @@ extension ModalBottomSheetExtension on BuildContext {
                         width: 69.0,
                         child: CupertinoPicker(
                           scrollController: FixedExtentScrollController(
-                              initialItem: initialValue.inMinutes),
+                            initialItem: initialValue.inMinutes,
+                          ),
                           looping: true,
                           itemExtent: 32,
                           onSelectedItemChanged: (int value) {
                             minutes = value;
                           },
                           children: List.generate(
-                              60,
-                              (index) => Text(
-                                  (index < 10 ? '0' : '') + index.toString())),
+                            60,
+                            (index) => Text(
+                              (index < 10 ? '0' : '') + index.toString(),
+                            ),
+                          ),
                         ),
                       ),
                     ),
@@ -127,18 +135,20 @@ extension ModalBottomSheetExtension on BuildContext {
                       Expanded(
                         flex: 1,
                         child: ElevatedButton(
-                            onPressed: () {
-                              //calling order matters
-                              Navigator.pop(context);
-                              onDisposed?.call();
-                            },
-                            style: ButtonStyle(
-                              backgroundColor: WidgetStatePropertyAll(
-                                  Color.fromARGB(255, 220, 227, 255)),
-                              foregroundColor: WidgetStatePropertyAll(
-                                  Color.fromARGB(255, 92, 121, 251)),
+                          onPressed: () {
+                            //calling order matters
+                            Navigator.pop(context);
+                          },
+                          style: ButtonStyle(
+                            backgroundColor: WidgetStatePropertyAll(
+                              Color.fromARGB(255, 220, 227, 255),
                             ),
-                            child: Text(AppLocalizations.of(this)!.cancel)),
+                            foregroundColor: WidgetStatePropertyAll(
+                              Color.fromARGB(255, 92, 121, 251),
+                            ),
+                          ),
+                          child: Text(AppLocalizations.of(this)!.cancel),
+                        ),
                       ),
                       SizedBox(width: 20.0),
                       Expanded(
@@ -147,7 +157,6 @@ extension ModalBottomSheetExtension on BuildContext {
                           onPressed: () {
                             Navigator.pop(context);
                             onSaved(Duration(minutes: minutes));
-                            onDisposed?.call();
                           },
                           child: Text(AppLocalizations.of(this)!.ok),
                         ),
@@ -160,7 +169,9 @@ extension ModalBottomSheetExtension on BuildContext {
           ),
         );
       },
-    );
+    ).whenComplete(() {
+      onDisposed?.call();
+    });
   }
 
   void showCupertinoDatePickerModal({
@@ -168,10 +179,10 @@ extension ModalBottomSheetExtension on BuildContext {
     required DateTime initialValue,
     required Function(DateTime value) onSaved,
     required CupertinoDatePickerMode mode,
-    Function? onDisposed,
+    VoidCallback? onDisposed,
   }) {
     showModalBottomSheet<void>(
-      isDismissible: false,
+      isDismissible: true,
       context: this,
       builder: (BuildContext context) {
         final textTheme = Theme.of(context).textTheme;
@@ -203,18 +214,20 @@ extension ModalBottomSheetExtension on BuildContext {
                     Expanded(
                       flex: 1,
                       child: ElevatedButton(
-                          onPressed: () {
-                            //calling order matters
-                            Navigator.pop(context);
-                            onDisposed?.call();
-                          },
-                          style: ButtonStyle(
-                            backgroundColor: WidgetStatePropertyAll(
-                                Color.fromARGB(255, 220, 227, 255)),
-                            foregroundColor: WidgetStatePropertyAll(
-                                Color.fromARGB(255, 92, 121, 251)),
+                        onPressed: () {
+                          //calling order matters
+                          Navigator.pop(context);
+                        },
+                        style: ButtonStyle(
+                          backgroundColor: WidgetStatePropertyAll(
+                            Color.fromARGB(255, 220, 227, 255),
                           ),
-                          child: Text(AppLocalizations.of(this)!.cancel)),
+                          foregroundColor: WidgetStatePropertyAll(
+                            Color.fromARGB(255, 92, 121, 251),
+                          ),
+                        ),
+                        child: Text(AppLocalizations.of(this)!.cancel),
+                      ),
                     ),
                     SizedBox(width: 20.0),
                     Expanded(
@@ -223,7 +236,6 @@ extension ModalBottomSheetExtension on BuildContext {
                         onPressed: () {
                           Navigator.pop(context);
                           onSaved(dateTime);
-                          onDisposed?.call();
                         },
                         child: Text(AppLocalizations.of(this)!.ok),
                       ),
@@ -235,6 +247,8 @@ extension ModalBottomSheetExtension on BuildContext {
           ),
         );
       },
-    );
+    ).whenComplete(() {
+      onDisposed?.call();
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Prevent schedule creation bottom sheets from closing when the backdrop/upper area is tapped.
- Allow Cupertino date/time/timer picker sheets to close from the backdrop.
- Move picker disposal callbacks to sheet completion so backdrop dismissal still triggers cleanup/validation.

## Validation
- `dart format --set-exit-if-changed lib/presentation/shared/components/cupertino_picker_modal.dart lib/presentation/calendar/screens/calendar_screen.dart lib/presentation/shared/components/bottom_nav_bar_scaffold.dart` (formatted files, then commit amended)
- `flutter analyze`
- `git diff --check HEAD~1 HEAD`