### PR TITLE
fix: normalize schedule date ranges

### DIFF
--- a/lib/data/daos/schedule_dao.dart
+++ b/lib/data/daos/schedule_dao.dart
@@ -14,31 +14,27 @@ class ScheduleDao extends DatabaseAccessor<AppDatabase>
   ScheduleDao(this.db) : super(db);
 
   Future<ScheduleWithPlace> createSchedule(
-      ScheduleWithPlace scheduleWithPlace) async {
+    ScheduleWithPlace scheduleWithPlace,
+  ) async {
     final placeModel = await db.placeDao.createPlace(scheduleWithPlace.place);
-    final scheduleModel = await into(db.schedules).insertReturning(
-      scheduleWithPlace.schedule.toCompanion(false),
-    );
+    final scheduleModel = await into(
+      db.schedules,
+    ).insertReturning(scheduleWithPlace.schedule.toCompanion(false));
 
-    return ScheduleWithPlace(
-      schedule: scheduleModel,
-      place: placeModel,
-    );
+    return ScheduleWithPlace(schedule: scheduleModel, place: placeModel);
   }
 
   Future<void> deleteSchedule(Schedule scheduleModel) async {
-    await (delete(db.schedules)
-          ..where((tbl) => tbl.id.equals(scheduleModel.id)))
-        .go();
+    await (delete(
+      db.schedules,
+    )..where((tbl) => tbl.id.equals(scheduleModel.id))).go();
   }
 
   Future<ScheduleWithPlace> getScheduleById(String id) async {
     try {
       final query = await (select(db.schedules).join([
         leftOuterJoin(db.places, db.places.id.equalsExp(db.schedules.placeId)),
-      ])
-            ..where(db.schedules.id.equals(id)))
-          .getSingle();
+      ])..where(db.schedules.id.equals(id))).getSingle();
       return ScheduleWithPlace(
         schedule: query.readTable(db.schedules),
         place: query.readTable(db.places),
@@ -49,30 +45,40 @@ class ScheduleDao extends DatabaseAccessor<AppDatabase>
   }
 
   Future<Schedule> updateSchedule(Schedule scheduleModel) async {
-    final scheduleList = await (update(db.schedules)
-          ..where((tbl) => tbl.id.equals(scheduleModel.id)))
-        .writeReturning(scheduleModel.toCompanion(true));
+    final scheduleList =
+        await (update(db.schedules)
+              ..where((tbl) => tbl.id.equals(scheduleModel.id)))
+            .writeReturning(scheduleModel.toCompanion(true));
     assert(scheduleList.length == 1);
     return scheduleList.first;
   }
 
   Future<List<ScheduleWithPlace>> getSchedulesByDate(
-      DateTime startDate, DateTime? endDate) async {
-    final query = select(db.schedules).join([
-      leftOuterJoin(db.places, db.places.id.equalsExp(db.schedules.placeId)),
-    ])
-      ..where(db.schedules.scheduleTime.isBiggerOrEqualValue(startDate) &
-          (endDate == null
-              ? Constant<bool>(true)
-              : db.schedules.scheduleTime.isSmallerOrEqualValue(endDate)));
+    DateTime startDate,
+    DateTime? endDate,
+  ) async {
+    final query =
+        select(db.schedules).join([
+          leftOuterJoin(
+            db.places,
+            db.places.id.equalsExp(db.schedules.placeId),
+          ),
+        ])..where(
+          db.schedules.scheduleTime.isBiggerOrEqualValue(startDate) &
+              (endDate == null
+                  ? Constant<bool>(true)
+                  : db.schedules.scheduleTime.isSmallerThanValue(endDate)),
+        );
     final result = await query.get();
     final List<ScheduleWithPlace> scheduleList = [];
 
     await Future.forEach(result, (schedule) async {
-      scheduleList.add(ScheduleWithPlace(
-        schedule: schedule.readTable(db.schedules),
-        place: schedule.readTable(db.places),
-      ));
+      scheduleList.add(
+        ScheduleWithPlace(
+          schedule: schedule.readTable(db.schedules),
+          place: schedule.readTable(db.places),
+        ),
+      );
     });
     return scheduleList;
   }
