### PR TITLE
Clarify schedule repository persistence

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -255,7 +255,7 @@ Navigation ← AppBloc ← UserEntity ← UserRepository ← AuthDataSource ← 
 ```
 Schedule Form → ScheduleBloc → CreateScheduleUseCase → ScheduleRepository
                      ↓
-Database ← ScheduleDao ← ScheduleRepository ← ScheduleEntity
+ScheduleRemoteDataSource → API
 ```
 
 ## 🎯 Key Features Architecture
@@ -272,7 +272,7 @@ Database ← ScheduleDao ← ScheduleRepository ← ScheduleEntity
 - **CRUD operations** for schedules
 - **Calendar integration** with multiple view modes
 - **Preparation time calculation** and management
-- **Real-time synchronization** between local and remote data
+- **In-memory schedule stream updates** after remote reads and writes
 - **Runtime preparation flow** with official timer starts, early-start entry, and finish/lateness handling
 - **Cache-coherent timed-preparation resume** using snapshot metadata and fingerprint invalidation
 - **Automatic timer system** for schedule start notifications
@@ -285,11 +285,11 @@ Database ← ScheduleDao ← ScheduleRepository ← ScheduleEntity
 - **Local notifications** for preparation alerts
 - **Permission handling** for notification access
 
-### 4. **Offline Support**
+### 4. **Local Runtime Persistence**
 
-- **Local database** with Drift for offline data access
-- **Synchronization strategy** for online/offline data consistency
-- **Caching mechanisms** for improved performance
+- **Local persistence** for runtime state such as timed-preparation snapshots, early-start sessions, and alarm registry records
+- **Remote-only schedule persistence** for schedule CRUD/read operations
+- **In-memory schedule streams** for loaded schedule ranges; no offline schedule CRUD/cache contract is currently implemented
 
 ### 5. **Error Handling System**
 
@@ -305,7 +305,7 @@ Database ← ScheduleDao ← ScheduleRepository ← ScheduleEntity
 
 - `PreparationWithTimeLocalDataSource` persists `PreparationWithTimeEntity` per schedule using SharedPreferences.
 - Intended for lightweight, per-schedule timer state (elapsed time, completion) that should survive app restarts.
-- Repository reads canonical preparation from remote/DB; BLoC can merge it with locally persisted timing state when needed.
+- Repository reads canonical schedule/preparation data from the remote API; BLoC can merge it with locally persisted timing state when needed.
 
 ## 🧪 Testing Strategy
 

--- a/lib/data/data_sources/schedule_local_data_source.dart
+++ b/lib/data/data_sources/schedule_local_data_source.dart
@@ -1,4 +1,3 @@
-import 'package:injectable/injectable.dart';
 import 'package:on_time_front/core/database/database.dart';
 import 'package:on_time_front/data/mappers/domain_persistence_mappers.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
@@ -18,7 +17,7 @@ abstract interface class ScheduleLocalDataSource {
   Future<void> deleteSchedule(ScheduleEntity scheduleEntity);
 }
 
