### PR TITLE
[codex] Avoid schedule tick router refreshes

### DIFF
--- a/lib/presentation/app/screens/app.dart
+++ b/lib/presentation/app/screens/app.dart
@@ -61,7 +61,6 @@ class _AppRouterViewState extends State<_AppRouterView>
 
   late final _router = goRouterConfig(
     context.read<AuthBloc>(),
-    context.read<ScheduleBloc>(),
     context.read<NotificationGateCubit>(),
     context.read<AlarmGateCubit>(),
   );

--- a/lib/presentation/shared/router/go_router.dart
+++ b/lib/presentation/shared/router/go_router.dart
@@ -34,17 +34,15 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
 
 GoRouter goRouterConfig(
   AuthBloc authBloc,
-  ScheduleBloc scheduleBloc,
   NotificationGateCubit notificationGateCubit,
   AlarmGateCubit alarmGateCubit,
 ) {
   return GoRouter(
-    refreshListenable: StreamToListenable([
-      scheduleBloc.stream,
-      authBloc.stream,
-      notificationGateCubit.stream,
-      alarmGateCubit.stream,
-    ]),
+    refreshListenable: appRouterRefreshListenable(
+      authStream: authBloc.stream,
+      notificationGateStream: notificationGateCubit.stream,
+      alarmGateStream: alarmGateCubit.stream,
+    ),
     navigatorKey: getIt.get<NavigationService>().navigatorKey,
     redirect: (BuildContext context, GoRouterState state) {
       return appRedirectLocation(
@@ -218,6 +216,19 @@ GoRouter goRouterConfig(
       ),
     ],
   );
+}
+
+@visibleForTesting
+StreamToListenable appRouterRefreshListenable({
+  required Stream<AuthState> authStream,
+  required Stream<NotificationGateState> notificationGateStream,
+  required Stream<AlarmGateState> alarmGateStream,
+}) {
+  return StreamToListenable([
+    authStream,
+    notificationGateStream,
+    alarmGateStream,
+  ]);
 }
 
 @visibleForTesting

--- a/test/presentation/shared/router/go_router_redirect_test.dart
+++ b/test/presentation/shared/router/go_router_redirect_test.dart
@@ -1,10 +1,51 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:on_time_front/presentation/app/bloc/auth/auth_bloc.dart';
+import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
 import 'package:on_time_front/presentation/app/cubit/alarm_gate_cubit.dart';
 import 'package:on_time_front/presentation/app/cubit/notification_gate_cubit.dart';
 import 'package:on_time_front/presentation/shared/router/go_router.dart';
 
 void main() {
+  test(
+    'router refresh listenable ignores schedule progress but refreshes for route gates',
+    () async {
+      final scheduleController = StreamController<ScheduleState>.broadcast();
+      final authController = StreamController<AuthState>.broadcast();
+      final notificationGateController =
+          StreamController<NotificationGateState>.broadcast();
+      final alarmGateController = StreamController<AlarmGateState>.broadcast();
+      final listenable = appRouterRefreshListenable(
+        authStream: authController.stream,
+        notificationGateStream: notificationGateController.stream,
+        alarmGateStream: alarmGateController.stream,
+      );
+      addTearDown(() async {
+        listenable.dispose();
+        await scheduleController.close();
+        await authController.close();
+        await notificationGateController.close();
+        await alarmGateController.close();
+      });
+
+      var refreshCount = 0;
+      listenable.addListener(() => refreshCount++);
+
+      scheduleController.add(const ScheduleState.initial());
+      await pumpEventQueue();
+
+      expect(refreshCount, 0);
+
+      authController.add(const AuthState.loading());
+      notificationGateController.add(const NotificationGateState.required());
+      alarmGateController.add(const AlarmGateState.required());
+      await pumpEventQueue();
+
+      expect(refreshCount, 3);
+    },
+  );
+
   test(
     'authenticated user goes directly to notification prompt while alarm gate is unresolved',
     () {


### PR DESCRIPTION
## Summary
- Remove raw `ScheduleBloc.stream` from the app-level `GoRouter.refreshListenable`.
- Keep router refreshes tied to auth, notification gate, and alarm gate state changes.
- Add a focused regression test proving schedule progress events do not notify the router refresh listenable while route gate events still do.

## Root Cause
`GoRouter.refreshListenable` subscribed directly to `ScheduleBloc.stream`, so every per-second `ScheduleTick` during active preparation could trigger global redirect evaluation even though global redirects do not read schedule progress.

Closes #524.

## Validation
- `flutter test test/presentation/shared/router/go_router_redirect_test.dart`
- `flutter analyze`
- `flutter test`