### PR TITLE
Centralize schedule mutation alarm effects

### DIFF
--- a/lib/domain/use-cases/create_schedule_with_place_use_case.dart
+++ b/lib/domain/use-cases/create_schedule_with_place_use_case.dart
@@ -1,22 +1,23 @@
-import 'dart:async';
-
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
-import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
 
 @Injectable()
 class CreateScheduleWithPlaceUseCase {
   final ScheduleRepository _scheduleRepository;
-  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
+  final ScheduleMutationAlarmEffectsCoordinator _alarmEffectsCoordinator;
 
   CreateScheduleWithPlaceUseCase(
     this._scheduleRepository,
-    this._reconcileAlarmsUseCase,
+    this._alarmEffectsCoordinator,
   );
 
   Future<void> call(ScheduleEntity schedule) async {
     await _scheduleRepository.createSchedule(schedule);
-    unawaited(_reconcileAlarmsUseCase());
+    await _alarmEffectsCoordinator(
+      operation: ScheduleMutationAlarmOperation.created,
+      scheduleId: schedule.id,
+    );
   }
 }

--- a/lib/domain/use-cases/delete_schedule_use_case.dart
+++ b/lib/domain/use-cases/delete_schedule_use_case.dart
@@ -1,26 +1,23 @@
-import 'dart:async';
-
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
-import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
-import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
 
 @Injectable()
 class DeleteScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
-  final CancelScheduleAlarmUseCase _cancelScheduleAlarmUseCase;
-  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
+  final ScheduleMutationAlarmEffectsCoordinator _alarmEffectsCoordinator;
 
   DeleteScheduleUseCase(
     this._scheduleRepository,
-    this._cancelScheduleAlarmUseCase,
-    this._reconcileAlarmsUseCase,
+    this._alarmEffectsCoordinator,
   );
 
   Future<void> call(ScheduleEntity schedule) async {
     await _scheduleRepository.deleteSchedule(schedule);
-    await _cancelScheduleAlarmUseCase(schedule.id);
-    unawaited(_reconcileAlarmsUseCase());
+    await _alarmEffectsCoordinator(
+      operation: ScheduleMutationAlarmOperation.deleted,
+      scheduleId: schedule.id,
+    );
   }
 }

--- a/lib/domain/use-cases/finish_schedule_use_case.dart
+++ b/lib/domain/use-cases/finish_schedule_use_case.dart
@@ -1,26 +1,23 @@
-import 'dart:async';
-
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
-import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
-import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
 
 @Injectable()
 class FinishScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
-  final CancelScheduleAlarmUseCase _cancelScheduleAlarmUseCase;
-  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
+  final ScheduleMutationAlarmEffectsCoordinator _alarmEffectsCoordinator;
 
   FinishScheduleUseCase(
     this._scheduleRepository,
-    this._cancelScheduleAlarmUseCase,
-    this._reconcileAlarmsUseCase,
+    this._alarmEffectsCoordinator,
   );
 
   Future<void> call(String scheduleId, int latenessTime) async {
     await _scheduleRepository.startSchedule(scheduleId);
     await _scheduleRepository.finishSchedule(scheduleId, latenessTime);
-    await _cancelScheduleAlarmUseCase(scheduleId);
-    unawaited(_reconcileAlarmsUseCase());
+    await _alarmEffectsCoordinator(
+      operation: ScheduleMutationAlarmOperation.finished,
+      scheduleId: scheduleId,
+    );
   }
 }

