### PR TITLE
fix: cache auth tokens in local data source

### DIFF
--- a/lib/data/data_sources/token_local_data_source.dart
+++ b/lib/data/data_sources/token_local_data_source.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/token_entity.dart';
@@ -18,10 +19,17 @@ class TokenLocalDataSourceImpl implements TokenLocalDataSource {
     accessibility: KeychainAccessibility.first_unlock_this_device,
   );
 
-  final storage = const FlutterSecureStorage(iOptions: _appleOptions);
+  TokenLocalDataSourceImpl()
+    : storage = const FlutterSecureStorage(iOptions: _appleOptions);
+
+  @visibleForTesting
+  TokenLocalDataSourceImpl.withStorage(this.storage);
+
+  final FlutterSecureStorage storage;
 
   final accessTokenKey = 'accessToken';
   final refreshTokenKey = 'refreshToken';
+  TokenEntity? _cachedToken;
 
   @override
   Future<void> storeTokens(TokenEntity token) async {
@@ -35,12 +43,19 @@ class TokenLocalDataSourceImpl implements TokenLocalDataSource {
       value: token.refreshToken,
       iOptions: _appleOptions,
     );
+    _cachedToken = token;
   }
 
   @override
   Future<TokenEntity> getToken() async {
+    final cachedToken = _cachedToken;
+    if (cachedToken != null) {
+      return cachedToken;
+    }
+
     final token = await _readToken(_appleOptions);
     if (token != null) {
+      _cachedToken = token;
       return token;
     }
 
@@ -65,6 +80,7 @@ class TokenLocalDataSourceImpl implements TokenLocalDataSource {
       key: refreshTokenKey,
       iOptions: IOSOptions.defaultOptions,
     );
+    _cachedToken = null;
   }
 
   @override
@@ -74,6 +90,16 @@ class TokenLocalDataSourceImpl implements TokenLocalDataSource {
       value: token,
       iOptions: _appleOptions,
     );
