### PR TITLE
test: guard domain entity decoupling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,26 @@ release, and feature discussions use the same terms.
 
 ## Language
 
+**OnTime User**:
+A person's OnTime account profile that owns schedules, places, preparation defaults, and notification preferences.
+_Avoid_: User identity, analytics subject, device
+
+**Schedule**:
+A planned commitment with an intended time, destination place, travel time, and optional preparation plan.
+_Avoid_: Alarm, notification, calendar row
+
+**Place**:
+The destination or location label attached to a Schedule.
+_Avoid_: Route, address record, notification location
+
+**Preparation**:
+An ordered plan of steps the user intends to complete before leaving for a Schedule.
+_Avoid_: Reminder, notification, alarm
+
+**Preparation Step**:
+One named action in a Preparation with an expected duration.
+_Avoid_: UI row, checklist widget, notification step
+
 **Product Usage Event**:
 A named record that a user performed a product-relevant action, excluding raw personal content.
 _Avoid_: User activity, tracking event, raw interaction log
@@ -107,6 +127,12 @@ _Avoid_: Notification, native alarm
 
 ## Relationships
 
+- An **OnTime User** may own zero or more **Schedules**.
+- A **Schedule** has one **Place**.
+- A **Schedule** may use one **Preparation**.
+- A **Preparation** contains zero or more **Preparation Steps** in user-defined order.
+- A **Preparation Step** belongs to exactly one **Preparation**.
+- A **Schedule Notification** uses **Schedule** and **Preparation** timing, but is not itself a **Schedule** or **Preparation**.
 - A **Product Usage Event** may describe a schedule, preparation, notification, alarm, onboarding, or account action without storing the user's raw schedule names, notes, place names, credentials, tokens, or free text.
 - First-release **Product Usage Events** are **Workflow Milestone Events**, not every tap or raw navigation step.
 - First-release **Workflow Milestone Events** cover analytics preference, onboarding, authentication, schedule, notification permission, alarm, and schedule-finish outcomes.
@@ -155,8 +181,14 @@ _Avoid_: Notification, native alarm
 > **Dev:** "Should the analytics event include the schedule note so we can understand why users are late?"
 > **Domain expert:** "No. A **Product Usage Event** can say a schedule was finished late, but it must not include the user's raw note."
 
+> **Dev:** "Can a **Schedule Notification** replace the **Schedule** if the user taps it?"
+> **Domain expert:** "No. The **Schedule Notification** only prompts preparation for the **Schedule**; the **Schedule** remains the planned commitment."
+
 ## Flagged ambiguities
 
+- "User" was overloaded as both the human actor and stored profile; resolved: use **OnTime User** for the account/profile concept and plain user only for the person performing an action.
+- "Schedule" was used near notification and alarm flows; resolved: a **Schedule** is the planned commitment, while notifications and alarms are delivery experiences for preparation timing.
+- "Preparation state" was ambiguous between step progress and display styling; resolved: **Preparation Step** progress belongs to preparation language, while visual labels should not redefine the domain.
 - "User activities" was used broadly; resolved: the canonical term is **Product Usage Event**, and raw personal content is out of scope.
 - "Analytics" was used to include all possible purposes; resolved: marketing and personalization are deferred, not first-release purposes.
 - "User identity" for analytics was ambiguous; resolved: analytics uses a **Pseudonymous Analytics Subject**, not directly identifying user data.

--- a/test/domain/entities/domain_entity_boundary_test.dart
+++ b/test/domain/entities/domain_entity_boundary_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('domain entities do not import lower architectural layers', () {
     final domainEntityDirectory = Directory('lib/domain/entities');
     final forbiddenImportPattern = RegExp(
-      r'''import\s+['"](?:(?:package:on_time_front/)|/)?(?:core|data|presentation)/''',
+      r'''import\s+['"](?:(?:package:on_time_front/)|(?:\.\./)+|/)?(?:core|data|presentation)/''',
     );
 
     final violations = domainEntityDirectory
@@ -19,6 +19,30 @@ void main() {
           return [
             for (var index = 0; index < lines.length; index++)
               if (forbiddenImportPattern.hasMatch(lines[index]))
+                '${file.path}:${index + 1}: ${lines[index].trim()}',
+          ];
+        })
+        .toList();
+
+    expect(violations, isEmpty);
+  });
+
+  test('domain entities do not expose persistence mapper methods', () {
+    final domainEntityDirectory = Directory('lib/domain/entities');
+    final legacyMapperMethodPattern = RegExp(
+      r'''\b(?:fromModel|toModel|from[A-Za-z0-9_]*Model|to[A-Za-z0-9_]*Model|fromScheduleWithPlaceModel|toScheduleModel|toScheduleWithPlaceModel|toPreparationUserModel)\b''',
+    );
+
+    final violations = domainEntityDirectory
+        .listSync()
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.dart'))
+        .where((file) => !file.path.endsWith('.freezed.dart'))
+        .expand((file) {
+          final lines = file.readAsLinesSync();
+          return [
+            for (var index = 0; index < lines.length; index++)
+              if (legacyMapperMethodPattern.hasMatch(lines[index]))
                 '${file.path}:${index + 1}: ${lines[index].trim()}',
           ];
         })


### PR DESCRIPTION
## Summary
- Clarify core scheduling glossary terms in `CONTEXT.md`: OnTime User, Schedule, Place, Preparation, and Preparation Step.
- Strengthen the domain entity boundary test to catch forbidden relative imports from lower layers.
- Add a regression assertion that domain entities do not reintroduce legacy persistence mapper method names.

Current `origin/main` already contains the data-layer mapper extraction for #525; this PR hardens that accepted boundary and records the resolved domain vocabulary without adding implementation details to the glossary.

Closes #525

## Tests
- `flutter pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/domain/entities/domain_entity_boundary_test.dart test/data/mappers/domain_persistence_mappers_test.dart test/data/data_sources/schedule_local_data_source_test.dart test/presentation/alarm/utils/preparation_step_state_mapper_test.dart`
- `flutter test test/domain/entities test/data/mappers/domain_persistence_mappers_test.dart test/data/data_sources/schedule_local_data_source_test.dart test/data/data_sources/preparation_local_data_source_test.dart test/data/daos/user_dao_test.dart test/presentation/alarm/utils/preparation_step_state_mapper_test.dart`
- `flutter analyze`
- `rg -n "package:on_time_front/(core|data|presentation)|(?:\.\./)+(?:core|data|presentation)|fromScheduleWithPlaceModel|toScheduleModel|toScheduleWithPlaceModel|toPreparationUserModel|\bfromModel\b|\btoModel\b|\bfrom[A-Za-z0-9_]*Model\b|\bto[A-Za-z0-9_]*Model\b|PreparationStateEnum" lib/domain/entities || true`