### PR TITLE
[codex] Serialize token refresh across Dio instances

### DIFF
--- a/lib/core/dio/app_dio.dart
+++ b/lib/core/dio/app_dio.dart
@@ -8,7 +8,7 @@ import 'package:on_time_front/core/dio/interceptors/token_session_invalidator.da
 import 'package:on_time_front/core/dio/transformers/logging_transformer.dart';
 import 'package:on_time_front/data/data_sources/token_local_data_source.dart';
 
-@Injectable(as: Dio)
+@LazySingleton(as: Dio)
 class AppDio with DioMixin implements Dio {
   AppDio(
     TokenLocalDataSource tokenLocalDataSource,

--- a/lib/core/dio/interceptors/token_interceptor.dart
+++ b/lib/core/dio/interceptors/token_interceptor.dart
@@ -11,6 +11,9 @@ class TokenInterceptor implements InterceptorsWrapper {
   static const _tokenUnavailableMessage =
       'Authentication token is unavailable for a protected request';
 
+  static bool _isRefreshing = false;
+  static final _requestsNeedRetry = <_RequestNeedingRetry>[];
+
   final Dio dio;
   final TokenLocalDataSource tokenLocalDataSource;
   final TokenSessionInvalidator _sessionInvalidator;
@@ -20,16 +23,6 @@ class TokenInterceptor implements InterceptorsWrapper {
     required this.tokenLocalDataSource,
     required TokenSessionInvalidator sessionInvalidator,
   }) : _sessionInvalidator = sessionInvalidator;
-
-  // when accessToken is expired & having multiple requests call
-  // this variable to lock others request to make sure only trigger call refresh token 01 times
-  // to prevent duplicate refresh call
-  bool _isRefreshing = false;
-
-  // when having multiple requests call at the same time, you need to store them in a list
-  // then loop this list to retry every request later, after call refresh token success
-  final _requestsNeedRetry =
-      <({RequestOptions options, ErrorInterceptorHandler handler})>[];
 
   @override
   void onRequest(
@@ -62,7 +55,13 @@ class TokenInterceptor implements InterceptorsWrapper {
     if (_shouldRefreshToken(err)) {
       final response = err.response;
       // if hasn't not refreshing yet, let's start it
-      _requestsNeedRetry.add((options: err.requestOptions, handler: handler));
+      _requestsNeedRetry.add(
+        _RequestNeedingRetry(
+          dio: dio,
+          options: err.requestOptions,
+          handler: handler,
+        ),
+      );
 
       if (!_isRefreshing) {
         _isRefreshing = true;
@@ -167,16 +166,14 @@ class TokenInterceptor implements InterceptorsWrapper {
     }
   }
 
-  Future<void> _retryRequests(
-    List<({RequestOptions options, ErrorInterceptorHandler handler})> requests,
-  ) async {
+  Future<void> _retryRequests(List<_RequestNeedingRetry> requests) async {
     await Future.wait(
       requests.map((requestNeedRetry) async {
         final options = requestNeedRetry.options;
         options.extra[_retryAfterRefreshKey] = true;
 
         try {
-          final response = await dio.fetch(options);
+          final response = await requestNeedRetry.dio.fetch(options);
           requestNeedRetry.handler.resolve(response);
         } on DioException catch (error) {
           requestNeedRetry.handler.reject(error);
@@ -197,4 +194,16 @@ class TokenInterceptor implements InterceptorsWrapper {
   void onResponse(Response response, ResponseInterceptorHandler handler) {
     handler.next(response);
   }
+}
+
+class _RequestNeedingRetry {
+  const _RequestNeedingRetry({
+    required this.dio,
+    required this.options,
+    required this.handler,
+  });
+
+  final Dio dio;
+  final RequestOptions options;
+  final ErrorInterceptorHandler handler;
 }

--- a/test/core/dio/interceptors/token_interceptor_test.dart
+++ b/test/core/dio/interceptors/token_interceptor_test.dart
@@ -21,18 +21,10 @@ void main() {
     sessionInvalidator = _FakeTokenSessionInvalidator(tokenLocalDataSource);
 
     adapter = _TokenRefreshAdapter();
-    dio = Dio(
-      BaseOptions(
-        baseUrl: 'https://example.com',
-        receiveDataWhenStatusError: true,
-      ),
-    )..httpClientAdapter = adapter;
-    dio.interceptors.add(
-      TokenInterceptor(
-        dio,
-        tokenLocalDataSource: tokenLocalDataSource,
-        sessionInvalidator: sessionInvalidator,
-      ),
+    dio = _dioWithTokenInterceptor(
+      adapter,
+      tokenLocalDataSource: tokenLocalDataSource,
+      sessionInvalidator: sessionInvalidator,
     );
   });
 
@@ -114,6 +106,41 @@ void main() {
 
     expect(responses.map((response) => response.statusCode), everyElement(200));
     expect(adapter.refreshRequests, 1);
+    expect(
+      adapter.protectedAuthorizationHeaders.where(
+        (header) => header == 'Bearer new-access-token',
+      ),
+      hasLength(2),
+    );
+  });
+
+  test('shares refresh coordination across interceptor instances', () async {
+    final refreshCompleter = Completer<void>();
+    adapter = _TokenRefreshAdapter(refreshCompleter: refreshCompleter);
+    final firstDio = _dioWithTokenInterceptor(
+      adapter,
+      tokenLocalDataSource: tokenLocalDataSource,
+      sessionInvalidator: sessionInvalidator,
+    );
+    final secondDio = _dioWithTokenInterceptor(
+      adapter,
+      tokenLocalDataSource: tokenLocalDataSource,
+      sessionInvalidator: sessionInvalidator,
+    );
+
+    final firstRequest = firstDio.get<String>('/protected/one');
+    await _flushMicrotasks();
+    final secondRequest = secondDio.get<String>('/protected/two');
+    await _flushMicrotasks();
+
+    expect(adapter.refreshRequests, 1);
+    refreshCompleter.complete();
+
+    final responses = await Future.wait([firstRequest, secondRequest]);
+
+    expect(responses.map((response) => response.statusCode), everyElement(200));
+    expect(adapter.refreshRequests, 1);
+    expect(tokenLocalDataSource.storeTokensCallCount, 1);
     expect(
       adapter.protectedAuthorizationHeaders.where(
         (header) => header == 'Bearer new-access-token',
@@ -209,6 +236,27 @@ void main() {
       expect(tokenLocalDataSource.deleteTokenCalled, isTrue);
     },
   );
+}
+
+Dio _dioWithTokenInterceptor(
+  HttpClientAdapter adapter, {
+  required TokenLocalDataSource tokenLocalDataSource,
+  required TokenSessionInvalidator sessionInvalidator,
+}) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'https://example.com',
+      receiveDataWhenStatusError: true,
+    ),
+  )..httpClientAdapter = adapter;
+  dio.interceptors.add(
+    TokenInterceptor(
+      dio,
+      tokenLocalDataSource: tokenLocalDataSource,
+      sessionInvalidator: sessionInvalidator,
+    ),
+  );
+  return dio;
 }
 
 Future<void> _flushMicrotasks() async {

--- a/test/presentation/home/components/month_calendar_test.dart
+++ b/test/presentation/home/components/month_calendar_test.dart
@@ -15,7 +15,8 @@ void main() {
     tester,
   ) async {
     DateTime? selected;
-    final targetDate = DateTime.now().add(const Duration(days: 2));
+    final now = DateTime.now();
+    final targetDate = DateTime(now.year, now.month, 15);
 
     await tester.pumpWidget(
       _TestApp(


### PR DESCRIPTION
## What changed

- Registers `AppDio` as a lazy singleton so app API callers share one configured Dio client.
- Moves `TokenInterceptor` refresh coordination to process-wide state so concurrent 401s across multiple interceptor instances queue behind one refresh request.
- Adds a regression test for two Dio instances receiving 401s at the same time.
- Stabilizes a month calendar widget test that could tap a duplicate day from an adjacent month.

## Why

Production logs showed default preparation updates returning `200`, followed immediately by access/refresh credential failures. The backend rotates refresh tokens, so concurrent refresh attempts with the same old token can make all but the first request fail as stale. Serializing refresh coordination on the client prevents those spurious logout/error paths.

## Validation

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test test/core/dio/interceptors/token_interceptor_test.dart`
- `flutter analyze`
- `flutter test`