@@ -85,10 +91,12 @@ class ScheduleDao extends DatabaseAccessor<AppDatabase>
     final List<ScheduleWithPlace> scheduleList = [];
 
     await Future.forEach(result, (schedule) async {
-      scheduleList.add(ScheduleWithPlace(
-        schedule: schedule.readTable(db.schedules),
-        place: schedule.readTable(db.places),
-      ));
+      scheduleList.add(
+        ScheduleWithPlace(
+          schedule: schedule.readTable(db.schedules),
+          place: schedule.readTable(db.places),
+        ),
+      );
     });
     return scheduleList;
   }

--- a/lib/domain/use-cases/load_schedules_for_month_use_case.dart
+++ b/lib/domain/use-cases/load_schedules_for_month_use_case.dart
@@ -9,8 +9,8 @@ class LoadSchedulesForMonthUseCase {
 
   Future<void> call(DateTime date) async {
     final startOfMonth = DateTime(date.year, date.month, 1);
-    final endOfMonth = DateTime(date.year, date.month + 1, 0);
+    final startOfNextMonth = DateTime(date.year, date.month + 1, 1);
 
-    await _loadSchedulesByDateUseCase(startOfMonth, endOfMonth);
+    await _loadSchedulesByDateUseCase(startOfMonth, startOfNextMonth);
   }
 }