-@Injectable(as: ScheduleLocalDataSource)
+// Not registered with DI; schedule repository persistence is remote-only.
 class ScheduleLocalDataSourceImpl implements ScheduleLocalDataSource {
   final AppDatabase appDatabase;
 

--- a/lib/data/repositories/schedule_repository_impl.dart
+++ b/lib/data/repositories/schedule_repository_impl.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:injectable/injectable.dart';
-import 'package:on_time_front/data/data_sources/schedule_local_data_source.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/repositories/schedule_repository.dart';
@@ -11,7 +10,6 @@ import 'package:rxdart/subjects.dart';
 
 @Singleton(as: ScheduleRepository)
 class ScheduleRepositoryImpl implements ScheduleRepository {
-  final ScheduleLocalDataSource scheduleLocalDataSource;
   final ScheduleRemoteDataSource scheduleRemoteDataSource;
   final TimedPreparationRepository timedPreparationRepository;
 
@@ -22,7 +20,6 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   final _scheduleListEquality = const ListEquality<ScheduleEntity>();
 
   ScheduleRepositoryImpl({
-    required this.scheduleLocalDataSource,
     required this.scheduleRemoteDataSource,
     required this.timedPreparationRepository,
   });
@@ -51,7 +48,6 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   Future<void> createSchedule(ScheduleEntity schedule) async {
     try {
       await scheduleRemoteDataSource.createSchedule(schedule);
-      //await scheduleLocalDataSource.createSchedule(schedule);
       _emitUpsertedSchedule(schedule);
     } catch (e) {
       rethrow;
@@ -63,7 +59,6 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
     try {
       await scheduleRemoteDataSource.deleteSchedule(schedule);
       await _clearTimedPreparationSafe(schedule.id);
-      //await scheduleLocalDataSource.deleteSchedule(schedule);
       _emitScheduleSet(
         Set.from(_scheduleStreamController.value)
           ..removeWhere((existing) => existing.id == schedule.id),
@@ -141,7 +136,6 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
         await _clearTimedPreparationSafe(refreshedSchedule.id);
       }
       _emitUpsertedSchedule(refreshedSchedule);
-      //await scheduleLocalDataSource.updateSchedule(schedule);
     } catch (e) {
       rethrow;
     }

--- a/lib/domain/use-cases/load_adjacent_schedule_with_preparation_use_case.dart
+++ b/lib/domain/use-cases/load_adjacent_schedule_with_preparation_use_case.dart
@@ -17,7 +17,7 @@ class LoadAdjacentScheduleWithPreparationUseCase {
 
   /// Loads schedules and preparation data from the server for the given date range.
   /// This triggers fetching schedules and preparation from the remote data source
-  /// and updating the local cache/stream.
+  /// and updating repository streams.
   ///
   /// [startDate] - Start date for the search range
   /// [endDate] - End date for the search range
@@ -29,13 +29,16 @@ class LoadAdjacentScheduleWithPreparationUseCase {
     await _loadSchedulesByDateUseCase(startDate, endDate);
 
     // Get the schedules that were loaded
-    final schedules =
-        await _getSchedulesByDateUseCase(startDate, endDate).first;
+    final schedules = await _getSchedulesByDateUseCase(
+      startDate,
+      endDate,
+    ).first;
 
     // Load preparation for all schedules in the date range
     await Future.wait(
-      schedules
-          .map((schedule) => _loadPreparationByScheduleIdUseCase(schedule.id)),
+      schedules.map(
+        (schedule) => _loadPreparationByScheduleIdUseCase(schedule.id),
+      ),
     );
   }
 }

--- a/lib/domain/use-cases/load_preparation_by_schedule_id_use_case.dart
+++ b/lib/domain/use-cases/load_preparation_by_schedule_id_use_case.dart
@@ -9,7 +9,7 @@ class LoadPreparationByScheduleIdUseCase {
 
   /// Loads preparation for the given schedule ID.
   /// This triggers fetching preparation from the remote data source
-  /// and updating the local cache/stream.
+  /// and updating the preparation repository stream/cache.
   ///
   /// [scheduleId] - The ID of the schedule to load preparation for
   Future<void> call(String scheduleId) async {

--- a/lib/domain/use-cases/load_schedules_by_date_use_case.dart
+++ b/lib/domain/use-cases/load_schedules_by_date_use_case.dart
@@ -9,7 +9,7 @@ class LoadSchedulesByDateUseCase {
 
   /// Loads schedules for the given date range.
   /// This triggers fetching schedules from the remote data source
-  /// and updating the local cache/stream.
+  /// and updating the in-memory schedule stream.
   ///
   /// [startDate] - Start date of the range (inclusive)
   /// [endDate] - End date of the range (exclusive), or null for all schedules after startDate

--- a/test/data/repositories/schedule_repository_impl_stream_test.dart
+++ b/test/data/repositories/schedule_repository_impl_stream_test.dart
@@ -1,35 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:on_time_front/data/data_sources/schedule_local_data_source.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
 import 'package:on_time_front/data/repositories/schedule_repository_impl.dart';
 import 'package:on_time_front/domain/entities/place_entity.dart';
 import 'package:on_time_front/domain/entities/schedule_entity.dart';
 import 'package:on_time_front/domain/entities/timed_preparation_snapshot_entity.dart';
 import 'package:on_time_front/domain/repositories/timed_preparation_repository.dart';
-
-class FakeScheduleLocalDataSource implements ScheduleLocalDataSource {
-  @override
-  Future<void> createSchedule(ScheduleEntity scheduleEntity) async {}
-
-  @override
-  Future<void> deleteSchedule(ScheduleEntity scheduleEntity) async {}
-
-  @override
-  Future<ScheduleEntity> getScheduleById(String id) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<List<ScheduleEntity>> getSchedulesByDate(
-    DateTime startDate,
-    DateTime? endDate,
-  ) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> updateSchedule(ScheduleEntity scheduleEntity) async {}
-}
 
 class FakeScheduleRemoteDataSource implements ScheduleRemoteDataSource {
   FakeScheduleRemoteDataSource({
@@ -98,6 +73,75 @@ class FakeTimedPreparationRepository implements TimedPreparationRepository {
 }
 
 void main() {
+  test('createSchedule publishes created schedule to stream cache', () async {
+    final schedule = _schedule(
+      id: 'created',
+      scheduleTime: DateTime(2026, 3, 20, 9),
+    );
+    final repository = ScheduleRepositoryImpl(
+      scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+        getSchedulesByDateHandler: (_, __) async => const [],
+      ),
+      timedPreparationRepository: FakeTimedPreparationRepository(),
+    );
+
+    await repository.createSchedule(schedule);
+
+    final latest = await repository.scheduleStream.firstWhere(
+      (schedules) => schedules.any((schedule) => schedule.id == 'created'),
+    );
+
+    expect(latest.single, schedule);
+  });
+
+  test('deleteSchedule removes deleted schedule from stream cache', () async {
+    final schedule = _schedule(
+      id: 'deleted',
+      scheduleTime: DateTime(2026, 3, 20, 9),
+    );
+    final repository = ScheduleRepositoryImpl(
+      scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+        getSchedulesByDateHandler: (_, __) async => const [],
+      ),
+      timedPreparationRepository: FakeTimedPreparationRepository(),
+    );
+    final events = <Set<ScheduleEntity>>[];
+    final subscription = repository.scheduleStream.listen(events.add);
+    addTearDown(subscription.cancel);
+
+    await repository.createSchedule(schedule);
+    await repository.deleteSchedule(schedule);
+    await pumpEventQueue();
+
+    expect(events.map((event) => event.map((s) => s.id).toList()), [
+      <String>[],
+      ['deleted'],
+      <String>[],
+    ]);
+  });
+
+  test('getScheduleById publishes fetched schedule to stream cache', () async {
+    final schedule = _schedule(
+      id: 'fetched',
+      scheduleTime: DateTime(2026, 3, 20, 9),
+    );
+    final repository = ScheduleRepositoryImpl(
+      scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
+        getSchedulesByDateHandler: (_, __) async => const [],
+        getScheduleByIdHandler: (_) async => schedule,
+      ),
+      timedPreparationRepository: FakeTimedPreparationRepository(),
+    );
+
+    final result = await repository.getScheduleById(schedule.id);
+    final latest = await repository.scheduleStream.firstWhere(
+      (schedules) => schedules.any((schedule) => schedule.id == 'fetched'),
+    );
+
+    expect(result, schedule);
+    expect(latest.single, schedule);
+  });
+
   test(
     'watchSchedulesByDate emits inclusive-start exclusive-end schedules sorted by time',
     () async {
@@ -121,7 +165,6 @@ void main() {
       );
 
       final repository = ScheduleRepositoryImpl(
-        scheduleLocalDataSource: FakeScheduleLocalDataSource(),
         scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
           getSchedulesByDateHandler: (_, __) async => [
             insideLater,
@@ -164,7 +207,6 @@ void main() {
       );
 
       final repository = ScheduleRepositoryImpl(
-        scheduleLocalDataSource: FakeScheduleLocalDataSource(),
         scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
           getSchedulesByDateHandler: (startDate, _) async {
             if (startDate == marchStart) {
@@ -251,7 +293,6 @@ void main() {
       );
 
       final repository = ScheduleRepositoryImpl(
-        scheduleLocalDataSource: FakeScheduleLocalDataSource(),
         scheduleRemoteDataSource: remote,
         timedPreparationRepository: FakeTimedPreparationRepository(),
       );
@@ -298,7 +339,6 @@ void main() {
     );
 
     final repository = ScheduleRepositoryImpl(
-      scheduleLocalDataSource: FakeScheduleLocalDataSource(),
       scheduleRemoteDataSource: FakeScheduleRemoteDataSource(
         getSchedulesByDateHandler: (_, __) async => [initialSchedule],
         getScheduleByIdHandler: (_) async => editedSchedule,

--- a/test/data/repositories/schedule_repository_impl_test.dart
+++ b/test/data/repositories/schedule_repository_impl_test.dart
@@ -33,7 +33,6 @@ class FakeTimedPreparationRepository implements TimedPreparationRepository {
 }
 
 void main() {
-  late MockScheduleLocalDataSource mockScheduleLocalDataSource;
   late MockScheduleRemoteDataSource mockScheduleRemoteDataSource;
   late FakeTimedPreparationRepository fakeTimedPreparationRepository;
   late ScheduleRepository scheduleRepository;
@@ -59,11 +58,9 @@ void main() {
   final tEndDate = DateTime.now().add(Duration(days: 1));
 
   setUp(() {
-    mockScheduleLocalDataSource = MockScheduleLocalDataSource();
     mockScheduleRemoteDataSource = MockScheduleRemoteDataSource();
     fakeTimedPreparationRepository = FakeTimedPreparationRepository();
     scheduleRepository = ScheduleRepositoryImpl(
-      scheduleLocalDataSource: mockScheduleLocalDataSource,
       scheduleRemoteDataSource: mockScheduleRemoteDataSource,
       timedPreparationRepository: fakeTimedPreparationRepository,
     );

--- a/test/helpers/mock.dart
+++ b/test/helpers/mock.dart
@@ -1,18 +1,14 @@
 import 'package:mockito/annotations.dart';
 import 'package:on_time_front/core/dio/app_dio.dart';
-import 'package:on_time_front/data/data_sources/schedule_local_data_source.dart';
 import 'package:on_time_front/data/data_sources/schedule_remote_data_source.dart';
 
 import 'package:on_time_front/data/data_sources/preparation_local_data_source.dart';
 import 'package:on_time_front/data/data_sources/preparation_remote_data_source.dart';
 
-@GenerateMocks(
-  [
-    ScheduleLocalDataSource,
-    ScheduleRemoteDataSource,
-    PreparationRemoteDataSource,
-    PreparationLocalDataSource,
-    AppDio,
-  ],
-)
+@GenerateMocks([
+  ScheduleRemoteDataSource,
+  PreparationRemoteDataSource,
+  PreparationLocalDataSource,
+  AppDio,
+])
 void main() {}


### PR DESCRIPTION
## Summary
- keep ScheduleRepositoryImpl remote-only by removing ScheduleLocalDataSource injection and dead local write comments
- document schedule persistence as remote-only with in-memory schedule streams, while local persistence remains runtime/timed-preparation specific
- add repository stream tests for create, delete, getScheduleById, getSchedulesByDate, and update behavior without a local schedule dependency

## Tests
- flutter test test/data/repositories/schedule_repository_impl_test.dart test/data/repositories/schedule_repository_impl_stream_test.dart
- flutter analyze
- flutter test

Closes #542