### PR TITLE
Fix swapped schedule date/time input model filenames

### DIFF
--- a/lib/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model.dart
@@ -1,17 +1,15 @@
 import 'package:formz/formz.dart';
 
-/// Validation errors for the [ScheduleTimeInputModel] [FormzInput].
-enum ScheduleTimeValidationError {
-  empty,
-}
+/// Validation errors for the [ScheduleDateInputModel] [FormzInput].
+enum ScheduleDateValidationError { empty }
 
-class ScheduleTimeInputModel
-    extends FormzInput<DateTime?, ScheduleTimeValidationError> {
-  const ScheduleTimeInputModel.pure([super.value]) : super.pure();
-  const ScheduleTimeInputModel.dirty([super.value]) : super.dirty();
+class ScheduleDateInputModel
+    extends FormzInput<DateTime?, ScheduleDateValidationError> {
+  const ScheduleDateInputModel.pure([super.value]) : super.pure();
+  const ScheduleDateInputModel.dirty([super.value]) : super.dirty();
 
   @override
-  ScheduleTimeValidationError? validator(DateTime? value) {
-    return value == null ? ScheduleTimeValidationError.empty : null;
+  ScheduleDateValidationError? validator(DateTime? value) {
+    return value == null ? ScheduleDateValidationError.empty : null;
   }
 }

--- a/lib/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model.dart
+++ b/lib/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model.dart
@@ -1,17 +1,15 @@
 import 'package:formz/formz.dart';
 
-/// Validation errors for the [ScheduleDateInputModel] [FormzInput].
-enum ScheduleDateValidationError {
-  empty,
-}
+/// Validation errors for the [ScheduleTimeInputModel] [FormzInput].
+enum ScheduleTimeValidationError { empty }
 
-class ScheduleDateInputModel
-    extends FormzInput<DateTime?, ScheduleDateValidationError> {
-  const ScheduleDateInputModel.pure([super.value]) : super.pure();
-  const ScheduleDateInputModel.dirty([super.value]) : super.dirty();
+class ScheduleTimeInputModel
+    extends FormzInput<DateTime?, ScheduleTimeValidationError> {
+  const ScheduleTimeInputModel.pure([super.value]) : super.pure();
+  const ScheduleTimeInputModel.dirty([super.value]) : super.dirty();
 
   @override
-  ScheduleDateValidationError? validator(DateTime? value) {
-    return value == null ? ScheduleDateValidationError.empty : null;
+  ScheduleTimeValidationError? validator(DateTime? value) {
+    return value == null ? ScheduleTimeValidationError.empty : null;
   }
 }

--- a/test/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model_test.dart
+++ b/test/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_date_time/input_models/schedule_date_input_model.dart';
+
+void main() {
+  test(
+    'schedule date input validates independently from the date model file',
+    () {
+      final validDate = DateTime(2026, 7, 1);
+
+      expect(
+        const ScheduleDateInputModel.dirty().error,
+        ScheduleDateValidationError.empty,
+      );
+      expect(ScheduleDateInputModel.dirty(validDate).isValid, isTrue);
+    },
+  );
+}

--- a/test/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model_test.dart
+++ b/test/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/presentation/schedule_create/schedule_date_time/input_models/schedule_time_input_model.dart';
+
+void main() {
+  test(
+    'schedule time input validates independently from the time model file',
+    () {
+      final validTime = DateTime(2026, 7, 1, 9, 30);
+
+      expect(
+        const ScheduleTimeInputModel.dirty().error,
+        ScheduleTimeValidationError.empty,
+      );
+      expect(ScheduleTimeInputModel.dirty(validTime).isValid, isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Move `ScheduleDateInputModel` and `ScheduleDateValidationError` into `schedule_date_input_model.dart`.
- Move `ScheduleTimeInputModel` and `ScheduleTimeValidationError` into `schedule_time_input_model.dart`.
- Add independent import tests for each input model file.

Closes #547

## Tests
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/presentation/schedule_create/schedule_date_time`
- `flutter analyze`