--- a/lib/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart
+++ b/lib/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:on_time_front/core/logging/app_logger.dart';
+import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+
+enum ScheduleMutationAlarmOperation { created, updated, deleted, finished }
+
+@Injectable()
+class ScheduleMutationAlarmEffectsCoordinator {
+  static const _logTag = '[ScheduleMutationAlarmEffects]';
+
+  final CancelScheduleAlarmUseCase _cancelScheduleAlarmUseCase;
+  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
+
+  ScheduleMutationAlarmEffectsCoordinator(
+    this._cancelScheduleAlarmUseCase,
+    this._reconcileAlarmsUseCase,
+  );
+
+  Future<void> call({
+    required ScheduleMutationAlarmOperation operation,
+    required String scheduleId,
+  }) async {
+    if (_requiresTargetedCancellation(operation)) {
+      await _cancelScheduleAlarmUseCase(scheduleId);
+    }
+    _reconcileBestEffort(operation, scheduleId);
+  }
+
+  bool _requiresTargetedCancellation(ScheduleMutationAlarmOperation operation) {
+    return operation == ScheduleMutationAlarmOperation.deleted ||
+        operation == ScheduleMutationAlarmOperation.finished;
+  }
+
+  void _reconcileBestEffort(
+    ScheduleMutationAlarmOperation operation,
+    String scheduleId,
+  ) {
+    unawaited(
+      _reconcileAlarmsUseCase().then<void>((_) {}).catchError((
+        Object error,
+        StackTrace _,
+      ) {
+        AppLogger.debug(
+          '$_logTag reconcile failed '
+          'operation=${operation.name} '
+          'scheduleId=$scheduleId '
+          'errorType=${error.runtimeType}',
+        );
+      }),
+    );
+  }
+}

--- a/lib/domain/use-cases/update_schedule_use_case.dart
+++ b/lib/domain/use-cases/update_schedule_use_case.dart
@@ -1,16 +1,17 @@
-import 'dart:async';
-
 import 'package:injectable/injectable.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
