### PR TITLE
[codex] Decouple domain entities from lower layers

### DIFF
--- a/lib/data/daos/preparation_schedule_dao.dart
+++ b/lib/data/daos/preparation_schedule_dao.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
+import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
 import '/core/database/database.dart';
 
@@ -20,22 +21,25 @@ class PreparationScheduleDao extends DatabaseAccessor<AppDatabase>
   PreparationScheduleDao(this.db) : super(db);
 
   Future<void> createPreparationSchedule(
-      PreparationEntity preparationEntity, String scheduleId) async {
+    PreparationEntity preparationEntity,
+    String scheduleId,
+  ) async {
     String? previousStepId;
 
     for (var step in preparationEntity.preparationStepList) {
       // Step 1: Insert the current preparation step
       final insertedStep = await into(db.preparationSchedules).insertReturning(
-        step.toPreparationScheduleModel(scheduleId).toCompanion(false),
+        step.toPreparationScheduleRow(scheduleId).toCompanion(false),
       );
 
       // Step 2: Update the `nextPreparationId` of the previous step
       if (previousStepId != null) {
-        await (update(db.preparationSchedules)
-              ..where((tbl) => tbl.id.equals(previousStepId!)))
-            .write(
+        await (update(
+          db.preparationSchedules,
+        )..where((tbl) => tbl.id.equals(previousStepId!))).write(
           PreparationSchedulesCompanion(
-              nextPreparationId: Value(insertedStep.id)),
+            nextPreparationId: Value(insertedStep.id),
+          ),
         );
       }
 
@@ -45,10 +49,11 @@ class PreparationScheduleDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationEntity> getPreparationSchedulesByScheduleId(
-      String scheduleId) async {
-    final allSteps = await (select(db.preparationSchedules)
-          ..where((tbl) => tbl.scheduleId.equals(scheduleId)))
-        .get();
+    String scheduleId,
+  ) async {
+    final allSteps = await (select(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.scheduleId.equals(scheduleId))).get();
 
     if (allSteps.isEmpty) {
       return PreparationEntity(preparationStepList: []);
@@ -80,10 +85,11 @@ class PreparationScheduleDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationStepEntity> getPreparationStepById(
-      String preparationStepId) async {
-    final result = await (select(db.preparationSchedules)
-          ..where((tbl) => tbl.id.equals(preparationStepId)))
-        .getSingleOrNull();
+    String preparationStepId,
+  ) async {
+    final result = await (select(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.id.equals(preparationStepId))).getSingleOrNull();
 
     if (result == null) {
       throw Exception("Preparation step not found");
@@ -98,10 +104,12 @@ class PreparationScheduleDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<void> updatePreparationSchedule(
-      PreparationStepEntity stepEntity, String scheduleId) async {
-    await (update(db.preparationSchedules)
-          ..where((tbl) => tbl.id.equals(stepEntity.id)))
-        .write(
+    PreparationStepEntity stepEntity,
+    String scheduleId,
+  ) async {
+    await (update(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.id.equals(stepEntity.id))).write(
       PreparationSchedulesCompanion(
         preparationName: Value(stepEntity.preparationName),
         preparationTime: Value(stepEntity.preparationTime.inMinutes),
@@ -111,28 +119,30 @@ class PreparationScheduleDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationEntity> deletePreparationSchedule(
-      String preparationId) async {
+    String preparationId,
+  ) async {
     // Step 1: 삭제할 준비 과정을 가져오기
-    final preparationToDelete = await (select(db.preparationSchedules)
-          ..where((tbl) => tbl.id.equals(preparationId)))
-        .getSingle();
+    final preparationToDelete = await (select(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.id.equals(preparationId))).getSingle();
 
     // Step 2: 이전 노드의 nextPreparationId를 업데이트
-    await (update(db.preparationSchedules)
-          ..where((tbl) => tbl.nextPreparationId.equals(preparationId)))
-        .write(
+    await (update(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.nextPreparationId.equals(preparationId))).write(
       PreparationSchedulesCompanion(
         nextPreparationId: Value(preparationToDelete.nextPreparationId),
       ),
     );
 
     // Step 3: 해당 노드 삭제
-    await (delete(db.preparationSchedules)
-          ..where((tbl) => tbl.id.equals(preparationId)))
-        .go();
+    await (delete(
+      db.preparationSchedules,
+    )..where((tbl) => tbl.id.equals(preparationId))).go();
 
     // Step 4: 재정렬된 PreparationEntity 반환
     return await getPreparationSchedulesByScheduleId(
-        preparationToDelete.scheduleId);
+      preparationToDelete.scheduleId,
+    );
   }
 }

--- a/lib/data/daos/preparation_user_dao.dart
+++ b/lib/data/daos/preparation_user_dao.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
+import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
 import '/core/database/database.dart';
 import 'package:on_time_front/data/tables/preparation_user_table.dart';
@@ -17,18 +18,20 @@ class PreparationUserDao extends DatabaseAccessor<AppDatabase>
   PreparationUserDao(this.db) : super(db);
 
   Future<void> createPreparationUser(
-      PreparationEntity preparationEntity, String userId) async {
+    PreparationEntity preparationEntity,
+    String userId,
+  ) async {
     String? previousStepId;
 
     for (var step in preparationEntity.preparationStepList) {
-      final insertedStep = await into(db.preparationUsers).insertReturning(
-        step.toPreparationUserModel(userId).toCompanion(false),
-      );
+      final insertedStep = await into(
+        db.preparationUsers,
+      ).insertReturning(step.toPreparationUserRow(userId).toCompanion(false));
 
       if (previousStepId != null) {
-        await (update(db.preparationUsers)
-              ..where((tbl) => tbl.id.equals(previousStepId!)))
-            .write(
+        await (update(
+          db.preparationUsers,
+        )..where((tbl) => tbl.id.equals(previousStepId!))).write(
           PreparationUsersCompanion(nextPreparationId: Value(insertedStep.id)),
         );
       }
@@ -38,9 +41,9 @@ class PreparationUserDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationEntity> getPreparationUsersByUserId(String userId) async {
-    final allSteps = await (select(db.preparationUsers)
-          ..where((tbl) => tbl.userId.equals(userId)))
-        .get();
+    final allSteps = await (select(
+      db.preparationUsers,
+    )..where((tbl) => tbl.userId.equals(userId))).get();
 
     if (allSteps.isEmpty) {
       return PreparationEntity(preparationStepList: []);
@@ -72,10 +75,11 @@ class PreparationUserDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationStepEntity> getPreparationStepById(
-      String preparationStepId) async {
-    final result = await (select(db.preparationUsers)
-          ..where((tbl) => tbl.id.equals(preparationStepId)))
-        .getSingleOrNull();
+    String preparationStepId,
+  ) async {
+    final result = await (select(
+      db.preparationUsers,
+    )..where((tbl) => tbl.id.equals(preparationStepId))).getSingleOrNull();
 
     if (result == null) {
       throw Exception("Preparation step not found");
@@ -90,10 +94,12 @@ class PreparationUserDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<void> updatePreparationUser(
-      PreparationStepEntity stepEntity, String userId) async {
-    await (update(db.preparationUsers)
-          ..where((tbl) => tbl.id.equals(stepEntity.id)))
-        .write(
+    PreparationStepEntity stepEntity,
+    String userId,
+  ) async {
+    await (update(
+      db.preparationUsers,
+    )..where((tbl) => tbl.id.equals(stepEntity.id))).write(
       PreparationUsersCompanion(
         preparationName: Value(stepEntity.preparationName),
         preparationTime: Value(stepEntity.preparationTime.inMinutes),
@@ -102,21 +108,21 @@ class PreparationUserDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<PreparationEntity> deletePreparationUser(String preparationId) async {
-    final preparationToDelete = await (select(db.preparationUsers)
-          ..where((tbl) => tbl.id.equals(preparationId)))
-        .getSingle();
+    final preparationToDelete = await (select(
+      db.preparationUsers,
+    )..where((tbl) => tbl.id.equals(preparationId))).getSingle();
 
-    await (update(db.preparationUsers)
-          ..where((tbl) => tbl.nextPreparationId.equals(preparationId)))
-        .write(
+    await (update(
+      db.preparationUsers,
+    )..where((tbl) => tbl.nextPreparationId.equals(preparationId))).write(
       PreparationUsersCompanion(
         nextPreparationId: Value(preparationToDelete.nextPreparationId),
       ),
     );
 
-    await (delete(db.preparationUsers)
-          ..where((tbl) => tbl.id.equals(preparationId)))
-        .go();
+    await (delete(
+      db.preparationUsers,
+    )..where((tbl) => tbl.id.equals(preparationId))).go();
 
     return await getPreparationUsersByUserId(preparationToDelete.userId);
   }

--- a/lib/data/daos/user_dao.dart
+++ b/lib/data/daos/user_dao.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 import '/core/database/database.dart';
+import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
 import 'package:on_time_front/data/tables/user_table.dart';
 import 'package:on_time_front/domain/entities/user_entity.dart';
 
@@ -12,22 +13,21 @@ class UserDao extends DatabaseAccessor<AppDatabase> with _$UserDaoMixin {
   UserDao(this.db) : super(db);
 
   Future<void> createUser(UserEntity userEntity) async {
-    await into(db.users).insert(
-      userEntity.toModel().toCompanion(false),
-    );
+    await into(db.users).insert(userEntity.toUserRow().toCompanion(false));
   }
 
   Future<UserEntity?> getUserById(String userId) async {
-    final user = await (select(db.users)..where((tbl) => tbl.id.equals(userId)))
-        .getSingleOrNull();
+    final user = await (select(
+      db.users,
+    )..where((tbl) => tbl.id.equals(userId))).getSingleOrNull();
     if (user != null) {
-      return UserEntity.fromModel(user);
+      return user.toUserEntity();
     }
     return null;
   }
 
   Future<List<UserEntity>> getAllUsers() async {
     final query = await select(db.users).get();
-    return query.map((user) => UserEntity.fromModel(user)).toList();
+    return query.map((user) => user.toUserEntity()).toList();
   }
 }

--- a/lib/data/data_sources/schedule_local_data_source.dart
+++ b/lib/data/data_sources/schedule_local_data_source.dart
@@ -1,12 +1,15 @@
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/database/database.dart';
+import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 
 abstract interface class ScheduleLocalDataSource {
   Future<void> createSchedule(ScheduleEntity scheduleEntity);
 
   Future<List<ScheduleEntity>> getSchedulesByDate(
-      DateTime startDate, DateTime? endDate);
+    DateTime startDate,
+    DateTime? endDate,
+  );
 
   Future<ScheduleEntity> getScheduleById(String id);
 
@@ -19,42 +22,41 @@ abstract interface class ScheduleLocalDataSource {
 class ScheduleLocalDataSourceImpl implements ScheduleLocalDataSource {
   final AppDatabase appDatabase;
 
-  ScheduleLocalDataSourceImpl({
-    required this.appDatabase,
-  });
+  ScheduleLocalDataSourceImpl({required this.appDatabase});
 
   @override
   Future<void> createSchedule(ScheduleEntity scheduleEntity) async {
-    await appDatabase.scheduleDao
-        .createSchedule(scheduleEntity.toScheduleWithPlaceModel());
+    await appDatabase.scheduleDao.createSchedule(
+      scheduleEntity.toScheduleWithPlaceRow(),
+    );
   }
 
   @override
   Future<void> deleteSchedule(ScheduleEntity schedulEntity) async {
-    await appDatabase.scheduleDao
-        .deleteSchedule(schedulEntity.toScheduleModel());
+    await appDatabase.scheduleDao.deleteSchedule(schedulEntity.toScheduleRow());
   }
 
   @override
   Future<ScheduleEntity> getScheduleById(String id) async {
-    final scheduleWithPlaceModel =
-        await appDatabase.scheduleDao.getScheduleById(id);
-    return ScheduleEntity.fromScheduleWithPlaceModel(scheduleWithPlaceModel);
+    final scheduleWithPlaceModel = await appDatabase.scheduleDao
+        .getScheduleById(id);
+    return scheduleWithPlaceModel.toScheduleEntity();
   }
 
   @override
   Future<List<ScheduleEntity>> getSchedulesByDate(
-      DateTime startDate, DateTime? endDate) async {
-    final scheduleWithPlaceModel =
-        await appDatabase.scheduleDao.getSchedulesByDate(startDate, endDate);
-    return scheduleWithPlaceModel
-        .map((e) => ScheduleEntity.fromScheduleWithPlaceModel(e))
-        .toList();
+    DateTime startDate,
+    DateTime? endDate,
+  ) async {
+    final scheduleWithPlaceModel = await appDatabase.scheduleDao
+        .getSchedulesByDate(startDate, endDate);
+    return scheduleWithPlaceModel.map((e) => e.toScheduleEntity()).toList();
   }
 
   @override
   Future<void> updateSchedule(ScheduleEntity scheduleEntity) async {
-    await appDatabase.scheduleDao
-        .updateSchedule(scheduleEntity.toScheduleModel());
+    await appDatabase.scheduleDao.updateSchedule(
+      scheduleEntity.toScheduleRow(),
+    );
   }
 }

--- a/lib/data/mappers/domain_persistence_mappers.dart
+++ b/lib/data/mappers/domain_persistence_mappers.dart
@@ -1,0 +1,112 @@
+import 'package:on_time_front/core/database/database.dart';
+import 'package:on_time_front/data/tables/schedule_with_place_model.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/user_entity.dart';
+
+extension PlacePersistenceMapper on PlaceEntity {
+  Place toPlaceRow() {
+    return Place(id: id, placeName: placeName);
+  }
+}
+
+extension PlaceRowPersistenceMapper on Place {
+  PlaceEntity toPlaceEntity() {
+    return PlaceEntity(id: id, placeName: placeName);
+  }
+}
+
+extension PreparationStepPersistenceMapper on PreparationStepEntity {
+  PreparationUser toPreparationUserRow(String userId) {
+    return PreparationUser(
+      id: id,
+      userId: userId,
+      preparationName: preparationName,
+      preparationTime: preparationTime.inMinutes,
+      nextPreparationId: nextPreparationId,
+    );
+  }
+
+  PreparationSchedule toPreparationScheduleRow(String scheduleId) {
+    return PreparationSchedule(
+      id: id,
+      scheduleId: scheduleId,
+      preparationName: preparationName,
+      preparationTime: preparationTime.inMinutes,
+      nextPreparationId: nextPreparationId,
+    );
+  }
+}
+
+extension SchedulePersistenceMapper on ScheduleEntity {
+  Schedule toScheduleRow() {
+    return Schedule(
+      id: id,
+      placeId: place.id,
+      scheduleName: scheduleName,
+      scheduleTime: scheduleTime,
+      moveTime: moveTime,
+      isChanged: isChanged,
+      isStarted: isStarted,
+      scheduleSpareTime: scheduleSpareTime,
+      scheduleNote: scheduleNote,
+      latenessTime: latenessTime,
+    );
+  }
+
+  ScheduleWithPlace toScheduleWithPlaceRow() {
+    return ScheduleWithPlace(
+      schedule: toScheduleRow(),
+      place: place.toPlaceRow(),
+    );
+  }
+}
+
+extension ScheduleWithPlacePersistenceMapper on ScheduleWithPlace {
+  ScheduleEntity toScheduleEntity() {
+    return ScheduleEntity(
+      id: schedule.id,
+      place: place.toPlaceEntity(),
+      scheduleName: schedule.scheduleName,
+      scheduleTime: schedule.scheduleTime,
+      moveTime: schedule.moveTime,
+      isChanged: schedule.isChanged,
+      isStarted: schedule.isStarted,
+      scheduleSpareTime: schedule.scheduleSpareTime,
+      scheduleNote: schedule.scheduleNote ?? '',
+      latenessTime: schedule.latenessTime,
+      doneStatus: ScheduleDoneStatus.notEnded,
+      preparationFrozen: schedule.isStarted,
+    );
+  }
+}
+
+extension UserPersistenceMapper on UserEntity {
+  User toUserRow() {
+    return map(
+      (userEntity) => User(
+        id: userEntity.id,
+        email: userEntity.email,
+        name: userEntity.name,
+        spareTime: userEntity.spareTime.inMinutes,
+        note: userEntity.note,
+        score: userEntity.score,
+      ),
+      empty: (_) => throw Exception('Cannot convert empty UserEntity to User'),
+    );
+  }
+}
+
+extension UserRowPersistenceMapper on User {
+  UserEntity toUserEntity() {
+    return UserEntity(
+      id: id,
+      email: email,
+      name: name,
+      spareTime: Duration(minutes: spareTime),
+      note: note,
+      score: score,
+    );
+  }
+}

--- a/lib/domain/entities/place_entity.dart
+++ b/lib/domain/entities/place_entity.dart
@@ -1,20 +1,10 @@
 import 'package:equatable/equatable.dart';
 
-import '/core/database/database.dart';
-
 class PlaceEntity extends Equatable {
   final String id;
   final String placeName;
 
   const PlaceEntity({required this.id, required this.placeName});
-
-  static PlaceEntity fromModel(Place place) {
-    return PlaceEntity(id: place.id, placeName: place.placeName);
-  }
-
-  Place toModel() {
-    return Place(id: id, placeName: placeName);
-  }
 
   @override
   List<Object?> get props => [id, placeName];

--- a/lib/domain/entities/preparation_step_entity.dart
+++ b/lib/domain/entities/preparation_step_entity.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:on_time_front/core/database/database.dart';
 
 class PreparationStepEntity extends Equatable {
   final String id;
@@ -13,26 +12,6 @@ class PreparationStepEntity extends Equatable {
     required this.preparationTime,
     this.nextPreparationId,
   });
-
-  PreparationUser toPreparationUserModel(String userId) {
-    return PreparationUser(
-      id: id,
-      userId: userId,
-      preparationName: preparationName,
-      preparationTime: preparationTime.inMinutes,
-      nextPreparationId: nextPreparationId,
-    );
-  }
-
-  PreparationSchedule toPreparationScheduleModel(String scheduleId) {
-    return PreparationSchedule(
-      id: id,
-      scheduleId: scheduleId,
-      preparationName: preparationName,
-      preparationTime: preparationTime.inMinutes,
-      nextPreparationId: nextPreparationId,
-    );
-  }
 
   @override
   String toString() {
@@ -54,6 +33,10 @@ class PreparationStepEntity extends Equatable {
   }
 
   @override
-  List<Object?> get props =>
-      [id, preparationName, preparationTime, nextPreparationId];
+  List<Object?> get props => [
+    id,
+    preparationName,
+    preparationTime,
+    nextPreparationId,
+  ];
 }

--- a/lib/domain/entities/preparation_with_time_entity.dart
+++ b/lib/domain/entities/preparation_with_time_entity.dart
@@ -1,7 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_step_with_time_entity.dart';
-import 'package:on_time_front/presentation/shared/constants/constants.dart';
 
 class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
   const PreparationWithTimeEntity({
@@ -9,7 +8,8 @@ class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
   }) : super(preparationStepList: preparationStepList);
 
   factory PreparationWithTimeEntity.fromPreparation(
-      PreparationEntity preparation) {
+    PreparationEntity preparation,
+  ) {
     final orderedPreparation = preparation.ordered;
     return PreparationWithTimeEntity(
       preparationStepList: orderedPreparation.preparationStepList
@@ -52,7 +52,9 @@ class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
   }
 
   Duration get elapsedTime => preparationStepList.fold<Duration>(
-      Duration.zero, (sum, s) => sum + s.elapsedTime);
+    Duration.zero,
+    (sum, s) => sum + s.elapsedTime,
+  );
 
   /// Returns the progress as a value between 0.0 and 1.0
   double get progress {
@@ -98,28 +100,6 @@ class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
         .toList();
   }
 
-  /// Returns the preparation state for each step
-  List<PreparationStateEnum> get preparationStepStates {
-    final resolvedIndex = resolvedCurrentStepIndex;
-
-    return List<PreparationStateEnum>.generate(
-      preparationStepList.length,
-      (index) {
-        if (isAllStepsDone) {
-          // All steps are done
-          return PreparationStateEnum.done;
-        }
-        if (index < resolvedIndex) {
-          return PreparationStateEnum.done;
-        }
-        if (index == resolvedIndex && !isAllStepsDone) {
-          return PreparationStateEnum.now;
-        }
-        return PreparationStateEnum.yet;
-      },
-    );
-  }
-
   PreparationWithTimeEntity timeElapsed(Duration elapsed) {
     final current = currentStep;
     if (current == null) {
@@ -127,8 +107,9 @@ class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
     }
 
     Duration remainingElapsed = elapsed;
-    List<PreparationStepWithTimeEntity> updatedSteps =
-        List.from(preparationStepList);
+    List<PreparationStepWithTimeEntity> updatedSteps = List.from(
+      preparationStepList,
+    );
 
     // Find the current step index
     int currentIndex = updatedSteps.indexWhere((step) => step.id == current.id);
@@ -171,13 +152,13 @@ class PreparationWithTimeEntity extends PreparationEntity implements Equatable {
       return this; // All steps are done, no changes needed
     }
 
-    final updatedCurrentStep = current.copyWith(
-      isDone: true,
-    );
+    final updatedCurrentStep = current.copyWith(isDone: true);
     return copyWith(
       preparationStepList: preparationStepList
-          .map((step) =>
-              step.id == updatedCurrentStep.id ? updatedCurrentStep : step)
+          .map(
+            (step) =>
+                step.id == updatedCurrentStep.id ? updatedCurrentStep : step,
+          )
           .toList(),
     );
   }

--- a/lib/domain/entities/schedule_entity.dart
+++ b/lib/domain/entities/schedule_entity.dart
@@ -1,7 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:on_time_front/data/tables/schedule_with_place_model.dart';
 
-import '/core/database/database.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_preparation_mode.dart';
@@ -48,49 +46,6 @@ class ScheduleEntity extends Equatable {
     this.preparationFrozen = false,
     this.customPreparations,
   });
-
-  static ScheduleEntity fromScheduleWithPlaceModel(
-    ScheduleWithPlace scheduleWithPlace,
-  ) {
-    final schedule = scheduleWithPlace.schedule;
-    final place = scheduleWithPlace.place;
-    return ScheduleEntity(
-      id: schedule.id,
-      place: PlaceEntity.fromModel(place),
-      scheduleName: schedule.scheduleName,
-      scheduleTime: schedule.scheduleTime,
-      moveTime: schedule.moveTime,
-      isChanged: schedule.isChanged,
-      isStarted: schedule.isStarted,
-      scheduleSpareTime: schedule.scheduleSpareTime,
-      scheduleNote: schedule.scheduleNote ?? '',
-      latenessTime: schedule.latenessTime,
-      doneStatus: ScheduleDoneStatus.notEnded,
-      preparationFrozen: schedule.isStarted,
-    );
-  }
-
-  Schedule toScheduleModel() {
-    return Schedule(
-      id: id,
-      placeId: place.id,
-      scheduleName: scheduleName,
-      scheduleTime: scheduleTime,
-      moveTime: moveTime,
-      isChanged: isChanged,
-      isStarted: isStarted,
-      scheduleSpareTime: scheduleSpareTime,
-      scheduleNote: scheduleNote,
-      latenessTime: latenessTime,
-    );
-  }
-
-  ScheduleWithPlace toScheduleWithPlaceModel() {
-    return ScheduleWithPlace(
-      schedule: toScheduleModel(),
-      place: place.toModel(),
-    );
-  }
 
   ScheduleEntity copyWith({
     ScheduleDoneStatus? doneStatus,

--- a/lib/domain/entities/user_entity.dart
+++ b/lib/domain/entities/user_entity.dart
@@ -1,4 +1,3 @@
-import '/core/database/database.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'user_entity.freezed.dart';
@@ -18,17 +17,6 @@ class UserEntity with _$UserEntity {
   }) = _UserEntity;
 
   const factory UserEntity.empty() = _UserEntityEmpty;
-
-  static UserEntity fromModel(User user) {
-    return UserEntity(
-      id: user.id,
-      email: user.email,
-      name: user.name,
-      spareTime: Duration(minutes: user.spareTime),
-      note: user.note,
-      score: user.score,
-    );
-  }
 
   UserEntity? get valueOrNull => switch (this) {
     _UserEntity() => this,
@@ -59,18 +47,4 @@ class UserEntity with _$UserEntity {
     _UserEntityEmpty() => null,
     _ => null,
   };
-
-  User toModel() {
-    return map(
-      (userEntity) => User(
-        id: userEntity.id,
-        email: userEntity.email,
-        name: userEntity.name,
-        spareTime: userEntity.spareTime.inMinutes,
-        note: userEntity.note,
-        score: userEntity.score,
-      ),
-      empty: (_) => throw Exception('Cannot convert empty UserEntity to User'),
-    );
-  }
 }

--- a/lib/presentation/alarm/components/alarm_screen_bottom_section.dart
+++ b/lib/presentation/alarm/components/alarm_screen_bottom_section.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
 import 'package:on_time_front/presentation/alarm/components/preparation_step_list_widget.dart';
+import 'package:on_time_front/presentation/alarm/utils/preparation_step_state_mapper.dart';
 import 'package:on_time_front/presentation/shared/constants/constants.dart';
 import 'package:on_time_front/l10n/app_localizations.dart';
 
@@ -19,22 +20,22 @@ class AlarmScreenBottomSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final steps =
-        List<PreparationStepEntity>.from(preparation.preparationStepList);
+    final steps = List<PreparationStepEntity>.from(
+      preparation.preparationStepList,
+    );
 
     return Column(
       children: [
         Expanded(
-            child: _PreparationStepListSection(
-          preparationSteps: steps,
-          currentStepIndex: preparation.resolvedCurrentStepIndex,
-          stepElapsedTimes: preparation.stepElapsedTimesInSeconds,
-          preparationStepStates: preparation.preparationStepStates,
-          onSkip: onSkip,
-        )),
-        _EndPreparationButtonSection(
-          onEndPreparation: onEndPreparation,
+          child: _PreparationStepListSection(
+            preparationSteps: steps,
+            currentStepIndex: preparation.resolvedCurrentStepIndex,
+            stepElapsedTimes: preparation.stepElapsedTimesInSeconds,
+            preparationStepStates: preparation.preparationStepStates,
+            onSkip: onSkip,
+          ),
         ),
+        _EndPreparationButtonSection(onEndPreparation: onEndPreparation),
       ],
     );
   }
@@ -88,9 +89,7 @@ class _PreparationStepListSection extends StatelessWidget {
 class _EndPreparationButtonSection extends StatelessWidget {
   final VoidCallback onEndPreparation;
 
-  const _EndPreparationButtonSection({
-    required this.onEndPreparation,
-  });
+  const _EndPreparationButtonSection({required this.onEndPreparation});
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -112,8 +111,9 @@ class _EndPreparationButtonSection extends StatelessWidget {
                 }
                 return colorScheme.primary;
               }),
-              foregroundColor:
-                  WidgetStatePropertyAll<Color>(colorScheme.onPrimary),
+              foregroundColor: WidgetStatePropertyAll<Color>(
+                colorScheme.onPrimary,
+              ),
             ),
             child: Text(AppLocalizations.of(context)!.finishPreparation),
           ),

--- a/lib/presentation/alarm/utils/preparation_step_state_mapper.dart
+++ b/lib/presentation/alarm/utils/preparation_step_state_mapper.dart
@@ -1,0 +1,23 @@
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
+import 'package:on_time_front/presentation/shared/constants/constants.dart';
+
+extension PreparationStepStateMapper on PreparationWithTimeEntity {
+  List<PreparationStateEnum> get preparationStepStates {
+    final resolvedIndex = resolvedCurrentStepIndex;
+
+    return List<PreparationStateEnum>.generate(preparationStepList.length, (
+      index,
+    ) {
+      if (isAllStepsDone) {
+        return PreparationStateEnum.done;
+      }
+      if (index < resolvedIndex) {
+        return PreparationStateEnum.done;
+      }
+      if (index == resolvedIndex && !isAllStepsDone) {
+        return PreparationStateEnum.now;
+      }
+      return PreparationStateEnum.yet;
+    });
+  }
+}

--- a/test/data/mappers/domain_persistence_mappers_test.dart
+++ b/test/data/mappers/domain_persistence_mappers_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/database/database.dart';
+import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
+import 'package:on_time_front/data/tables/schedule_with_place_model.dart';
+import 'package:on_time_front/domain/entities/place_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
+import 'package:on_time_front/domain/entities/schedule_entity.dart';
+import 'package:on_time_front/domain/entities/user_entity.dart';
+
+void main() {
+  group('domain persistence mappers', () {
+    test(
+      'map schedules to and from database rows preserving stored fields',
+      () {
+        final entity = ScheduleWithPlace(
+          schedule: Schedule(
+            id: 'schedule-model',
+            placeId: 'place-model',
+            scheduleName: 'Doctor',
+            scheduleTime: DateTime(2026, 4, 1, 15),
+            moveTime: const Duration(minutes: 30),
+            isChanged: true,
+            isStarted: false,
+            scheduleSpareTime: const Duration(minutes: 5),
+            scheduleNote: null,
+            latenessTime: 7,
+          ),
+          place: const Place(id: 'place-model', placeName: 'Clinic'),
+        ).toScheduleEntity();
+
+        expect(entity.id, 'schedule-model');
+        expect(entity.place.placeName, 'Clinic');
+        expect(entity.scheduleNote, '');
+        expect(entity.doneStatus, ScheduleDoneStatus.notEnded);
+
+        final row = entity
+            .copyWith(doneStatus: ScheduleDoneStatus.normalEnd)
+            .toScheduleWithPlaceRow();
+
+        expect(row.schedule.id, 'schedule-model');
+        expect(row.schedule.placeId, 'place-model');
+        expect(row.schedule.scheduleName, 'Doctor');
+        expect(row.schedule.moveTime, const Duration(minutes: 30));
+        expect(row.schedule.scheduleNote, '');
+        expect(row.schedule.latenessTime, 7);
+        expect(row.place.placeName, 'Clinic');
+      },
+    );
+
+    test('maps users to and from database rows preserving profile values', () {
+      const row = User(
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User',
+        spareTime: 12,
+        note: 'note',
+        score: 4.5,
+      );
+
+      final entity = row.toUserEntity();
+      final roundTrip = entity.toUserRow();
+
+      expect(entity.valueOrNull, entity);
+      expect(entity.spareTimeOrNull, const Duration(minutes: 12));
+      expect(entity.scoreOrNull, 4.5);
+      expect(entity.nameOrNull, 'User');
+      expect(entity.emailOrNull, 'user@example.com');
+      expect(roundTrip.id, row.id);
+      expect(roundTrip.email, row.email);
+      expect(roundTrip.name, row.name);
+      expect(roundTrip.spareTime, row.spareTime);
+      expect(roundTrip.note, row.note);
+      expect(roundTrip.score, row.score);
+    });
+
+    test('empty users cannot be converted to database rows', () {
+      const entity = UserEntity.empty();
+
+      expect(entity.toUserRow, throwsException);
+    });
+
+    test('maps places and preparation steps to database rows', () {
+      const place = PlaceEntity(id: 'place-1', placeName: 'Office');
+      const step = PreparationStepEntity(
+        id: 'step-1',
+        preparationName: 'Pack',
+        preparationTime: Duration(minutes: 8),
+        nextPreparationId: 'step-2',
+      );
+
+      final placeRow = place.toPlaceRow();
+      final userStepRow = step.toPreparationUserRow('user-1');
+      final scheduleStepRow = step.toPreparationScheduleRow('schedule-1');
+
+      expect(placeRow.toPlaceEntity(), place);
+      expect(userStepRow.userId, 'user-1');
+      expect(userStepRow.preparationTime, 8);
+      expect(userStepRow.nextPreparationId, 'step-2');
+      expect(scheduleStepRow.scheduleId, 'schedule-1');
+      expect(scheduleStepRow.preparationName, 'Pack');
+    });
+  });
+}

--- a/test/domain/entities/domain_entity_boundary_test.dart
+++ b/test/domain/entities/domain_entity_boundary_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('domain entities do not import lower architectural layers', () {
+    final domainEntityDirectory = Directory('lib/domain/entities');
+    final forbiddenImportPattern = RegExp(
+      r'''import\s+['"](?:(?:package:on_time_front/)|/)?(?:core|data|presentation)/''',
+    );
+
+    final violations = domainEntityDirectory
+        .listSync()
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.dart'))
+        .where((file) => !file.path.endsWith('.freezed.dart'))
+        .expand((file) {
+          final lines = file.readAsLinesSync();
+          return [
+            for (var index = 0; index < lines.length; index++)
+              if (forbiddenImportPattern.hasMatch(lines[index]))
+                '${file.path}:${index + 1}: ${lines[index].trim()}',
+          ];
+        })
+        .toList();
+
+    expect(violations, isEmpty);
+  });
+}

--- a/test/domain/entities/preparation_timing_entity_test.dart
+++ b/test/domain/entities/preparation_timing_entity_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:on_time_front/core/database/database.dart';
-import 'package:on_time_front/data/tables/schedule_with_place_model.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_entity.dart';
 import 'package:on_time_front/domain/entities/preparation_step_entity.dart';
@@ -9,7 +7,6 @@ import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart'
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_with_preparation_entity.dart';
 import 'package:on_time_front/presentation/app/bloc/schedule/schedule_bloc.dart';
-import 'package:on_time_front/presentation/shared/constants/constants.dart';
 
 void main() {
   group('Preparation timing entities', () {
@@ -149,10 +146,6 @@ void main() {
       expect(progressed.currentStepRemainingTime, const Duration(minutes: 8));
       expect(progressed.currentStepName, 'dress');
       expect(progressed.stepElapsedTimesInSeconds, [600, 120]);
-      expect(progressed.preparationStepStates, [
-        PreparationStateEnum.done,
-        PreparationStateEnum.now,
-      ]);
       expect(progressed.progress, 0.6);
     });
 
@@ -162,10 +155,6 @@ void main() {
       expect(skipped.preparationStepList[0].isDone, isTrue);
       expect(skipped.preparationStepList[1].isDone, isFalse);
       expect(skipped.currentStep?.id, 's2');
-      expect(skipped.preparationStepStates, [
-        PreparationStateEnum.done,
-        PreparationStateEnum.now,
-      ]);
     });
 
     test('completed and empty preparations expose safe display fallbacks', () {
@@ -185,10 +174,6 @@ void main() {
       expect(completed.currentStepIndex, -1);
       expect(completed.resolvedCurrentStepIndex, 1);
       expect(completed.currentStepName, 'dress');
-      expect(completed.preparationStepStates, [
-        PreparationStateEnum.done,
-        PreparationStateEnum.done,
-      ]);
       expect(completed.skipCurrentStep(), same(completed));
       expect(
         completed.timeElapsed(const Duration(minutes: 1)),
@@ -197,7 +182,6 @@ void main() {
 
       expect(empty.currentStepName, '');
       expect(empty.progress, 0);
-      expect(empty.preparationStepStates, isEmpty);
       expect(zeroDuration.progress, 0);
     });
 
@@ -299,44 +283,7 @@ void main() {
     );
   });
 
-  group('ScheduleEntity model mapping', () {
-    test('maps to and from database models preserving user-visible fields', () {
-      final entity = ScheduleEntity.fromScheduleWithPlaceModel(
-        ScheduleWithPlace(
-          schedule: Schedule(
-            id: 'schedule-model',
-            placeId: 'place-model',
-            scheduleName: 'Doctor',
-            scheduleTime: DateTime(2026, 4, 1, 15),
-            moveTime: const Duration(minutes: 30),
-            isChanged: true,
-            isStarted: false,
-            scheduleSpareTime: const Duration(minutes: 5),
-            scheduleNote: null,
-            latenessTime: 7,
-          ),
-          place: const Place(id: 'place-model', placeName: 'Clinic'),
-        ),
-      );
-
-      expect(entity.id, 'schedule-model');
-      expect(entity.place.placeName, 'Clinic');
-      expect(entity.scheduleNote, '');
-      expect(entity.doneStatus, ScheduleDoneStatus.notEnded);
-
-      final model = entity
-          .copyWith(doneStatus: ScheduleDoneStatus.normalEnd)
-          .toScheduleWithPlaceModel();
-
-      expect(model.schedule.id, 'schedule-model');
-      expect(model.schedule.placeId, 'place-model');
-      expect(model.schedule.scheduleName, 'Doctor');
-      expect(model.schedule.moveTime, const Duration(minutes: 30));
-      expect(model.schedule.scheduleNote, '');
-      expect(model.schedule.latenessTime, 7);
-      expect(model.place.placeName, 'Clinic');
-    });
-
+  group('ScheduleEntity diagnostics', () {
     test(
       'string representation includes schedule identity for diagnostics',
       () {

--- a/test/domain/entities/user_entity_test.dart
+++ b/test/domain/entities/user_entity_test.dart
@@ -1,45 +1,31 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:on_time_front/core/database/database.dart';
 import 'package:on_time_front/domain/entities/user_entity.dart';
 
 void main() {
-  test('fromModel and toModel preserve user profile values', () {
-    const model = User(
+  test('user exposes profile convenience values', () {
+    const entity = UserEntity(
       id: 'user-1',
       email: 'user@example.com',
       name: 'User',
-      spareTime: 12,
+      spareTime: Duration(minutes: 12),
       note: 'note',
       score: 4.5,
     );
-
-    final entity = UserEntity.fromModel(model);
-    final roundTrip = entity.toModel();
 
     expect(entity.valueOrNull, entity);
     expect(entity.spareTimeOrNull, const Duration(minutes: 12));
     expect(entity.scoreOrNull, 4.5);
     expect(entity.nameOrNull, 'User');
     expect(entity.emailOrNull, 'user@example.com');
-    expect(roundTrip.id, model.id);
-    expect(roundTrip.email, model.email);
-    expect(roundTrip.name, model.name);
-    expect(roundTrip.spareTime, model.spareTime);
-    expect(roundTrip.note, model.note);
-    expect(roundTrip.score, model.score);
   });
 
-  test(
-    'empty user exposes null convenience values and cannot become a model',
-    () {
-      const entity = UserEntity.empty();
+  test('empty user exposes null convenience values', () {
+    const entity = UserEntity.empty();
 
-      expect(entity.valueOrNull, isNull);
-      expect(entity.spareTimeOrNull, isNull);
-      expect(entity.scoreOrNull, isNull);
-      expect(entity.nameOrNull, isNull);
-      expect(entity.emailOrNull, isNull);
-      expect(entity.toModel, throwsException);
-    },
-  );
+    expect(entity.valueOrNull, isNull);
+    expect(entity.spareTimeOrNull, isNull);
+    expect(entity.scoreOrNull, isNull);
+    expect(entity.nameOrNull, isNull);
+    expect(entity.emailOrNull, isNull);
+  });
 }

--- a/test/presentation/alarm/utils/preparation_step_state_mapper_test.dart
+++ b/test/presentation/alarm/utils/preparation_step_state_mapper_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/preparation_step_with_time_entity.dart';
+import 'package:on_time_front/domain/entities/preparation_with_time_entity.dart';
+import 'package:on_time_front/presentation/alarm/utils/preparation_step_state_mapper.dart';
+import 'package:on_time_front/presentation/shared/constants/constants.dart';
+
+void main() {
+  group('PreparationStepStateMapper', () {
+    const preparation = PreparationWithTimeEntity(
+      preparationStepList: [
+        PreparationStepWithTimeEntity(
+          id: 's1',
+          preparationName: 'wash',
+          preparationTime: Duration(minutes: 10),
+          nextPreparationId: 's2',
+        ),
+        PreparationStepWithTimeEntity(
+          id: 's2',
+          preparationName: 'dress',
+          preparationTime: Duration(minutes: 10),
+          nextPreparationId: null,
+        ),
+      ],
+    );
+
+    test('marks prior, current, and future preparation steps for display', () {
+      final progressed = preparation.timeElapsed(const Duration(minutes: 12));
+
+      expect(progressed.preparationStepStates, [
+        PreparationStateEnum.done,
+        PreparationStateEnum.now,
+      ]);
+    });
+
+    test('marks every step done when preparation is complete', () {
+      final completed = preparation.timeElapsed(const Duration(minutes: 20));
+
+      expect(completed.preparationStepStates, [
+        PreparationStateEnum.done,
+        PreparationStateEnum.done,
+      ]);
+    });
+
+    test('returns no display states for an empty preparation', () {
+      const empty = PreparationWithTimeEntity(preparationStepList: []);
+
+      expect(empty.preparationStepStates, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Move Drift/database row conversions from domain entities into data-layer mapper extensions
- Remove presentation UI-state derivation from `PreparationWithTimeEntity` and derive it in the alarm presentation layer
- Add boundary, mapper, and presentation-state tests for the new architecture rule

## Validation
- `flutter analyze`
- `flutter test`
- `rg` checks for forbidden domain imports and removed domain mapper method names

Closes #525