### PR TITLE
[codex] Add range-aware schedule watch

### DIFF
--- a/lib/data/repositories/schedule_repository_impl.dart
+++ b/lib/data/repositories/schedule_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/data/data_sources/schedule_local_data_source.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
@@ -16,6 +17,9 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
 
   late final _scheduleStreamController =
       BehaviorSubject<Set<ScheduleEntity>>.seeded(const <ScheduleEntity>{});
+  final _rangeStreamControllers =
+      <_ScheduleDateRange, BehaviorSubject<List<ScheduleEntity>>>{};
+  final _scheduleListEquality = const ListEquality<ScheduleEntity>();
 
   ScheduleRepositoryImpl({
     required this.scheduleLocalDataSource,
@@ -26,6 +30,22 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   @override
   Stream<Set<ScheduleEntity>> get scheduleStream =>
       _scheduleStreamController.stream;
+
+  @override
+  Stream<List<ScheduleEntity>> watchSchedulesByDate(
+    DateTime startDate,
+    DateTime endDate,
+  ) {
+    final range = _ScheduleDateRange(startDate: startDate, endDate: endDate);
+    return _rangeStreamControllers
+        .putIfAbsent(
+          range,
+          () => BehaviorSubject<List<ScheduleEntity>>.seeded(
+            _schedulesInRange(range),
+          ),
+        )
+        .stream;
+  }
 
   @override
   Future<void> createSchedule(ScheduleEntity schedule) async {
@@ -44,9 +64,10 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
       await scheduleRemoteDataSource.deleteSchedule(schedule);
       await _clearTimedPreparationSafe(schedule.id);
       //await scheduleLocalDataSource.deleteSchedule(schedule);
-      _scheduleStreamController.add(
+      _emitScheduleSet(
         Set.from(_scheduleStreamController.value)
           ..removeWhere((existing) => existing.id == schedule.id),
+        affectedRanges: _rangesContaining(schedule.scheduleTime),
       );
     } catch (e) {
       rethrow;
@@ -158,11 +179,23 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   }
 
   void _emitUpsertedSchedule(ScheduleEntity schedule) {
+    final existingSchedules = _scheduleStreamController.value.where(
+      (existing) => existing.id == schedule.id,
+    );
+    final previousSchedule = existingSchedules.isEmpty
+        ? null
+        : existingSchedules.first;
     final nextSchedules =
         Set<ScheduleEntity>.from(_scheduleStreamController.value)
           ..removeWhere((existing) => existing.id == schedule.id)
           ..add(schedule);
-    _scheduleStreamController.add(nextSchedules);
+    _emitScheduleSet(
+      nextSchedules,
+      affectedRanges: _rangesContainingAny([
+        schedule.scheduleTime,
+        if (previousSchedule != null) previousSchedule.scheduleTime,
+      ]),
+    );
   }
 
   void _replaceSchedulesInRange({
@@ -179,6 +212,88 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
     for (final schedule in schedules) {
       nextSchedules.add(schedule);
     }
-    _scheduleStreamController.add(nextSchedules);
+    final loadedRange = endDate == null
+        ? null
+        : _ScheduleDateRange(startDate: startDate, endDate: endDate);
+    _emitScheduleSet(
+      nextSchedules,
+      affectedRanges: loadedRange == null
+          ? _rangeStreamControllers.keys
+          : _rangesOverlapping(loadedRange),
+    );
   }
+
+  void _emitScheduleSet(
+    Set<ScheduleEntity> nextSchedules, {
+    required Iterable<_ScheduleDateRange> affectedRanges,
+  }) {
+    _scheduleStreamController.add(nextSchedules);
+    _publishRangeUpdates(affectedRanges);
+  }
+
+  Iterable<_ScheduleDateRange> _rangesContaining(DateTime scheduleTime) {
+    return _rangeStreamControllers.keys.where(
+      (range) => range.contains(scheduleTime),
+    );
+  }
+
+  Iterable<_ScheduleDateRange> _rangesContainingAny(
+    Iterable<DateTime> scheduleTimes,
+  ) {
+    return _rangeStreamControllers.keys.where(
+      (range) => scheduleTimes.any(range.contains),
+    );
+  }
+
+  Iterable<_ScheduleDateRange> _rangesOverlapping(_ScheduleDateRange range) {
+    return _rangeStreamControllers.keys.where(range.overlaps);
+  }
+
+  void _publishRangeUpdates(Iterable<_ScheduleDateRange> affectedRanges) {
+    for (final range in affectedRanges) {
+      final controller = _rangeStreamControllers[range];
+      if (controller == null || controller.isClosed) {
+        continue;
+      }
+      final nextSchedules = _schedulesInRange(range);
+      if (!_scheduleListEquality.equals(controller.value, nextSchedules)) {
+        controller.add(nextSchedules);
+      }
+    }
+  }
+
+  List<ScheduleEntity> _schedulesInRange(_ScheduleDateRange range) {
+    final schedules = _scheduleStreamController.value
+        .where((schedule) => range.contains(schedule.scheduleTime))
+        .toList();
+    schedules.sort((a, b) => a.scheduleTime.compareTo(b.scheduleTime));
+    return schedules;
+  }
+}
+
+class _ScheduleDateRange {
+  const _ScheduleDateRange({required this.startDate, required this.endDate});
+
+  final DateTime startDate;
+  final DateTime endDate;
+
+  bool contains(DateTime dateTime) {
+    return dateTime.compareTo(startDate) >= 0 && dateTime.isBefore(endDate);
+  }
+
+  bool overlaps(_ScheduleDateRange other) {
+    return startDate.isBefore(other.endDate) &&
+        other.startDate.isBefore(endDate);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is _ScheduleDateRange &&
+            startDate == other.startDate &&
+            endDate == other.endDate;
+  }
+
+  @override
+  int get hashCode => Object.hash(startDate, endDate);
 }

--- a/lib/domain/repositories/schedule_repository.dart
+++ b/lib/domain/repositories/schedule_repository.dart
@@ -3,6 +3,14 @@ import 'package:on_time_front/domain/entities/schedule_entity.dart';
 abstract interface class ScheduleRepository {
   Stream<Set<ScheduleEntity>> get scheduleStream;
 
+  /// Watch schedules already loaded in the given date range.
+  ///
+  /// [startDate] is inclusive and [endDate] is exclusive.
+  Stream<List<ScheduleEntity>> watchSchedulesByDate(
+    DateTime startDate,
+    DateTime endDate,
+  );
+
   /// Create a schedule
   /// This is for creating a schedule
   Future<void> createSchedule(ScheduleEntity schedule);

--- a/lib/domain/use-cases/get_schedules_by_date_use_case.dart
+++ b/lib/domain/use-cases/get_schedules_by_date_use_case.dart
@@ -8,18 +8,7 @@ class GetSchedulesByDateUseCase {
 
   GetSchedulesByDateUseCase(this._scheduleRepository);
 
-  Stream<List<ScheduleEntity>> call(
-      DateTime startDate, DateTime endDate) async* {
-    final schedulesStream = _scheduleRepository.scheduleStream;
-    await for (final schedules in schedulesStream) {
-      final filteredSchedules = schedules
-          .where((schedule) =>
-              schedule.scheduleTime.compareTo(startDate) >= 0 &&
-              schedule.scheduleTime.isBefore(endDate))
-          .toList();
-      filteredSchedules
-          .sort((a, b) => a.scheduleTime.compareTo(b.scheduleTime));
-      yield filteredSchedules;
-    }
+  Stream<List<ScheduleEntity>> call(DateTime startDate, DateTime endDate) {
+    return _scheduleRepository.watchSchedulesByDate(startDate, endDate);
   }
 }

--- a/test/data/repositories/schedule_repository_impl_stream_test.dart
+++ b/test/data/repositories/schedule_repository_impl_stream_test.dart
@@ -99,6 +99,120 @@ class FakeTimedPreparationRepository implements TimedPreparationRepository {
 
 void main() {
   test(
+    'watchSchedulesByDate emits inclusive-start exclusive-end schedules sorted by time',
+    () async {
+      final startDate = DateTime(2026, 3, 1);
+      final endDate = DateTime(2026, 4, 1);
+      final insideLater = _schedule(
+        id: 'inside-later',
+        scheduleTime: DateTime(2026, 3, 20, 13),
+      );
+      final insideStart = _schedule(
+        id: 'inside-start',
+        scheduleTime: startDate,
+      );
+      final before = _schedule(
+        id: 'before',
+        scheduleTime: DateTime(2026, 2, 28, 23, 59),
+      );
+      final exclusiveEnd = _schedule(
+        id: 'exclusive-end',
+        scheduleTime: endDate,
+      );
+
+      final repository = ScheduleRepositoryImpl(
+        scheduleLocalDataSource: FakeScheduleLocalDataSource(),
+        scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+          getSchedulesByDateHandler: (_, __) async => [
+            insideLater,
+            before,
+            exclusiveEnd,
+            insideStart,
+          ],
+        ),
+        timedPreparationRepository: FakeTimedPreparationRepository(),
+      );
+
+      final rangeStream = repository.watchSchedulesByDate(startDate, endDate);
+      await repository.getSchedulesByDate(startDate, endDate);
+
+      final schedules = await rangeStream.firstWhere(
+        (schedules) => schedules.length == 2,
+      );
+
+      expect(schedules.map((schedule) => schedule.id), [
+        'inside-start',
+        'inside-later',
+      ]);
+    },
+  );
+
+  test(
+    'active date range watches update only when their visible schedules change',
+    () async {
+      final marchStart = DateTime(2026, 3, 1);
+      final marchEnd = DateTime(2026, 4, 1);
+      final aprilStart = DateTime(2026, 4, 1);
+      final aprilEnd = DateTime(2026, 5, 1);
+      final marchSchedule = _schedule(
+        id: 'march',
+        scheduleTime: DateTime(2026, 3, 20, 9),
+      );
+      final aprilSchedule = _schedule(
+        id: 'april',
+        scheduleTime: DateTime(2026, 4, 10, 9),
+      );
+
+      final repository = ScheduleRepositoryImpl(
+        scheduleLocalDataSource: FakeScheduleLocalDataSource(),
+        scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+          getSchedulesByDateHandler: (startDate, _) async {
+            if (startDate == marchStart) {
+              return [marchSchedule];
+            }
+            return [aprilSchedule];
+          },
+        ),
+        timedPreparationRepository: FakeTimedPreparationRepository(),
+      );
+      final marchEvents = <List<ScheduleEntity>>[];
+      final aprilEvents = <List<ScheduleEntity>>[];
+      final marchSubscription = repository
+          .watchSchedulesByDate(marchStart, marchEnd)
+          .listen(marchEvents.add);
+      final aprilSubscription = repository
+          .watchSchedulesByDate(aprilStart, aprilEnd)
+          .listen(aprilEvents.add);
+      addTearDown(marchSubscription.cancel);
+      addTearDown(aprilSubscription.cancel);
+      await pumpEventQueue();
+
+      await repository.getSchedulesByDate(marchStart, marchEnd);
+      await pumpEventQueue();
+
+      expect(marchEvents.map((event) => event.map((s) => s.id).toList()), [
+        <String>[],
+        ['march'],
+      ]);
+      expect(aprilEvents.map((event) => event.map((s) => s.id).toList()), [
+        <String>[],
+      ]);
+
+      await repository.getSchedulesByDate(aprilStart, aprilEnd);
+      await pumpEventQueue();
+
+      expect(marchEvents.map((event) => event.map((s) => s.id).toList()), [
+        <String>[],
+        ['march'],
+      ]);
+      expect(aprilEvents.map((event) => event.map((s) => s.id).toList()), [
+        <String>[],
+        ['april'],
+      ]);
+    },
+  );
+
+  test(
     'getSchedulesByDate upserts existing schedule by id in stream cache',
     () async {
       final startDate = DateTime(2026, 3, 1);
@@ -209,4 +323,18 @@ void main() {
     expect(latest.first.moveTime, const Duration(minutes: 20));
     expect(latest.first.scheduleSpareTime, const Duration(minutes: 15));
   });
+}
+
+ScheduleEntity _schedule({required String id, required DateTime scheduleTime}) {
+  return ScheduleEntity(
+    id: id,
+    place: const PlaceEntity(id: 'place-1', placeName: 'Office'),
+    scheduleName: id,
+    scheduleTime: scheduleTime,
+    moveTime: const Duration(minutes: 10),
+    isChanged: false,
+    isStarted: false,
+    scheduleSpareTime: const Duration(minutes: 5),
+    scheduleNote: '',
+  );
 }

--- a/test/domain/use-cases/schedule_date_use_cases_test.dart
+++ b/test/domain/use-cases/schedule_date_use_cases_test.dart
@@ -17,28 +17,23 @@ import 'package:on_time_front/domain/use-cases/load_schedules_for_week_use_case.
 
 void main() {
   test(
-    'GetSchedulesByDateUseCase filters inclusive start exclusive end sorted',
+    'GetSchedulesByDateUseCase watches requested schedule date range',
     () async {
       final repository = _FakeScheduleRepository();
       final useCase = GetSchedulesByDateUseCase(repository);
       final start = DateTime(2026, 5, 10);
       final end = DateTime(2026, 5, 17);
-      final resultFuture = useCase(start, end).first;
-      await pumpEventQueue();
-
-      repository.emit([
-        _schedule('late', DateTime(2026, 5, 18)),
+      repository.watchResult = [
         _schedule('inside-later', DateTime(2026, 5, 12, 9)),
         _schedule('inside-start', DateTime(2026, 5, 10)),
-        _schedule('before', DateTime(2026, 5, 9, 23, 59)),
-        _schedule('exclusive-end', end),
-      ]);
+      ];
 
-      final result = await resultFuture;
+      final result = await useCase(start, end).first;
 
+      expect(repository.watchedRanges, [(start, end)]);
       expect(result.map((schedule) => schedule.id), [
-        'inside-start',
         'inside-later',
+        'inside-start',
       ]);
     },
   );
@@ -186,15 +181,23 @@ class _RecordingLoadSchedulesByDateUseCase
 }
 
 class _FakeScheduleRepository implements ScheduleRepository {
-  final _controller = StreamController<Set<ScheduleEntity>>.broadcast();
   final loadedRanges = <(DateTime, DateTime?)>[];
+  final watchedRanges = <(DateTime, DateTime)>[];
+  List<ScheduleEntity> watchResult = const [];
 
-  void emit(List<ScheduleEntity> schedules) {
-    _controller.add(schedules.toSet());
+  @override
+  Stream<Set<ScheduleEntity>> get scheduleStream {
+    throw StateError('Use watchSchedulesByDate for range schedule streams.');
   }
 
   @override
-  Stream<Set<ScheduleEntity>> get scheduleStream => _controller.stream;
+  Stream<List<ScheduleEntity>> watchSchedulesByDate(
+    DateTime startDate,
+    DateTime endDate,
+  ) {
+    watchedRanges.add((startDate, endDate));
+    return Stream.value(watchResult);
+  }
 
   @override
   Future<List<ScheduleEntity>> getSchedulesByDate(

--- a/test/domain/use-cases/schedule_mutation_use_cases_test.dart
+++ b/test/domain/use-cases/schedule_mutation_use_cases_test.dart
@@ -143,6 +143,12 @@ class _FakeScheduleRepository implements ScheduleRepository {
   Stream<Set<ScheduleEntity>> get scheduleStream => const Stream.empty();
 
   @override
+  Stream<List<ScheduleEntity>> watchSchedulesByDate(
+    DateTime startDate,
+    DateTime endDate,
+  ) => const Stream.empty();
+
+  @override
   Future<void> createSchedule(ScheduleEntity schedule) async {
     createdSchedules.add(schedule);
   }

--- a/test/domain/use-cases/timed_preparation_use_cases_test.dart
+++ b/test/domain/use-cases/timed_preparation_use_cases_test.dart
@@ -350,6 +350,23 @@ class _FakeScheduleRepository implements ScheduleRepository {
   Stream<Set<ScheduleEntity>> get scheduleStream => Stream.value(_schedules);
 
   @override
+  Stream<List<ScheduleEntity>> watchSchedulesByDate(
+    DateTime startDate,
+    DateTime endDate,
+  ) {
+    return Stream.value(
+      _schedules
+          .where(
+            (schedule) =>
+                schedule.scheduleTime.compareTo(startDate) >= 0 &&
+                schedule.scheduleTime.isBefore(endDate),
+          )
+          .toList()
+        ..sort((a, b) => a.scheduleTime.compareTo(b.scheduleTime)),
+    );
+  }
+
+  @override
   Future<void> createSchedule(ScheduleEntity schedule) async {}
 
   @override


### PR DESCRIPTION
## Summary

- Add a range-aware schedule watch API to the schedule repository.
- Move date-range filtering and sorting out of each `GetSchedulesByDateUseCase` subscriber and into the repository projection.
- Update schedule stream tests to cover inclusive-start/exclusive-end behavior, sorted output, multiple active ranges, and unrelated range updates.

## Why

Fixes #526. Weekly and monthly schedule consumers previously subscribed to one global schedule stream and repeated filtering/sorting independently on every emission. The repository now owns scoped sorted range streams while the existing load path remains responsible for remote fetch/cache updates.

## Validation

- `flutter analyze`
- `flutter test`
