### PR TITLE
Use runtime app metadata for version reporting

### DIFF
--- a/lib/core/services/app_metadata_service.dart
+++ b/lib/core/services/app_metadata_service.dart
@@ -1,0 +1,25 @@
+import 'package:injectable/injectable.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class AppMetadata {
+  const AppMetadata({required this.version, required this.buildNumber});
+
+  final String version;
+  final String buildNumber;
+}
+
+abstract interface class AppMetadataProvider {
+  Future<AppMetadata> getMetadata();
+}
+
+@Singleton(as: AppMetadataProvider)
+class PackageInfoAppMetadataProvider implements AppMetadataProvider {
+  @override
+  Future<AppMetadata> getMetadata() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    return AppMetadata(
+      version: packageInfo.version,
+      buildNumber: packageInfo.buildNumber,
+    );
+  }
+}

--- a/lib/core/services/product_analytics_service.dart
+++ b/lib/core/services/product_analytics_service.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/core/services/device_info_service/shared.dart';
 import 'package:on_time_front/domain/entities/analytics_preference.dart';
 import 'package:on_time_front/domain/entities/product_usage_event.dart';
@@ -45,14 +46,17 @@ class FirebaseAnalyticsProviderClient implements AnalyticsProviderClient {
 class ProductAnalyticsService {
   ProductAnalyticsService({
     required AnalyticsProviderClient client,
+    required AppMetadataProvider appMetadataProvider,
     @ignoreParam
     bool collectionAllowedInBuild = const bool.fromEnvironment(
       'ONTIME_ANALYTICS_ENABLED',
     ),
   }) : _client = client,
+       _appMetadataProvider = appMetadataProvider,
        _collectionAllowedInBuild = collectionAllowedInBuild;
 
   final AnalyticsProviderClient _client;
+  final AppMetadataProvider _appMetadataProvider;
   final bool _collectionAllowedInBuild;
   bool _collectionEnabled = false;
 
@@ -66,11 +70,12 @@ class ProductAnalyticsService {
 
   Future<void> track(ProductUsageEvent event) async {
     if (!_collectionEnabled) return;
+    final metadata = await _appMetadataProvider.getMetadata();
     await _client.logEvent(
       name: event.name,
       parameters: event.toAnalyticsParameters(
         platform: _platformWireValue(),
-        appVersion: '1.0.0',
+        appVersion: metadata.version,
       ),
     );
   }

--- a/lib/data/repositories/alarm_repository_impl.dart
+++ b/lib/data/repositories/alarm_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/core/services/device_info_service/shared.dart';
 import 'package:on_time_front/core/validation/backend_constraints.dart';
 import 'package:on_time_front/data/data_sources/alarm_remote_data_source.dart';
@@ -13,10 +14,12 @@ import 'package:uuid/uuid.dart';
 class AlarmRepositoryImpl implements AlarmRepository {
   final AlarmRemoteDataSource remoteDataSource;
   final AlarmSchedulerService schedulerService;
+  final AppMetadataProvider appMetadataProvider;
 
   AlarmRepositoryImpl({
     required this.remoteDataSource,
     required this.schedulerService,
+    required this.appMetadataProvider,
   });
 
   static const _deviceIdKey = 'alarm_device_id';
@@ -38,10 +41,11 @@ class AlarmRepositoryImpl implements AlarmRepository {
   @override
   Future<AlarmDeviceInfo> buildCurrentDeviceInfo() async {
     final capabilities = await schedulerService.getCapabilities();
+    final metadata = await appMetadataProvider.getMetadata();
     return AlarmDeviceInfo(
       deviceId: await getDeviceId(),
       platform: _platformWireValue(),
-      appVersion: '1.0.0',
+      appVersion: metadata.version,
       osVersion: _osWireValue(),
       supportsNativeAlarm: capabilities.supportsNativeAlarm,
       nativeAlarmProvider: capabilities.nativeAlarmProvider,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import flutter_appauth
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import google_sign_in_ios
+import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 import sign_in_with_apple
@@ -27,6 +28,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -972,6 +972,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.2.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ dependencies:
   sign_in_with_apple: ^8.1.0
   permission_handler: ^12.0.3
   firebase_analytics: ^12.4.3
+  package_info_plus: ^10.2.0
 
 
 

--- a/test/core/services/app_metadata_service_test.dart
+++ b/test/core/services/app_metadata_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  test('package info metadata provider returns runtime app metadata', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'OnTime',
+      packageName: 'devkor.ontime',
+      version: '9.8.7',
+      buildNumber: '654',
+      buildSignature: '',
+    );
+
+    final metadata = await PackageInfoAppMetadataProvider().getMetadata();
+
+    expect(metadata.version, '9.8.7');
+    expect(metadata.buildNumber, '654');
+  });
+}

--- a/test/core/services/product_analytics_service_test.dart
+++ b/test/core/services/product_analytics_service_test.dart
@@ -1,18 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/core/services/product_analytics_service.dart';
 import 'package:on_time_front/domain/entities/analytics_preference.dart';
 import 'package:on_time_front/domain/entities/product_usage_event.dart';
 
 void main() {
-  test('unconfirmed analytics preference does not log product usage events', () async {
+  test('product usage events include the runtime app version', () async {
     final client = _FakeAnalyticsProviderClient();
     final service = ProductAnalyticsService(
       client: client,
+      appMetadataProvider: _FakeAppMetadataProvider(
+        const AppMetadata(version: '9.8.7', buildNumber: '654'),
+      ),
       collectionAllowedInBuild: true,
     );
 
     await service.applyPreference(
-      const AnalyticsPreference(enabled: true, isConfirmed: false),
+      const AnalyticsPreference(enabled: true, isConfirmed: true),
     );
     await service.track(
       const ProductUsageEvent(
@@ -22,9 +26,36 @@ void main() {
       ),
     );
 
-    expect(client.collectionEnabledValues, [false]);
-    expect(client.loggedEvents, isEmpty);
+    expect(client.loggedEvents.single.parameters['app_version'], '9.8.7');
   });
+
+  test(
+    'unconfirmed analytics preference does not log product usage events',
+    () async {
+      final client = _FakeAnalyticsProviderClient();
+      final service = ProductAnalyticsService(
+        client: client,
+        appMetadataProvider: _FakeAppMetadataProvider(
+          const AppMetadata(version: '9.8.7', buildNumber: '654'),
+        ),
+        collectionAllowedInBuild: true,
+      );
+
+      await service.applyPreference(
+        const AnalyticsPreference(enabled: true, isConfirmed: false),
+      );
+      await service.track(
+        const ProductUsageEvent(
+          name: 'schedule_created',
+          workflow: 'schedule',
+          result: 'success',
+        ),
+      );
+
+      expect(client.collectionEnabledValues, [false]);
+      expect(client.loggedEvents, isEmpty);
+    },
+  );
 }
 
 class _FakeAnalyticsProviderClient implements AnalyticsProviderClient {
@@ -46,4 +77,13 @@ class _FakeAnalyticsProviderClient implements AnalyticsProviderClient {
 
   @override
   Future<void> setUserId(String? userId) async {}
+}
+
+class _FakeAppMetadataProvider implements AppMetadataProvider {
+  const _FakeAppMetadataProvider(this.metadata);
+
+  final AppMetadata metadata;
+
+  @override
+  Future<AppMetadata> getMetadata() async => metadata;
 }

--- a/test/data/repositories/alarm_repository_impl_test.dart
+++ b/test/data/repositories/alarm_repository_impl_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/data/data_sources/alarm_remote_data_source.dart';
 import 'package:on_time_front/data/repositories/alarm_repository_impl.dart';
 import 'package:on_time_front/domain/entities/alarm_entities.dart';
@@ -9,15 +10,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   late _FakeAlarmRemoteDataSource remoteDataSource;
   late _FakeAlarmSchedulerService schedulerService;
+  late _FakeAppMetadataProvider appMetadataProvider;
   late AlarmRepositoryImpl repository;
 
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     remoteDataSource = _FakeAlarmRemoteDataSource();
     schedulerService = _FakeAlarmSchedulerService();
+    appMetadataProvider = _FakeAppMetadataProvider(
+      const AppMetadata(version: '9.8.7', buildNumber: '654'),
+    );
     repository = AlarmRepositoryImpl(
       remoteDataSource: remoteDataSource,
       schedulerService: schedulerService,
+      appMetadataProvider: appMetadataProvider,
     );
   });
 
@@ -47,7 +53,7 @@ void main() {
   );
 
   test(
-    'buildCurrentDeviceInfo combines persisted id and scheduler capabilities',
+    'buildCurrentDeviceInfo combines persisted id, scheduler capabilities, and runtime app version',
     () async {
       SharedPreferences.setMockInitialValues({
         'alarm_device_id': '123e4567-e89b-12d3-a456-426614174000',
@@ -61,7 +67,7 @@ void main() {
       final info = await repository.buildCurrentDeviceInfo();
 
       expect(info.deviceId, '123e4567-e89b-12d3-a456-426614174000');
-      expect(info.appVersion, '1.0.0');
+      expect(info.appVersion, '9.8.7');
       expect(info.supportsNativeAlarm, isTrue);
       expect(info.nativeAlarmProvider, AlarmProvider.androidAlarmManager);
       expect(info.fallbackProvider, AlarmProvider.localNotification);
@@ -88,7 +94,7 @@ void main() {
     const deviceInfo = AlarmDeviceInfo(
       deviceId: 'device-1',
       platform: 'android',
-      appVersion: '1.0.0',
+      appVersion: '9.8.7',
       osVersion: 'android',
       supportsNativeAlarm: true,
       nativeAlarmProvider: AlarmProvider.androidAlarmManager,
@@ -135,6 +141,15 @@ class _FakeAlarmSchedulerService extends AlarmSchedulerService {
 
   @override
   Future<AlarmSchedulerCapabilities> getCapabilities() async => capabilities;
+}
+
+class _FakeAppMetadataProvider implements AppMetadataProvider {
+  const _FakeAppMetadataProvider(this.metadata);
+
+  final AppMetadata metadata;
+
+  @override
+  Future<AppMetadata> getMetadata() async => metadata;
 }
 
 class _FakeAlarmRemoteDataSource implements AlarmRemoteDataSource {

--- a/test/presentation/app/cubit/analytics_preference_cubit_test.dart
+++ b/test/presentation/app/cubit/analytics_preference_cubit_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/core/services/product_analytics_service.dart';
 import 'package:on_time_front/domain/entities/analytics_preference.dart';
 import 'package:on_time_front/domain/repositories/analytics_preference_repository.dart';
@@ -7,54 +8,65 @@ import 'package:on_time_front/domain/use-cases/update_analytics_preference_use_c
 import 'package:on_time_front/presentation/app/cubit/analytics_preference_cubit.dart';
 
 void main() {
-  test('load fails closed when signed-in account preference cannot be loaded', () async {
-    final repository = _FakeAnalyticsPreferenceRepository()
-      ..localPreference = const AnalyticsPreference(enabled: true)
-      ..loadAccountError = Exception('backend unavailable');
-    final cubit = AnalyticsPreferenceCubit(
-      loadPreferenceUseCase: LoadAnalyticsPreferenceUseCase(repository),
-      updatePreferenceUseCase: UpdateAnalyticsPreferenceUseCase(repository),
-      analyticsService: ProductAnalyticsService(
-        client: _FakeAnalyticsProviderClient(),
-        collectionAllowedInBuild: true,
-      ),
-    );
-    addTearDown(cubit.close);
+  test(
+    'load fails closed when signed-in account preference cannot be loaded',
+    () async {
+      final repository = _FakeAnalyticsPreferenceRepository()
+        ..localPreference = const AnalyticsPreference(enabled: true)
+        ..loadAccountError = Exception('backend unavailable');
+      final cubit = AnalyticsPreferenceCubit(
+        loadPreferenceUseCase: LoadAnalyticsPreferenceUseCase(repository),
+        updatePreferenceUseCase: UpdateAnalyticsPreferenceUseCase(repository),
+        analyticsService: ProductAnalyticsService(
+          client: _FakeAnalyticsProviderClient(),
+          appMetadataProvider: _FakeAppMetadataProvider(),
+          collectionAllowedInBuild: true,
+        ),
+      );
+      addTearDown(cubit.close);
 
-    await cubit.load(signedIn: true);
+      await cubit.load(signedIn: true);
 
-    expect(cubit.state.status, AnalyticsPreferenceStatus.failure);
-    expect(cubit.state.enabled, isFalse);
-    expect(cubit.state.canEmitEvents, isFalse);
-  });
+      expect(cubit.state.status, AnalyticsPreferenceStatus.failure);
+      expect(cubit.state.enabled, isFalse);
+      expect(cubit.state.canEmitEvents, isFalse);
+    },
+  );
 
-  test('load applies confirmed enabled preference to analytics service', () async {
-    final client = _FakeAnalyticsProviderClient();
-    final repository = _FakeAnalyticsPreferenceRepository()
-      ..localPreference = const AnalyticsPreference(enabled: true)
-      ..accountPreference = const AnalyticsPreference(enabled: true);
-    final cubit = AnalyticsPreferenceCubit(
-      loadPreferenceUseCase: LoadAnalyticsPreferenceUseCase(repository),
-      updatePreferenceUseCase: UpdateAnalyticsPreferenceUseCase(repository),
-      analyticsService: ProductAnalyticsService(
-        client: client,
-        collectionAllowedInBuild: true,
-      ),
-    );
-    addTearDown(cubit.close);
+  test(
+    'load applies confirmed enabled preference to analytics service',
+    () async {
+      final client = _FakeAnalyticsProviderClient();
+      final repository = _FakeAnalyticsPreferenceRepository()
+        ..localPreference = const AnalyticsPreference(enabled: true)
+        ..accountPreference = const AnalyticsPreference(enabled: true);
+      final cubit = AnalyticsPreferenceCubit(
+        loadPreferenceUseCase: LoadAnalyticsPreferenceUseCase(repository),
+        updatePreferenceUseCase: UpdateAnalyticsPreferenceUseCase(repository),
+        analyticsService: ProductAnalyticsService(
+          client: client,
+          appMetadataProvider: _FakeAppMetadataProvider(),
+          collectionAllowedInBuild: true,
+        ),
+      );
+      addTearDown(cubit.close);
 
-    await cubit.load(signedIn: true);
+      await cubit.load(signedIn: true);
 
-    expect(cubit.state.canEmitEvents, isTrue);
-    expect(client.collectionEnabledValues, [true]);
-  });
+      expect(cubit.state.canEmitEvents, isTrue);
+      expect(client.collectionEnabledValues, [true]);
+    },
+  );
 }
 
 class _FakeAnalyticsPreferenceRepository
     implements AnalyticsPreferenceRepository {
-  AnalyticsPreference localPreference = const AnalyticsPreference(enabled: false);
-  AnalyticsPreference accountPreference =
-      const AnalyticsPreference(enabled: false);
+  AnalyticsPreference localPreference = const AnalyticsPreference(
+    enabled: false,
+  );
+  AnalyticsPreference accountPreference = const AnalyticsPreference(
+    enabled: false,
+  );
   Object? loadAccountError;
 
   @override
@@ -95,4 +107,11 @@ class _FakeAnalyticsProviderClient implements AnalyticsProviderClient {
 
   @override
   Future<void> setUserId(String? userId) async {}
+}
+
+class _FakeAppMetadataProvider implements AppMetadataProvider {
+  @override
+  Future<AppMetadata> getMetadata() async {
+    return const AppMetadata(version: '9.8.7', buildNumber: '654');
+  }
 }

--- a/test/presentation/my_page/my_page_screen_test.dart
+++ b/test/presentation/my_page/my_page_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:on_time_front/core/constants/external_links.dart';
 import 'package:on_time_front/core/di/di_setup.dart';
 import 'package:on_time_front/core/services/alarm_scheduler_service.dart';
+import 'package:on_time_front/core/services/app_metadata_service.dart';
 import 'package:on_time_front/core/services/fallback_alarm_notification_service.dart';
 import 'package:on_time_front/core/services/notification_service.dart';
 import 'package:on_time_front/core/services/product_analytics_service.dart';
@@ -92,6 +93,7 @@ void main() {
       ),
       analyticsService: ProductAnalyticsService(
         client: _FakeAnalyticsProviderClient(),
+        appMetadataProvider: _FakeAppMetadataProvider(),
         collectionAllowedInBuild: true,
       ),
     );
@@ -605,6 +607,7 @@ AnalyticsPreferenceCubit _buildAnalyticsPreferenceCubit({
     ),
     analyticsService: ProductAnalyticsService(
       client: _FakeAnalyticsProviderClient(),
+      appMetadataProvider: _FakeAppMetadataProvider(),
       collectionAllowedInBuild: true,
     ),
   );
@@ -772,6 +775,13 @@ class _FakeAlarmRepository implements AlarmRepository {
   @override
   Future<void> postAlarmStatus(AlarmStatusReport report) {
     throw UnimplementedError();
+  }
+}
+
+class _FakeAppMetadataProvider implements AppMetadataProvider {
+  @override
+  Future<AppMetadata> getMetadata() async {
+    return const AppMetadata(version: '9.8.7', buildNumber: '654');
   }
 }
 


### PR DESCRIPTION
## Summary

- Add an injectable `PackageInfo`-backed app metadata provider.
- Use the injected runtime app version for Product Usage Event `app_version` parameters.
- Use the same metadata source for `AlarmDeviceInfo.appVersion` during alarm device registration.
- Add regression coverage for the metadata provider, analytics event parameters, and alarm device payloads.

## Test results

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/core/services/app_metadata_service_test.dart test/core/services/product_analytics_service_test.dart test/data/repositories/alarm_repository_impl_test.dart test/presentation/app/cubit/analytics_preference_cubit_test.dart test/presentation/my_page/my_page_screen_test.dart`
- `flutter analyze`

Closes #546
