### PR TITLE
[codex] Close active preparation screen to home

### DIFF
--- a/lib/presentation/alarm/screens/alarm_screen.dart
+++ b/lib/presentation/alarm/screens/alarm_screen.dart
@@ -10,8 +10,6 @@ import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart'
 import 'package:on_time_front/presentation/alarm/components/alarm_screen_bottom_section.dart';
 import 'package:on_time_front/presentation/alarm/components/alarm_screen_top_section.dart';
 import 'package:on_time_front/presentation/alarm/components/preparation_completion_dialog.dart';
-import 'package:on_time_front/presentation/shared/components/modal_wide_button.dart';
-import 'package:on_time_front/presentation/shared/components/two_action_dialog.dart';
 import 'package:on_time_front/presentation/shared/router/route_arguments.dart';
 import 'package:on_time_front/presentation/shared/utils/time_format.dart';
 
@@ -233,30 +231,6 @@ class _AlarmScreenState extends State<AlarmScreen> {
     );
   }
 
-  Future<void> _showLeaveConfirmationDialog(BuildContext context) async {
-    final l10n = AppLocalizations.of(context)!;
-    final result = await showTwoActionDialog(
-      context,
-      config: TwoActionDialogConfig(
-        title: l10n.confirmLeave,
-        description: l10n.confirmLeaveDescription,
-        barrierDismissible: false,
-        secondaryAction: DialogActionConfig(
-          label: l10n.leave,
-          variant: ModalWideButtonVariant.neutral,
-        ),
-        primaryAction: DialogActionConfig(
-          label: l10n.stay,
-          variant: ModalWideButtonVariant.primary,
-        ),
-      ),
-    );
-
-    if (result == DialogActionResult.secondary && context.mounted) {
-      context.go('/home');
-    }
-  }
-
   Widget _buildAlarmScreen({
     required ScheduleWithPreparationEntity schedule,
   }) {
@@ -331,7 +305,7 @@ class _AlarmScreenState extends State<AlarmScreen> {
                       child: IconButton(
                         key: const Key('alarm_close_button'),
                         icon: const Icon(Icons.close, color: Colors.white),
-                        onPressed: () => _showLeaveConfirmationDialog(context),
+                        onPressed: () => context.go('/home'),
                       ),
                     ),
                   ),

--- a/test/presentation/alarm/screens/preparation_flow_widget_test.dart
+++ b/test/presentation/alarm/screens/preparation_flow_widget_test.dart
@@ -1048,68 +1048,7 @@ void main() {
     );
 
     testWidgets(
-      'active alarm close button shows confirm dialog and stay keeps alarm',
-      (tester) async {
-        await setLargeTestViewport(tester);
-        now = DateTime.now();
-
-        final schedule = buildSchedule(
-          id: 's-active-stay',
-          scheduleTime: now.add(const Duration(minutes: 35)),
-          steps: const [
-            PreparationStepWithTimeEntity(
-              id: 'p1',
-              preparationName: 'Prep',
-              preparationTime: Duration(minutes: 10),
-              nextPreparationId: null,
-            ),
-          ],
-        );
-
-        final router = GoRouter(
-          initialLocation: '/alarmScreen',
-          routes: [
-            GoRoute(path: '/home', builder: (_, __) => const Text('HOME')),
-            GoRoute(
-              path: '/alarmScreen',
-              builder: (_, __) => const AlarmScreen(),
-            ),
-          ],
-        );
-
-        final earlyBundle = createEarlyStartUseCaseBundle();
-        final alarmBloc = ScheduleBloc.test(
-          StubGetNearestUpcomingScheduleUseCase(() => Stream.value(schedule)),
-          navigationService,
-          NoopSaveTimedPreparationUseCase(),
-          StubGetTimedPreparationSnapshotUseCase({}),
-          NoopClearTimedPreparationUseCase(),
-          startUseCase,
-          finishUseCase,
-          markEarlyStartSessionUseCase: earlyBundle.markUseCase,
-          getEarlyStartSessionUseCase: earlyBundle.getUseCase,
-          clearEarlyStartSessionUseCase: earlyBundle.clearUseCase,
-          nowProvider: () => now,
-        );
-        addTearDown(alarmBloc.close);
-
-        await pumpWithRouter(tester, bloc: alarmBloc, router: router);
-        await tapAndPump(tester, find.byKey(const Key('alarm_close_button')));
-        await pumpUntilFound(tester, find.byType(TwoActionDialog));
-
-        await tapAndPump(tester, find.text("I'll stay"));
-        await tester.pump(const Duration(milliseconds: 150));
-
-        expect(find.text('HOME'), findsNothing);
-        expect(find.byType(AlarmScreen), findsOneWidget);
-        alarmBloc.add(const ScheduleFinished(0));
-        await tester.pump();
-      },
-      timeout: const Timeout(Duration(seconds: 15)),
-    );
-
-    testWidgets(
-      'active alarm close button leave action navigates home',
+      'active alarm close button navigates home without confirmation',
       (tester) async {
         await setLargeTestViewport(tester);
         now = DateTime.now();
@@ -1156,11 +1095,10 @@ void main() {
 
         await pumpWithRouter(tester, bloc: alarmBloc, router: router);
         await tapAndPump(tester, find.byKey(const Key('alarm_close_button')));
-        await pumpUntilFound(tester, find.byType(TwoActionDialog));
 
-        await tapAndPump(tester, find.text("I'm leaving"));
         await pumpUntilRouteText(tester, 'HOME');
 
+        expect(find.byType(TwoActionDialog), findsNothing);
         expect(find.text('HOME'), findsOneWidget);
         alarmBloc.add(const ScheduleFinished(0));
         await tester.pump();


### PR DESCRIPTION
## What changed
- Changed the active preparation/alarm screen close button to navigate directly to Home.
- Removed the leave-confirmation dialog from that active preparation close path.
- Updated the preparation flow widget test to assert no confirmation dialog is shown.

## Why
The requested behavior is for the X button on the preparation ongoing screen to leave to Home immediately without warning.

## Validation
- `dart analyze lib/presentation/alarm/screens/alarm_screen.dart test/presentation/alarm/screens/preparation_flow_widget_test.dart`
- `flutter test test/presentation/alarm/screens/preparation_flow_widget_test.dart`