-import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
 
 @Injectable()
 class UpdateScheduleUseCase {
   final ScheduleRepository _scheduleRepository;
-  final ReconcileAlarmsUseCase _reconcileAlarmsUseCase;
+  final ScheduleMutationAlarmEffectsCoordinator _alarmEffectsCoordinator;
 
-  UpdateScheduleUseCase(this._scheduleRepository, this._reconcileAlarmsUseCase);
+  UpdateScheduleUseCase(
+    this._scheduleRepository,
+    this._alarmEffectsCoordinator,
+  );
 
   Future<void> call(
     ScheduleEntity schedule, {
@@ -20,6 +21,9 @@ class UpdateScheduleUseCase {
       schedule,
       includePreparationSource: includePreparationSource,
     );
-    unawaited(_reconcileAlarmsUseCase());
+    await _alarmEffectsCoordinator(
+      operation: ScheduleMutationAlarmOperation.updated,
+      scheduleId: schedule.id,
+    );
   }
 }

--- a/test/domain/use-cases/schedule_mutation_alarm_effects_coordinator_test.dart
+++ b/test/domain/use-cases/schedule_mutation_alarm_effects_coordinator_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:on_time_front/domain/entities/alarm_entities.dart';
+import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
+import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
+
+void main() {
+  test(
+    'created and updated schedules reconcile without targeted cancellation',
+    () async {
+      final cancel = _FakeCancelScheduleAlarmUseCase();
+      final reconcile = _FakeReconcileAlarmsUseCase();
+      final coordinator = ScheduleMutationAlarmEffectsCoordinator(
+        cancel,
+        reconcile,
+      );
+
+      await coordinator(
+        operation: ScheduleMutationAlarmOperation.created,
+        scheduleId: 'schedule-1',
+      );
+      await coordinator(
+        operation: ScheduleMutationAlarmOperation.updated,
+        scheduleId: 'schedule-1',
+      );
+      await pumpEventQueue();
+
+      expect(cancel.cancelledScheduleIds, isEmpty);
+      expect(reconcile.callCount, 2);
+    },
+  );
+
+  test(
+    'deleted and finished schedules cancel targeted alarm before reconciling',
+    () async {
+      final events = <String>[];
+      final cancel = _FakeCancelScheduleAlarmUseCase(events: events);
+      final reconcile = _FakeReconcileAlarmsUseCase(events: events);
+      final coordinator = ScheduleMutationAlarmEffectsCoordinator(
+        cancel,
+        reconcile,
+      );
+
+      await coordinator(
+        operation: ScheduleMutationAlarmOperation.deleted,
+        scheduleId: 'schedule-1',
+      );
+      await coordinator(
+        operation: ScheduleMutationAlarmOperation.finished,
+        scheduleId: 'schedule-2',
+      );
+      await pumpEventQueue();
+
+      expect(events, [
+        'cancel:schedule-1',
+        'reconcile',
+        'cancel:schedule-2',
+        'reconcile',
+      ]);
+    },
+  );
+
+  test('reconciliation failures remain best-effort', () async {
+    final cancel = _FakeCancelScheduleAlarmUseCase();
+    final reconcile = _FakeReconcileAlarmsUseCase()..throwOnCall = true;
+    final coordinator = ScheduleMutationAlarmEffectsCoordinator(
+      cancel,
+      reconcile,
+    );
+
+    await coordinator(
+      operation: ScheduleMutationAlarmOperation.created,
+      scheduleId: 'schedule-1',
+    );
+    await pumpEventQueue();
+
+    expect(reconcile.callCount, 1);
+  });
+}
+
+class _FakeCancelScheduleAlarmUseCase implements CancelScheduleAlarmUseCase {
+  _FakeCancelScheduleAlarmUseCase({List<String>? events}) : _events = events;
+
+  final cancelledScheduleIds = <String>[];
+  final List<String>? _events;
+
+  @override
+  Future<void> call(String scheduleId) async {
+    cancelledScheduleIds.add(scheduleId);
+    _events?.add('cancel:$scheduleId');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeReconcileAlarmsUseCase implements ReconcileAlarmsUseCase {
+  _FakeReconcileAlarmsUseCase({List<String>? events}) : _events = events;
+
+  int callCount = 0;
+  bool throwOnCall = false;
+  final List<String>? _events;
+
+  @override
+  Future<AlarmReconciliationResult> call() async {
+    callCount += 1;
+    _events?.add('reconcile');
+    if (throwOnCall) {
+      throw Exception('reconcile failed');
+    }
+    return AlarmReconciliationResult(
+      status: AlarmReconciliationStatus.armed,
+      nativeAlarmProvider: AlarmProvider.none,
+      fallbackProvider: AlarmProvider.localNotification,
+      armedScheduleIds: const [],
+      skippedScheduleCount: 0,
+      failures: const [],
+      scheduleWindowStart: DateTime.utc(2026, 5, 15),
+      scheduleWindowEnd: DateTime.utc(2026, 5, 23),
+      alarmCoverageStart: DateTime.utc(2026, 5, 15),
+      alarmCoverageEnd: DateTime.utc(2026, 5, 22),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/domain/use-cases/schedule_mutation_use_cases_test.dart
+++ b/test/domain/use-cases/schedule_mutation_use_cases_test.dart
@@ -1,34 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:on_time_front/domain/entities/alarm_entities.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/user_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
 import 'package:on_time_front/domain/repositories/user_repository.dart';
 import 'package:on_time_front/domain/use-cases/cancel_all_alarms_use_case.dart';
-import 'package:on_time_front/domain/use-cases/cancel_schedule_alarm_use_case.dart';
 import 'package:on_time_front/domain/use-cases/create_schedule_with_place_use_case.dart';
 import 'package:on_time_front/domain/use-cases/delete_schedule_use_case.dart';
 import 'package:on_time_front/domain/use-cases/finish_schedule_use_case.dart';
-import 'package:on_time_front/domain/use-cases/reconcile_alarms_use_case.dart';
+import 'package:on_time_front/domain/use-cases/schedule_mutation_alarm_effects_coordinator.dart';
 import 'package:on_time_front/domain/use-cases/sign_out_use_case.dart';
 import 'package:on_time_front/domain/use-cases/start_schedule_use_case.dart';
 import 'package:on_time_front/domain/use-cases/update_schedule_use_case.dart';
 
 void main() {
   test(
-    'create and update schedule use cases persist then reconcile alarms',
+    'create and update schedule use cases persist then request alarm effects',
     () async {
       final scheduleRepository = _FakeScheduleRepository();
-      final reconcile = _FakeReconcileAlarmsUseCase();
+      final alarmEffects = _FakeScheduleMutationAlarmEffectsCoordinator();
       final createUseCase = CreateScheduleWithPlaceUseCase(
         scheduleRepository,
-        reconcile,
+        alarmEffects,
       );
       final updateUseCase = UpdateScheduleUseCase(
         scheduleRepository,
-        reconcile,
+        alarmEffects,
       );
       final schedule = _schedule('schedule-1');
 
@@ -43,51 +41,63 @@ void main() {
         scheduleRepository.updatedSchedules.single.doneStatus,
         ScheduleDoneStatus.lateEnd,
       );
-      expect(reconcile.callCount, 2);
+      expect(alarmEffects.calls, ['created:schedule-1', 'updated:schedule-1']);
     },
   );
 
   test(
-    'delete schedule removes schedule, cancels alarm, then reconciles',
+    'create and update schedule use cases skip alarm effects on repository failure',
     () async {
       final scheduleRepository = _FakeScheduleRepository();
-      final cancel = _FakeCancelScheduleAlarmUseCase();
-      final reconcile = _FakeReconcileAlarmsUseCase();
-      final useCase = DeleteScheduleUseCase(
+      final alarmEffects = _FakeScheduleMutationAlarmEffectsCoordinator();
+      final createUseCase = CreateScheduleWithPlaceUseCase(
         scheduleRepository,
-        cancel,
-        reconcile,
+        alarmEffects,
+      );
+      final updateUseCase = UpdateScheduleUseCase(
+        scheduleRepository,
+        alarmEffects,
       );
       final schedule = _schedule('schedule-1');
 
-      await useCase(schedule);
-      await pumpEventQueue();
+      scheduleRepository.failCreate = true;
+      await expectLater(createUseCase(schedule), throwsException);
 
-      expect(scheduleRepository.deletedSchedules, [schedule]);
-      expect(cancel.cancelledScheduleIds, ['schedule-1']);
-      expect(reconcile.callCount, 1);
+      scheduleRepository.failCreate = false;
+      scheduleRepository.failUpdate = true;
+      await expectLater(updateUseCase(schedule), throwsException);
+
+      expect(alarmEffects.calls, isEmpty);
     },
   );
 
   test(
-    'finish schedule records lateness, cancels alarm, then reconciles',
+    'delete schedule removes schedule then requests deleted alarm effects',
     () async {
       final scheduleRepository = _FakeScheduleRepository();
-      final cancel = _FakeCancelScheduleAlarmUseCase();
-      final reconcile = _FakeReconcileAlarmsUseCase();
-      final useCase = FinishScheduleUseCase(
-        scheduleRepository,
-        cancel,
-        reconcile,
-      );
+      final alarmEffects = _FakeScheduleMutationAlarmEffectsCoordinator();
+      final useCase = DeleteScheduleUseCase(scheduleRepository, alarmEffects);
+      final schedule = _schedule('schedule-1');
+
+      await useCase(schedule);
+
+      expect(scheduleRepository.deletedSchedules, [schedule]);
+      expect(alarmEffects.calls, ['deleted:schedule-1']);
+    },
+  );
+
+  test(
+    'finish schedule records lateness then requests finished alarm effects',
+    () async {
+      final scheduleRepository = _FakeScheduleRepository();
+      final alarmEffects = _FakeScheduleMutationAlarmEffectsCoordinator();
+      final useCase = FinishScheduleUseCase(scheduleRepository, alarmEffects);
 
       await useCase('schedule-1', 12);
-      await pumpEventQueue();
 
       expect(scheduleRepository.finishedSchedules, [('schedule-1', 12)]);
       expect(scheduleRepository.startedScheduleIds, ['schedule-1']);
-      expect(cancel.cancelledScheduleIds, ['schedule-1']);
-      expect(reconcile.callCount, 1);
+      expect(alarmEffects.calls, ['finished:schedule-1']);
     },
   );
 
@@ -138,6 +148,8 @@ class _FakeScheduleRepository implements ScheduleRepository {
   final deletedSchedules = <ScheduleEntity>[];
   final startedScheduleIds = <String>[];
   final finishedSchedules = <(String, int)>[];
+  bool failCreate = false;
+  bool failUpdate = false;
 
   @override
   Stream<Set<ScheduleEntity>> get scheduleStream => const Stream.empty();
@@ -150,6 +162,9 @@ class _FakeScheduleRepository implements ScheduleRepository {
 
   @override
   Future<void> createSchedule(ScheduleEntity schedule) async {
+    if (failCreate) {
+      throw Exception('create failed');
+    }
     createdSchedules.add(schedule);
   }
 
@@ -182,20 +197,11 @@ class _FakeScheduleRepository implements ScheduleRepository {
     ScheduleEntity schedule, {
     bool includePreparationSource = false,
   }) async {
+    if (failUpdate) {
+      throw Exception('update failed');
+    }
     updatedSchedules.add(schedule);
   }
-}
-
-class _FakeCancelScheduleAlarmUseCase implements CancelScheduleAlarmUseCase {
-  final cancelledScheduleIds = <String>[];
-
-  @override
-  Future<void> call(String scheduleId) async {
-    cancelledScheduleIds.add(scheduleId);
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeCancelAllAlarmsUseCase implements CancelAllAlarmsUseCase {
@@ -210,24 +216,16 @@ class _FakeCancelAllAlarmsUseCase implements CancelAllAlarmsUseCase {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-class _FakeReconcileAlarmsUseCase implements ReconcileAlarmsUseCase {
-  int callCount = 0;
+class _FakeScheduleMutationAlarmEffectsCoordinator
+    implements ScheduleMutationAlarmEffectsCoordinator {
+  final calls = <String>[];
 
   @override
-  Future<AlarmReconciliationResult> call() async {
-    callCount += 1;
-    return AlarmReconciliationResult(
-      status: AlarmReconciliationStatus.armed,
-      nativeAlarmProvider: AlarmProvider.none,
-      fallbackProvider: AlarmProvider.localNotification,
-      armedScheduleIds: const [],
-      skippedScheduleCount: 0,
-      failures: const [],
-      scheduleWindowStart: DateTime.utc(2026, 5, 15),
-      scheduleWindowEnd: DateTime.utc(2026, 5, 23),
-      alarmCoverageStart: DateTime.utc(2026, 5, 15),
-      alarmCoverageEnd: DateTime.utc(2026, 5, 22),
-    );
+  Future<void> call({
+    required ScheduleMutationAlarmOperation operation,
+    required String scheduleId,
+  }) async {
+    calls.add('${operation.name}:$scheduleId');
   }
 
   @override


### PR DESCRIPTION
## Summary
- Add a domain-level `ScheduleMutationAlarmEffectsCoordinator` for created, updated, deleted, and finished schedule mutations.
- Route create/update/delete/finish use cases through the coordinator instead of injecting alarm reconciliation directly.
- Keep delete/finish targeted alarm cancellation before global reconciliation, and contain best-effort reconcile failures.

## Tests
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/domain/use-cases/schedule_mutation_alarm_effects_coordinator_test.dart test/domain/use-cases/schedule_mutation_use_cases_test.dart`
- `flutter analyze`
- `flutter test`

Closes #533