### PR TITLE
[codex] Move tooling packages out of root runtime dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.73"
-  accessibility_tools:
-    dependency: transitive
-    description:
-      name: accessibility_tools
-      sha256: aaa782bf794d823f371f45d232efe8605cffe081c34a1d83fe4db491ddbba0c7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.6.0"
   analyzer:
     dependency: transitive
     description:
@@ -256,14 +248,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
-  device_frame_plus:
-    dependency: transitive
-    description:
-      name: device_frame_plus
-      sha256: ccc94abccd4d9f0a9f19ef239001b3a59896e678ad42601371d7065889f2bf78
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
   dio:
     dependency: "direct main"
     description:
@@ -605,7 +589,7 @@ packages:
     source: hosted
     version: "0.8.0"
   freezed:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: freezed
       sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
@@ -756,14 +740,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.1"
-  inspector:
-    dependency: transitive
-    description:
-      name: inspector
-      sha256: a01ea538b15947a9189835cc910041bab91aea3ad7c421684118aa1040189ded
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   intl:
     dependency: "direct main"
     description:
@@ -949,7 +925,7 @@ packages:
     source: hosted
     version: "2.0.0"
   mockito:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: mockito
       sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
@@ -1164,14 +1140,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  resizable_widget:
-    dependency: transitive
-    description:
-      name: resizable_widget
-      sha256: db2919754b93f386b9b3fb15e9f48f6c9d6d41f00a24397629133c99df86606a
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
   rxdart:
     dependency: "direct main"
     description:
@@ -1593,22 +1561,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.23.0"
-  widgetbook:
-    dependency: "direct main"
-    description:
-      name: widgetbook
-      sha256: "0ffadb039b1811870b2f643e1730d419d38435b0e1931cc83f32ecd7e50200e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.20.2"
-  widgetbook_annotation:
-    dependency: "direct main"
-    description:
-      name: widgetbook_annotation
-      sha256: "55504431b15eedef3c1fc4af2d108ac98b32610b59d4a4e2eea87a8515d17eef"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.9.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,6 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.7.0
   
-  mockito: ^5.4.4
   equatable: ^2.0.5
   collection: ^1.18.0
   uuid: ^4.5.1
@@ -69,7 +68,6 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_swipe_action_cell: ^3.1.5
   flutter_secure_storage: ^10.3.1
-  freezed: ^3.2.3
   freezed_annotation: ^3.1.0
   formz: ^0.8.0
   dotted_line: ^3.2.3
@@ -80,8 +78,6 @@ dependencies:
   timezone: ^0.10.0
   google_sign_in_web: ^1.1.0
   google_sign_in_platform_interface: ^3.1.0
-  widgetbook: ^3.11.0
-  widgetbook_annotation: ^3.3.0
   intl: ^0.20.2
 
   sign_in_with_apple: ^8.1.0
@@ -97,6 +93,8 @@ dev_dependencies:
   
   drift_dev: ^2.31.0
   build_runner: ^2.4.15
+  freezed: ^3.2.3
+  mockito: ^5.4.4
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -548,14 +548,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.8.0"
-  freezed:
-    dependency: transitive
-    description:
-      name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.3"
   freezed_annotation:
     dependency: transitive
     description:
@@ -868,14 +860,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  mockito:
-    dependency: transitive
-    description:
-      name: mockito
-      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.5.0"
   nested:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Move root `mockito` and `freezed` from runtime `dependencies` to `dev_dependencies`.
- Remove root `widgetbook` and `widgetbook_annotation` because Widgetbook owns them in `widgetbook/pubspec.yaml`.
- Refresh root and Widgetbook lockfiles so root runtime scope no longer includes Widgetbook-only packages and Widgetbook no longer inherits root dev-only packages through the path dependency.

## Validation
- Guard before fix failed as expected: `Forbidden root runtime dependencies: mockito, freezed, widgetbook, widgetbook_annotation`
- Guard after fix: `Root runtime dependency scope is clean`
- `flutter pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze`
- `flutter test`
- `cd widgetbook && flutter pub get`
- `git diff --check`

Closes #536