--- a/test/data/daos/schedule_dao_test.dart
+++ b/test/data/daos/schedule_dao_test.dart
@@ -47,158 +47,174 @@ void main() async {
   tearDown(() async {
     await appDatabase.close();
   });
-  group(
-    'createSchedule',
-    () {
-      test(
-        'should insert a schedule into the database',
-        () async {
-          final result =
-              await scheduleDao.createSchedule(scheduleWithPlaceModel);
-          expect(result, equals(scheduleWithPlaceModel));
-        },
-      );
-    },
-  );
+  group('createSchedule', () {
+    test('should insert a schedule into the database', () async {
+      final result = await scheduleDao.createSchedule(scheduleWithPlaceModel);
+      expect(result, equals(scheduleWithPlaceModel));
+    });
+  });
 
   group('updateSchedule', () {
-    test(
-      'should update a schedule in the database',
-      () async {
-        //arange
-        await appDatabase.into(appDatabase.places).insert(
-              placeModel.toCompanion(false),
-            );
-        await appDatabase.into(appDatabase.schedules).insertReturning(
-              scheduleModel.toCompanion(false),
-            );
+    test('should update a schedule in the database', () async {
+      //arange
+      await appDatabase
+          .into(appDatabase.places)
+          .insert(placeModel.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(scheduleModel.toCompanion(false));
 
-        final updatedScheduleModel = scheduleModel.copyWith(
-          scheduleName: 'Updated Schedule',
-        );
+      final updatedScheduleModel = scheduleModel.copyWith(
+        scheduleName: 'Updated Schedule',
+      );
 
-        //act
-        final result = await scheduleDao.updateSchedule(updatedScheduleModel);
+      //act
+      final result = await scheduleDao.updateSchedule(updatedScheduleModel);
 
-        //assert
-        expect(result, equals(updatedScheduleModel));
-      },
-    );
+      //assert
+      expect(result, equals(updatedScheduleModel));
+    });
   });
-  group(
-    'deleteSchedule',
-    () {
-      test(
-        'should delete a schedule from the database',
-        () async {
-          //arange
-          await appDatabase.into(appDatabase.places).insert(
-                placeModel.toCompanion(false),
-              );
-          await appDatabase.into(appDatabase.schedules).insertReturning(
-                scheduleModel.toCompanion(false),
-              );
+  group('deleteSchedule', () {
+    test('should delete a schedule from the database', () async {
+      //arange
+      await appDatabase
+          .into(appDatabase.places)
+          .insert(placeModel.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(scheduleModel.toCompanion(false));
 
-          appDatabase.select(appDatabase.schedules).get().then(
-            (value) {
-              expect(value, isNotEmpty);
-            },
-          );
+      appDatabase.select(appDatabase.schedules).get().then((value) {
+        expect(value, isNotEmpty);
+      });
 
-          //act
-          await scheduleDao.deleteSchedule(scheduleModel);
+      //act
+      await scheduleDao.deleteSchedule(scheduleModel);
 
-          //assert
-          appDatabase.select(appDatabase.schedules).get().then(
-            (value) {
-              expect(value, isEmpty);
-            },
-          );
-        },
-      );
-    },
-  );
-  group(
-    'getScheduleById',
-    () {
-      test(
-        'should return a schedule from the database of given [id]',
-        () async {
-          //arange
-          await appDatabase.into(appDatabase.places).insert(
-                placeModel.toCompanion(false),
-              );
-          await appDatabase.into(appDatabase.schedules).insertReturning(
-                scheduleModel.toCompanion(false),
-              );
+      //assert
+      appDatabase.select(appDatabase.schedules).get().then((value) {
+        expect(value, isEmpty);
+      });
+    });
+  });
+  group('getScheduleById', () {
+    test('should return a schedule from the database of given [id]', () async {
+      //arange
+      await appDatabase
+          .into(appDatabase.places)
+          .insert(placeModel.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(scheduleModel.toCompanion(false));
 
-          //act
-          final result = await scheduleDao.getScheduleById(scheduleModel.id);
+      //act
+      final result = await scheduleDao.getScheduleById(scheduleModel.id);
 
-          //
-          expect(result, equals(scheduleWithPlaceModel));
-        },
-      );
-    },
-  );
+      //
+      expect(result, equals(scheduleWithPlaceModel));
+    });
+  });
 
   group('getSchedulesByDate', () {
-    test('should return a list of schedules between [startDate] and [endDate]',
-        () async {
-      //arange
-      final laterDate = scheduleTime.add(Duration(days: 4));
-      final laterScheduleModel = scheduleModel.copyWith(
+    test('includes start date and excludes exact end date', () async {
+      final rangeStart = DateTime(2026, 2, 1);
+      final rangeEnd = DateTime(2026, 3, 1);
+      final startBoundarySchedule = scheduleModel.copyWith(
         id: uuid.v7(),
-        scheduleTime: laterDate,
+        scheduleTime: rangeStart,
+      );
+      final lastDaySchedule = scheduleModel.copyWith(
+        id: uuid.v7(),
+        scheduleTime: DateTime(2026, 2, 28, 23, 59),
+      );
+      final endBoundarySchedule = scheduleModel.copyWith(
+        id: uuid.v7(),
+        scheduleTime: rangeEnd,
       );
 
-      await appDatabase.into(appDatabase.places).insert(
-            placeModel.toCompanion(false),
-          );
-      await appDatabase.into(appDatabase.schedules).insertReturning(
-            scheduleModel.toCompanion(false),
-          );
-      await appDatabase.into(appDatabase.schedules).insertReturning(
-            laterScheduleModel.toCompanion(false),
-          );
+      await appDatabase
+          .into(appDatabase.places)
+          .insert(placeModel.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(startBoundarySchedule.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(lastDaySchedule.toCompanion(false));
+      await appDatabase
+          .into(appDatabase.schedules)
+          .insertReturning(endBoundarySchedule.toCompanion(false));
 
-      //act
-      final result = await scheduleDao.getSchedulesByDate(startDate, endDate);
+      final result = await scheduleDao.getSchedulesByDate(rangeStart, rangeEnd);
 
-      //assert
-      expect(result, equals([scheduleWithPlaceModel]));
+      expect(
+        result.map((scheduleWithPlace) => scheduleWithPlace.schedule.id),
+        unorderedEquals([startBoundarySchedule.id, lastDaySchedule.id]),
+      );
     });
 
     test(
-        'should return a list of schedules later then [startDate] if [endDate] is null',
-        () async {
-      //arange
-      final laterDate = DateTime(2022, 1, 4, 0, 0, 0, 0);
-      final laterScheduleModel = scheduleModel.copyWith(
-        id: uuid.v7(),
-        scheduleTime: laterDate,
-      );
-      final laterScheduleWithPlaceModel = ScheduleWithPlace(
-        schedule: laterScheduleModel,
-        place: placeModel,
-      );
+      'should return a list of schedules between [startDate] and [endDate]',
+      () async {
+        //arange
+        final laterDate = scheduleTime.add(Duration(days: 4));
+        final laterScheduleModel = scheduleModel.copyWith(
+          id: uuid.v7(),
+          scheduleTime: laterDate,
+        );
 
-      await appDatabase.into(appDatabase.places).insert(
-            placeModel.toCompanion(false),
-          );
-      await appDatabase.into(appDatabase.schedules).insertReturning(
-            scheduleModel.toCompanion(false),
-          );
-      await appDatabase.into(appDatabase.schedules).insertReturning(
-            laterScheduleModel.toCompanion(false),
-          );
+        await appDatabase
+            .into(appDatabase.places)
+            .insert(placeModel.toCompanion(false));
+        await appDatabase
+            .into(appDatabase.schedules)
+            .insertReturning(scheduleModel.toCompanion(false));
+        await appDatabase
+            .into(appDatabase.schedules)
+            .insertReturning(laterScheduleModel.toCompanion(false));
 
-      //act
-      final result = await scheduleDao.getSchedulesByDate(startDate, null);
+        //act
+        final result = await scheduleDao.getSchedulesByDate(startDate, endDate);
 
-      //assert
-      expect(result,
-          equals([scheduleWithPlaceModel, laterScheduleWithPlaceModel]));
-    });
+        //assert
+        expect(result, equals([scheduleWithPlaceModel]));
+      },
+    );
+
+    test(
+      'should return a list of schedules later then [startDate] if [endDate] is null',
+      () async {
+        //arange
+        final laterDate = DateTime(2022, 1, 4, 0, 0, 0, 0);
+        final laterScheduleModel = scheduleModel.copyWith(
+          id: uuid.v7(),
+          scheduleTime: laterDate,
+        );
+        final laterScheduleWithPlaceModel = ScheduleWithPlace(
+          schedule: laterScheduleModel,
+          place: placeModel,
+        );
+
+        await appDatabase
+            .into(appDatabase.places)
+            .insert(placeModel.toCompanion(false));
+        await appDatabase
+            .into(appDatabase.schedules)
+            .insertReturning(scheduleModel.toCompanion(false));
+        await appDatabase
+            .into(appDatabase.schedules)
+            .insertReturning(laterScheduleModel.toCompanion(false));
+
+        //act
+        final result = await scheduleDao.getSchedulesByDate(startDate, null);
+
+        //assert
+        expect(
+          result,
+          equals([scheduleWithPlaceModel, laterScheduleWithPlaceModel]),
+        );
+      },
+    );
   });
 }

--- a/test/data/data_sources/schedule_local_data_source_test.dart
+++ b/test/data/data_sources/schedule_local_data_source_test.dart
@@ -83,6 +83,43 @@ void main() {
     expect(schedules.single.latenessTime, 2);
   });
 
+  test(
+    'filters schedule date ranges as start-inclusive and end-exclusive',
+    () async {
+      final startBoundary = _schedule(
+        id: 'start-boundary',
+        placeId: 'place-1',
+        placeName: 'Office',
+        time: DateTime(2026, 2, 1),
+      );
+      final lastDay = _schedule(
+        id: 'last-day',
+        placeId: 'place-2',
+        placeName: 'Cafe',
+        time: DateTime(2026, 2, 28, 23, 59),
+      );
+      final nextMonthStart = _schedule(
+        id: 'next-month-start',
+        placeId: 'place-3',
+        placeName: 'Station',
+        time: DateTime(2026, 3, 1),
+      );
+      await dataSource.createSchedule(startBoundary);
+      await dataSource.createSchedule(lastDay);
+      await dataSource.createSchedule(nextMonthStart);
+
+      final schedules = await dataSource.getSchedulesByDate(
+        DateTime(2026, 2, 1),
+        DateTime(2026, 3, 1),
+      );
+
+      expect(
+        schedules.map((schedule) => schedule.id),
+        unorderedEquals(['start-boundary', 'last-day']),
+      );
+    },
+  );
+
   test('deleteSchedule removes only the requested schedule', () async {
     await dataSource.createSchedule(
       _schedule(

--- a/test/domain/use-cases/schedule_date_use_cases_test.dart
+++ b/test/domain/use-cases/schedule_date_use_cases_test.dart
@@ -60,7 +60,7 @@ void main() {
 
       await useCase(DateTime(2026, 2, 14));
 
-      expect(recorder.calls, [(DateTime(2026, 2), DateTime(2026, 2, 28))]);
+      expect(recorder.calls, [(DateTime(2026, 2), DateTime(2026, 3))]);
     },
   );
 


### PR DESCRIPTION
## Summary

- Normalize local DAO schedule date range filtering to the existing inclusive-start, exclusive-end contract.
- Load calendar months as `[first day, first day of next month)` so final-day schedules are included.
- Add DAO, local data source, and domain use-case coverage for date range boundary behavior.

## Tests

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/data/daos/schedule_dao_test.dart` (red, then green)
- `flutter test test/domain/use-cases/schedule_date_use_cases_test.dart` (red, then green)
- `flutter test test/data/data_sources/schedule_local_data_source_test.dart`
- `flutter analyze`
- `flutter test`

Closes #540