+    final cachedToken = _cachedToken;
+    final refreshToken =
+        cachedToken?.refreshToken ??
+        await storage.read(key: refreshTokenKey, iOptions: _appleOptions);
+    if (refreshToken != null) {
+      _cachedToken = TokenEntity(
+        accessToken: token,
+        refreshToken: refreshToken,
+      );
+    }
   }
 
   Future<TokenEntity?> _readToken(IOSOptions options) async {

--- a/test/core/dio/interceptors/token_interceptor_test.dart
+++ b/test/core/dio/interceptors/token_interceptor_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:google_sign_in/google_sign_in.dart';
@@ -40,6 +41,43 @@ void main() {
 
   tearDown(() async {
     await getIt.reset();
+  });
+
+  test('reuses cached access token for repeated protected requests', () async {
+    await getIt.reset();
+
+    final storage = _CountingSecureStorage({
+      'accessToken': 'access-token',
+      'refreshToken': 'refresh-token',
+    });
+    final cachedTokenLocalDataSource = TokenLocalDataSourceImpl.withStorage(
+      storage,
+    );
+    getIt.registerSingleton<TokenLocalDataSource>(cachedTokenLocalDataSource);
+    getIt.registerSingleton<UserRepository>(
+      _FakeUserRepository(cachedTokenLocalDataSource),
+    );
+
+    adapter = _TokenRefreshAdapter(authorizeProtectedRequests: true);
+    dio = Dio(
+      BaseOptions(
+        baseUrl: 'https://example.com',
+        receiveDataWhenStatusError: true,
+      ),
+    )..httpClientAdapter = adapter;
+    dio.interceptors.add(TokenInterceptor(dio));
+
+    final firstResponse = await dio.get<String>('/protected/one');
+    final secondResponse = await dio.get<String>('/protected/two');
+
+    expect(firstResponse.statusCode, 200);
+    expect(secondResponse.statusCode, 200);
+    expect(adapter.refreshRequests, 0);
+    expect(adapter.protectedAuthorizationHeaders, [
+      'Bearer access-token',
+      'Bearer access-token',
+    ]);
+    expect(storage.readsByKey, {'accessToken': 1, 'refreshToken': 1});
   });
 
   test(
@@ -190,12 +228,14 @@ class _TokenRefreshAdapter implements HttpClientAdapter {
     this.retryStatusCode = 200,
     this.refreshCompleter,
     this.omitRefreshHeaders = false,
+    this.authorizeProtectedRequests = false,
   });
 
   final int refreshStatusCode;
   final int retryStatusCode;
   final Completer<void>? refreshCompleter;
   final bool omitRefreshHeaders;
+  final bool authorizeProtectedRequests;
 
   final requestedPaths = <String>[];
   final protectedAuthorizationHeaders = <String?>[];
@@ -237,7 +277,7 @@ class _TokenRefreshAdapter implements HttpClientAdapter {
       final requestCount = (_pathRequestCounts[options.path] ?? 0) + 1;
       _pathRequestCounts[options.path] = requestCount;
 
-      if (requestCount == 1) {
+      if (!authorizeProtectedRequests && requestCount == 1) {
         return _response(401, '{"message":"Unauthorized"}');
       }
 
@@ -259,6 +299,27 @@ class _TokenRefreshAdapter implements HttpClientAdapter {
 
   @override
   void close({bool force = false}) {}
+}
+
+class _CountingSecureStorage extends FlutterSecureStorage {
+  _CountingSecureStorage(this.values);
+
+  final Map<String, String?> values;
+  final readsByKey = <String, int>{};
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    readsByKey[key] = (readsByKey[key] ?? 0) + 1;
+    return values[key];
+  }
 }
 
 class _FakeTokenLocalDataSource implements TokenLocalDataSource {

--- a/test/data/data_sources/token_local_data_source_test.dart
+++ b/test/data/data_sources/token_local_data_source_test.dart
@@ -22,6 +22,26 @@ void main() {
     expect(await dataSource.getToken(), token);
   });
 
+  test(
+    'does not reread secure storage after the token cache is warm',
+    () async {
+      const token = TokenEntity(
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      );
+      final storage = _CountingSecureStorage({
+        'accessToken': token.accessToken,
+        'refreshToken': token.refreshToken,
+      });
+      dataSource = TokenLocalDataSourceImpl.withStorage(storage);
+
+      expect(await dataSource.getToken(), token);
+      expect(await dataSource.getToken(), token);
+
+      expect(storage.readsByKey, {'accessToken': 1, 'refreshToken': 1});
+    },
+  );
+
   test('auth token write only updates the access token slot', () async {
     await dataSource.storeTokens(
       const TokenEntity(
@@ -40,6 +60,54 @@ void main() {
       ),
     );
   });
+
+  test(
+    'auth token write warms the cache when refresh token is persisted',
+    () async {
+      final storage = _CountingSecureStorage({'refreshToken': 'refresh-token'});
+      dataSource = TokenLocalDataSourceImpl.withStorage(storage);
+
+      await dataSource.storeAuthToken('new-access');
+      storage.readsByKey.clear();
+
+      expect(
+        await dataSource.getToken(),
+        const TokenEntity(
+          accessToken: 'new-access',
+          refreshToken: 'refresh-token',
+        ),
+      );
+      expect(storage.readsByKey, isEmpty);
+    },
+  );
+
+  test(
+    'legacy token load migrates to current storage and warms cache',
+    () async {
+      const legacyToken = TokenEntity(
+        accessToken: 'legacy-access',
+        refreshToken: 'legacy-refresh',
+      );
+      final storage = _LegacyTokenSecureStorage(
+        currentValues: {},
+        legacyValues: {
+          'accessToken': legacyToken.accessToken,
+          'refreshToken': legacyToken.refreshToken,
+        },
+      );
+      dataSource = TokenLocalDataSourceImpl.withStorage(storage);
+
+      expect(await dataSource.getToken(), legacyToken);
+      storage.readsByKey.clear();
+
+      expect(await dataSource.getToken(), legacyToken);
+      expect(storage.currentValues, {
+        'accessToken': legacyToken.accessToken,
+        'refreshToken': legacyToken.refreshToken,
+      });
+      expect(storage.readsByKey, isEmpty);
+    },
+  );
 
   test(
     'delete removes both token values and missing tokens fail clearly',
@@ -65,4 +133,98 @@ void main() {
       );
     },
   );
+}
+
+class _CountingSecureStorage extends FlutterSecureStorage {
+  _CountingSecureStorage(this.values);
+
+  final Map<String, String?> values;
+  final readsByKey = <String, int>{};
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    readsByKey[key] = (readsByKey[key] ?? 0) + 1;
+    return values[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    values.remove(key);
+  }
+}
+
+class _LegacyTokenSecureStorage extends FlutterSecureStorage {
+  _LegacyTokenSecureStorage({
+    required this.currentValues,
+    required this.legacyValues,
+  });
+
+  final Map<String, String?> currentValues;
+  final Map<String, String?> legacyValues;
+  final readsByKey = <String, int>{};
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    readsByKey[key] = (readsByKey[key] ?? 0) + 1;
+    return _valuesFor(iOptions)[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    _valuesFor(iOptions)[key] = value;
+  }
+
+  Map<String, String?> _valuesFor(AppleOptions? iOptions) {
+    return iOptions?.accessibility ==
+            KeychainAccessibility.first_unlock_this_device
+        ? currentValues
+        : legacyValues;
+  }
 }


### PR DESCRIPTION
## Summary
- add an in-memory token cache inside `TokenLocalDataSourceImpl` while keeping `FlutterSecureStorage` as the persistence layer
- warm/update the cache from `getToken`, `storeTokens`, `storeAuthToken`, and legacy-token migration
- clear the cache in `deleteToken` and cover repeated protected request behavior

Closes #530

## Tests
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/data/data_sources/token_local_data_source_test.dart && flutter test test/core/dio/interceptors/token_interceptor_test.dart`
- `flutter analyze`
- `flutter test`
